### PR TITLE
PTW fixes, minor chronolgy update, KPW champions wiki link

### DIFF
--- a/const/name-to-flag.yaml
+++ b/const/name-to-flag.yaml
@@ -32,6 +32,7 @@ Carmen Rojas: BO
 Chakara: GB
 Chris The Bambikiller: AT
 Chris Botherway: ENGLAND
+Chris Cage: DE
 Chris Colen: AT
 Chris Masters: US
 Chris Tyson: DE
@@ -43,6 +44,7 @@ Cybernic Machine: BE
 # D
 Damian Dunne: GB
 Damon Brix: AT
+Denim Adams: HU
 Deti Black: DE
 Devlyn Macabre: US
 Dieter Schwartz: DE
@@ -74,6 +76,7 @@ Gaya Glass: IL
 Gianni Valletta: MT
 Goran: AT
 Gulyas Öcsi: HU
+Gulyas Vilmos: HU
 # H
 Heidi Katrina: ENGLAND
 Heimo Ukonselkä: FI
@@ -87,8 +90,10 @@ Iva Kolasky: HU
 Ivan Kiev: DE
 # J
 Jakob Sigmarsson: PL
+Jarek Nowak: PL
 Javier Vives: ES
 Jay Revolt: PL
+Jeff: PL
 Jerry "Rich" Mandecki: PL
 Jody Fleisch: ENGLAND
 Joe Bravo: AT
@@ -113,6 +118,7 @@ Kripto: PL
 Lanny Poffo: CA
 Laurance Roman: DE
 Lee Rogers: GB
+Leo Zayde: PL
 Leśny: PL
 Lexi Luxx: SE
 Lider: PL
@@ -125,6 +131,8 @@ Luke Bjorn: IT
 Makoto Morimitsu: JP
 Mansoor: SA
 Marcel Koniecki: PL
+Marcin Najman: PL
+Marcin "Rzeźnik" Rzeźniczek: PL
 Marcus Monere: DE
 Mario Rodriguez: PL
 Marius Al-Ani: DE
@@ -142,6 +150,7 @@ Maverick: HU
 MBM: BE
 Mexx: AT
 Michael Kovac: AT
+Michael Payne: PL
 Mika The Polish Punisher: PL
 Mike D. Vecchio: BE
 Miyagi Shida: PL
@@ -165,6 +174,7 @@ Peter Tihanyi: HU
 PG Hooker: HU
 Piotr Opolski: PL
 PJ Black: ZA
+Polish Giant: PL
 Primate: GB
 # R
 Rambo: DO
@@ -197,8 +207,10 @@ Speedball Mike Bailey: CA
 Starbuck: CA
 Steinbolt: SE
 Svedberg: SE
+Szymon Kolanus: PL
 # T
 TAXI Złotówa: PL
+Terry Shadow (impostor): PL
 The Grannatic: DE
 TJ Charles: IE
 Tom Fulton: SCOTLAND

--- a/content/_index.md
+++ b/content/_index.md
@@ -7,10 +7,10 @@ template = "index.html"
 
 This is a project to write down and preserve the history of Polish Pro Wrestling.
 
-Currently, this history is spread across many sites: news portals, blogs, forums, other wiki sites similar to this, video sites; and Cagematch.
-But due to the nature of the (free) web, a lof of this content is no longer accessible, or degraded. TPW wants to have all wrestling shows that happened in Poland (and none other), backyards included. TPW wants to have bios on all wrestlers that appeared in Poland, local or foreign. TPW wants to preserve media that may fall of the face of the internet - photos and videos of these events.
+Currently, this history is spread across many sites: news portals, blogs, forums, other wiki sites similar to this one, video sites, and Cagematch.
+However, due to the nature of the (free) web, a lot of this content is no longer accessible, or degraded. The aim of TPW is to list all the wrestling shows that took place in Poland (backyards included), to have bios on all the wrestlers that worked in Poland (domestic and international), and to preserve media that may fall off the face of the Internet - photos and videos of these events.
 
-The official, Polish name for this project is "Teczki Polskiego Wrestlingu", which is more like _The Secret Files of Polish Wrestling_. But to keep the acronym consistent, the English-language name uses _Tales_.
+The official Polish name for this project is "Teczki Polskiego Wrestlingu", which is more like _The Secret Files of Polish Wrestling_. But to keep the acronym consistent, the English name uses _Tales_.
 
 ## Sections
 

--- a/content/a/chronology.md
+++ b/content/a/chronology.md
@@ -1,5 +1,5 @@
 +++
-title = "Polish wrestling chronology"
+title = "Chronology of Polish wrestling"
 template = "base_with_gallery.html"
 weight = 0
 authors = ["M3n747"]

--- a/content/e/kpw/2018-03-10-kpw-arena-9-na-krawedzi.md
+++ b/content/e/kpw/2018-03-10-kpw-arena-9-na-krawedzi.md
@@ -13,7 +13,7 @@ Na Krawędzi (_On The Edge_) was held as part of the second SzlamFest in the B90
 This show was also the debut of the future [Chemik](@/w/chemik.md) - who appeared as a personal butler to Kawaler. Before the women's match, the Kawaleria faction installed themselves at comfy ringside seats and remained there for the rest of the evening, while the butler kept pouring vodka for them and some lucky members of the audience.
 
 {% card() %}
-- - "Ostrowski, [Peter Pannache](@/w/peter-pannache.md)"
+- - "[Boski Ostrowski](@/w/ostrowski.md), [Peter Pannache](@/w/peter-pannache.md)"
   - "[Mateusz Kowalski](@/w/mateusz-kowalski.md), [Adam Bravo](@/w/adam-bravo.md)"
   - '[Rosetti](@/w/rosetti.md)'
   - s: 2v2v1 Handicap Match

--- a/content/e/mzw/2015-05-31-mzw-champions-war.md
+++ b/content/e/mzw/2015-05-31-mzw-champions-war.md
@@ -8,14 +8,14 @@ venue = ["gosir-glucholazy"]
 1 = { path = "plakat.webp" }
 +++
 
-The first Champions War by MZW was held in Głuchołazy on May 31, 2015. The matches featured MZW trainees, experienced wrestlers like [Asmund](@/w/asmund.md) or [Dobroniak](@/w/stanislaw-van-dobroniak.md), a number of German wrestlers, and MZW's first, and last women's match.
+The first Champions War by MZW was held in Głuchołazy on May 31, 2015. The matches featured MZW trainees, experienced wrestlers like [Asmund](@/w/asmund.md) or [Dobroniak](@/w/stanislaw-van-dobroniak.md), a number of German wrestlers, and MZW's first and last women's match.
 
-The event is infamous in the Polish wrestling scene for having female performer Akira collapse during the show, then die within hours in a hospital. While the initial diagnosis was severe damage to the spine, an autopsy later confirmed that the actual cause of death was an undiscovered brain aneurysm.
+The event is infamous in the Polish wrestling scene for having female performer Akira collapse during the show, then die a few days later in a hospital. While initially the media claimed severe damage to the spine due to a chokeslam, an autopsy later confirmed that the actual cause of death was an undiscovered brain aneurysm.
 [Hexia](@/w/hexia.md) and the organisation were ultimately cleared of all charges. However, the press slammed MZW and wrestling in general for being dangerous, and the organisation's future become uncertain.
-Some fans in the internet wrestling community now mockingly referred to the organisation as Maniac Zgon Wrestling (_zgon_ being the word for death or demise).
+Some fans in the Internet wrestling community now mockingly referred to the organisation as "Maniac Zgon Wrestling" (_zgon_ being the Polish word for death or demise).
 
-MZW briefly paused their activity following the event, to return later the same year in [Opawa](@/e/mzw/2015-09-05-mzw-untitled.md).
-Hexia appeared again for MZW more than a year later, and continued to wrestle until 2018, mostly in a team with [Mr B.](@/w/mr-b.md) However, MZW held no women's matches since.
+MZW briefly paused their activities following the event, to return later the same year in [Opawa](@/e/mzw/2015-09-05-mzw-untitled.md).
+Hexia appeared again for MZW more than a year later, and continued to wrestle until 2018, mostly in a team with [Mr B](@/w/mr-b.md). However, MZW held no women's matches since.
 
 
 {% card() %}

--- a/content/e/mzw/2017-12-02-mzw-freak-show.md
+++ b/content/e/mzw/2017-12-02-mzw-freak-show.md
@@ -32,7 +32,7 @@ Another new face, although an experienced wrestler by then, was [Damian Lambert]
   - "[Bartosz Borowsky](@/w/boro.md)"
   - Blue Thunder
   - Kamil Kwiecień
-  - "Karol Górski(2)"
+  - "Karol Górski (2)"
   - "[Kuba Kamiński](@/w/jacob-crane.md)"
   - Marcel Koniecki
   - "[Rafał Orszak](@/w/rafael-kid.md)"

--- a/content/e/ppw/2019-12-07-ppw-2kola-to-my-nie-zarobimy.md
+++ b/content/e/ppw/2019-12-07-ppw-2kola-to-my-nie-zarobimy.md
@@ -12,9 +12,9 @@ hide_results = true
 1 = { path = "2019-12-07-ppw-2kola-to-my-nie-zarobimy-plakat.jpg", caption = "Official poster", source = "[Official PpW Facebook]" }
 +++
 
-This was likely the first PpW event open for general public, as opposed to friends and insiders that comprised the audiences in prior years.
+This was likely the first PpW event open for general public, as opposed to friends and insiders that comprised the audiences in the prior years.
 
-"2 koła" is Polish for "2 wheels", a fitting name for a [motorcycle-themed pub](@/v/2kola.md) in which the event was held. It is also a slang term for "2 thousand" in context of money - thus the name of the event can be understood as "We Ain't Gonna Make 2GRAND".
+"2 koła" is Polish for "2 wheels", a fitting name for a [motorcycle-themed pub](@/v/2kola.md) in which the event was held. It is also a slang term for "2 thousand" in the context of money - thus the name of the event can be understood as "We Ain't Gonna Make 2GRAND".
 
 {% card() %}
 - ["[Mister Z](@/w/mister-z.md)", "Terry Shadow (impostor)", {nc: "?"}]

--- a/content/e/ptw/2024-02-03-ptw-5-gold-rush.md
+++ b/content/e/ptw/2024-02-03-ptw-5-gold-rush.md
@@ -61,7 +61,7 @@ Polish celebrity and former boxer Marcin Najman was also expected to appear in s
 - - '[Arkadiusz Pawłowski](@/w/pan-pawlowski.md)'
   - Karolina (Pawłowski's real-life partner)
   - '[Wiktor Longman](@/w/wiktor-longman.md)'
-  - '[Bad Bones](@/w/bad-bones.md), Marcin "Rzeźnik" Rzeźniczak'
+  - '[Bad Bones](@/w/bad-bones.md), Marcin "Rzeźnik" Rzeźniczek'
   - g: true
     s: "Pawłowski's in-ring proposal"
 {% end %}

--- a/content/o/dfw.md
+++ b/content/o/dfw.md
@@ -5,13 +5,15 @@ template = "org_page.html"
 authors = ["Krzysztof Zych"]
 [taxonomies]
 chrono_root = ["dfw"]
+[extra]
+toclevel = 3
 [extra.gallery]
 1 = { path = "pas-dfw.jpg", caption = "The damaged DFW Championship belt plate. As of 2024, it was kept at [PPW](@/o/ppw.md)'s training facilities."}
 2 = { path = "mjt1-pas-dfw.jpg", caption = "A fan holding the DFW Championship belt at [PPW Mistrz Jest Tylko Jeden](@/e/ppw/2022-03-12-ppw-mistrz-jest-tylko-jeden.md)"}
 +++
 
-Dream Factory Wrestling was a short-lived wrestling organization from Toruń, estabilished in 2015.
-Widely considered to be just another backyard, nevertheless they managed to hold multiple showcases and events in 2016, before fizzling out at the end of 2017.
+Dream Factory Wrestling was a short-lived wrestling organization from Toruń, established in 2015.
+Widely considered to be just another backyard, they nevertheless managed to hold multiple showcases and events in 2016, before fizzling out at the end of 2017.
 DFW wrestlers were not trained by an experienced pro wrestler directly, nor by someone who received such training. Some of them later received proper training in places like PAW, but only after DFW dissolved.
 Dream Factory, unlike other backyards, did not do any sort of ultraviolent matches. They did dabble in hardcore wrestling, as several Street Fight-style matches were held, with kendo sticks, chairs, ladders and Legos.
 
@@ -19,32 +21,30 @@ Dream Factory, unlike other backyards, did not do any sort of ultraviolent match
 
 #### Before 2015: Local backyard
 
-Dream Factory Wrestling came to be as a result of two backyard organizations merging. These were: TWF from Toruń, and BGW from Grudziądz. The first one started in 2011, and had some presence on the wrestling forums at the time. Facebook still has some relics of their [fanpage](https://www.facebook.com/TorunWrestlingFederation/), but none of their videos are available anymore.
+Dream Factory Wrestling came to be as a result of two backyard organizations merging: Toruń Wrestling Federation (TWF) from Toruń, and BGW from Grudziądz. TWF started in 2011 and had some presence on the wrestling forums at the time. Facebook still has some relics of their [fanpage](https://www.facebook.com/TorunWrestlingFederation/), but none of their videos are available anymore. BGW is more obscure, and probably had no online presence.
 
-BGW is more obscure, and probably had no online presence.
+#### 2015: The first shows
 
-#### 2015: First shows
+The new organization named itself after its members' shared dream to be wrestlers, hence "Dream Factory". In May 2015, [Chris Hunter](@/w/chris-hunter.md) posted about getting their own ring and holding a total of 10 training sessions before their [first show](@/e/dfw/2015-06-20-dfw-showcase.md) in June that year.
 
-The new organization named itself after its members' shared dream - to be a wrestler. Hence, Dream Factory. In May 2015, [Chris Hunter](@/w/chris-hunter.md) posted about getting their own ring, and holding a total of 10 training sessions before their [first show](@/e/dfw/2015-06-20-dfw-showcase.md) in June that year.
+#### 2016: The peak year
 
-#### 2016: Peak year
+DFW held 10 shows in 2016, some of them sideshows to community festivals in smaller towns and villages around Toruń. Others were held at various local high schools, often to an indifferent audience. In June, [Norris](@/w/isnorr.md) joined their roster, appearing in every event since then. [Rob Scaffold](@/w/rob-scaffold.md) debuted in August, then Faust in November - all coming from the backyard-era [PpW](@/o/ppw.md).
 
-DFW held 10 shows in 2016, some of them sideshows to community festivals in smaller towns and villages around Toruń. Others were held at various local highschools, often to an indifferent audience. In June, [Norris](@/w/isnorr.md) joined their roster, appearing on every event since then. [Rob Scaffold](@/w/rob-scaffold.md) appears in August, then Faust in November - all coming from backyard-era [PpW](@/o/ppw.md).
-
-An interesting event was [Lesson of Respect](@/e/dfw/2016-10-29-dfw-lesson-of-respect.md), where the audience was mostly schoolchildren, held in Toruń's historical Artus Court. Norris, who in real life is a teacher, was clearly the kids' favorite in his superhero character.
+An interesting event was [Lesson of Respect](@/e/dfw/2016-10-29-dfw-lesson-of-respect.md), with an audience of mostly schoolchildren, held in Toruń's historical Artus Court. Norris, a teacher in real life, was clearly the kids' favorite in his superhero character.
 
 #### 2017: Slower but bolder
 
-The next year had only 6 shows, some of them with 5 matches on the card (as opposed to the previous years, where 3 matches were typical). DFW gained its first female wrestler, who debuted in the ring on their [Valentine's day show](@/e/dfw/2017-02-14-dfw-love-hurts-wrestling-even-more.md). More characters from the Polish scene appear: PpW's [Steven Strong](@/w/biesiad.md) at that same show, later joined by [Cade Bruce](@/w/mister-z.md).
+The next year only saw six DFW shows, some with as many as five matches on the card (whereas in the previous years three matches were typical). DFW gained its first female wrestler, who debuted in the ring on their [Valentine's day show](@/e/dfw/2017-02-14-dfw-love-hurts-wrestling-even-more.md). More characters from the Polish scene appeared: PpW's [Steven Strong](@/w/biesiad.md) at that same show, later joined by [Cade Bruce](@/w/mister-z.md).
 
-However, later in the year, two important characters left, to later appear in [MZW](@/o/mzw.md) - those were [Charlie](@/w/madman-charlie.md) and [Revage](@/w/rafael-kid.md), DFW Champion at the time. On October 29th, Hunter posted about the organization suspending its activity.
+However, later in the year, two important characters left to subsequently appear in [MZW](@/o/mzw.md): [Charlie](@/w/madman-charlie.md) and [Revage](@/w/rafael-kid.md), the DFW Champion at the time. On October 29th, Hunter posted about the organization suspending its activity.
 
 #### 2018: Final shows, on-line activity
 
-Despite the suspension, there were two more, short events held in 2018. One a gauntlet match for the vacant championship, the other with just two matches as a sideshow to a community festival.
+Despite the suspension, there were two small events held in 2018. One was a gauntlet match for the vacant championship, and the other, with only two matches, was a sideshow to a community festival.
 
 On April 1st, 2019, the fanpage teased a comeback show, which would feature a tournament for a new Poland-wide championship, split across three cities: Toruń, Gdynia ([KPW](@/o/kpw.md)'s territory) and Wrocław ([MZW's](@/o/mzw.md)), a reference to their own [Tournament of Dreams](@/e/dfw/2016-06-11-dfw-tournament-of-dreams-1.md) which was split over two events in two months.
-The finale would be contested as a three-way match, and a tournament ladder graphic was later posted.
+The finale would be contested as a three-way match and a tournament ladder graphic was later posted.
 The event was to also feature a rematch between Hunter and Norris for the DFW belt, and Direk against Seagal for the FOW belt.
 This was obviously an April Fools joke, which did bring some activity back to the page. A later post explained that, and invited fans to follow some of the talent on-line in non-wrestling activities.
 
@@ -52,7 +52,7 @@ The Facebook page was briefly active again between 2020 and 2021, reminiscing ab
 
 ### Scene relations
 
-DFW had neither budget nor recognition for any sort of foreign guests, and they had none. On the Polish scene, they were cooperating with PpW, with some of their talent, notably Charlie and [Direk](@/w/direk.md) appearing at PpW's backyard-era events. At [Recent Dreams](@/e/dfw/2017-04-23-dfw-recent-dreams.md), PJ Blake had a comedy match against [Amisz](@/w/axel-fox.md), at that time merely an internet personality, still to make his [debut for MZW](@/e/mzw/2017-12-02-mzw-freak-show.md) later that year. Direk and Charlie also returned to the new, more professional PpW after 2019.
+DFW had neither the budget nor the recognition to afford any sort of foreign guests. On the Polish scene they were cooperating with PpW with some of their talent, notably Charlie and [Direk](@/w/direk.md), appearing in PpW's backyard-era events. At [Recent Dreams](@/e/dfw/2017-04-23-dfw-recent-dreams.md) PJ Blake had a comedy match against [Amisz](@/w/axel-fox.md), at that time merely an Internet personality still to make his [debut for MZW](@/e/mzw/2017-12-02-mzw-freak-show.md) later that year. Direk and Charlie also returned to the new, more professional PpW after 2019.
 
 After the organization dissolved in 2018, some unspecified wrestlers were announced to have joined the Polish Wrestling Academy (PAW), which is MZW's wrestling school.
 
@@ -60,7 +60,7 @@ After the organization dissolved in 2018, some unspecified wrestlers were announ
 
 DFW had one singles championship, introduced and awarded at the first (and only) [Tournament of Dreams](@/e/dfw/2016-08-20-dfw-tournament-of-dreams-2.md). The inaugural champion was Chris Hunter, and the final person to hold the belt was Norris.
 
-Norris brought the belt to PpW, although it was never defended there. At some point, the belt's faceplate was damaged, showing a large fracture line down the middle. The plate was also removed from the leather strap, which was reused for another belt.
+Norris brought the belt to PpW, although it was never defended there. At some point the belt's faceplate was damaged, showing a large fracture line down the middle. The plate was also removed from the leather strap, which was reused for another belt.
 
 ### References
 

--- a/content/o/ewenement-dojo.md
+++ b/content/o/ewenement-dojo.md
@@ -16,7 +16,7 @@ Ewenement Dojo is the wrestling school associated with [PpW Ewenement](@/o/ppw.m
 
 ## Basic info
 
-* Years active: July 2024-current, previously as PpW Dojo
+* Years active: July 2024-current (operated as PpW Dojo prior to 2024)
 * Coaching staff:
   - [Jacob Crane](@/w/jacob-crane.md) - Head Coach
   - [Biesiad Strong](@/w/biesiad.md) - Martial Arts Coach
@@ -34,10 +34,10 @@ The foundation of Ewenement Dojo was announced on June 8th 2024, at [PpW Ledwo L
 Ewenement Dojo is an evolution of PpW Dojo, which previously operated semi-officially, and was partially closed for rookies.
 In reality it was an auxiliary dojo with no consistent schedule, where PpW talent trained under [Jacob Crane](@/w/jacob-crane.md) and [Justin Joy](@/w/justin-joy.md).
 
-Preceding it was the Summer Wrestling Camp organised by PpW with Jacob Crane as Head Coach, fresh after his return from a 3-month stint with Big Japan Wrestling.
+Preceding it was the Summer Wrestling Camp organised by PpW with Jacob Crane as Head Coach, fresh after his return from a three-month stint with Big Japan Wrestling.
 
-For the first time in Polish wrestling's history, it was announced that the training sessions will be held mainly on weekly basis, instead of weekend-only two day training regimes.
-This change was inspired by German dojos such as wXw Academy, and martial arts dojos.
+For the first time in the Polish wrestling history, it was announced that the training sessions will be held mainly on a weekly basis instead of weekend-only two day training regimes.
+This change was inspired by German dojos such as wXw Academy, as well as martial arts dojos.
 
 ## References
 

--- a/content/o/kpw.md
+++ b/content/o/kpw.md
@@ -3,6 +3,8 @@ title = "Kombat Pro Wrestling"
 weight = 1
 authors = ["Krzysztof Zych"]
 template = "org_page.html"
+[extra]
+toclevel = 3
 [taxonomies]
 chrono_root = ["kpw"]
 +++

--- a/content/o/kpw.md
+++ b/content/o/kpw.md
@@ -56,3 +56,4 @@ The Tag Team Championship was created in 2018 and the first champions crowned in
 ### References
 
 * [Video: Top 10 moments of KPW](https://www.youtube.com/watch?v=NeyUetRatMU) by What Is Wrestling
+* Detailed [KPW champions list](https://pl.wikipedia.org/wiki/Wikipedysta:M3n747/brudnopis/mistrzowiekpw) on Wikipedia (in Polish)

--- a/content/o/mzw.md
+++ b/content/o/mzw.md
@@ -6,6 +6,7 @@ template = "org_page.html"
 [taxonomies]
 chrono_root = ["mzw"]
 [extra]
+toclevel = 3
 allow_section_pagination = true
 +++
 

--- a/content/o/paw.md
+++ b/content/o/paw.md
@@ -10,7 +10,7 @@ hide_events = true
 1 = { path = "paw-lokacje.webp", caption = "Poster for the summer course in August 2024, showing distances between Kępno and other major cities in the area.", source = "Facebook @PolskaAkademiaWrestlingu"}
 +++
 
-PAW, whose full name translates to _Polish Wrestling Academy_, is the wrestling school associated with [MZW](@/o/mzw.md).
+Polska Akademia Wrestlingu (_Polish Wrestling Academy_, PAW) is the wrestling school associated with [MZW](@/o/mzw.md).
 
 ## Basic info
 
@@ -18,8 +18,8 @@ PAW, whose full name translates to _Polish Wrestling Academy_, is the wrestling 
 * Location:
   1. Głuchołazy (2017 - 2018) - in [GOSiR Głuchołazy](@/v/gosir-glucholazy.md)
   2. Wrocław (2018 - Oct 2021) - first in [Czasoprzestrzeń](@/v/czasoprzestrzen.md),
-     then in "Blaszak", a facility located on Leona Popielskiego street, 
-     and finally in a facility on [Aleksandra Ostrowskiego](@/v/ostrowskiego-wroclaw.md) street
+     then in "Blaszak", a facility located at Leona Popielskiego street, 
+     and finally in a facility at [Aleksandra Ostrowskiego](@/v/ostrowskiego-wroclaw.md) street
   3. Toruń (Oct 2021 - Oct 2022) - in Liceum Ogólnokształcące nr 2, a high school
   4. Wrocław (Oct 2022 - Apr 2024) - in [Czasoprzestrzeń](@/v/czasoprzestrzen.md)
   5. Kępno (2024-) - in Kępno Dojo
@@ -46,51 +46,51 @@ PAW, whose full name translates to _Polish Wrestling Academy_, is the wrestling 
 * Chris X
 * Leo Zayde
 * [Prince Striker](@/w/royal-striker.md)
-* Referee Sewi
+* Referee Seweryn
 * [Isnorr](@/w/isnorr.md)
 
 ## History
 
 ### 2017-2018: Rebranding MZW Academy
 
-PAW was created in 2017, after Maniac Zone Wrestling reorganized itself with the goal to have separate legal entities for the organization itself, and its wrestling school.
-The goal of this split was to allow training both complete newcomers, as well as people connected with other wrestling organizations and backyards, without linking them to MZW itself.
-At that time, the coaches were [Justin Joy](@/w/justin-joy.md), [Shadow](@/w/shadow.md), [Asmund](@/w/asmund.md) and [Jędruś Bułecka](@/w/jedrus-bulecka.md).
-PAW held training camps regularly (for 1-2 weekends a month), in [Głuchołazy](@/v/gosir-glucholazy.md), a small town near the Polish-Czech border.
-Despite the remote location with limited transport connections, these sessions had decent attendance numbers, and attracted both people new to wrestling, and talent from backyards like [PpW](@/o/ppw.md) or [DFW](@/o/dfw.md), of which some would later join MZW's roster.
+PAW was created in 2017, after Maniac Zone Wrestling reorganized itself with the goal to have separate legal entities for the organization itself and its wrestling school.
+The goal of this split was to allow for training of both complete newcomers as well as people connected with other wrestling organizations and backyards, without linking them to MZW itself.
+At that time the coaches were [Justin Joy](@/w/justin-joy.md), [Shadow](@/w/shadow.md), [Asmund](@/w/asmund.md) and [Jędruś Bułecka](@/w/jedrus-bulecka.md).
+PAW held training camps regularly (for 1-2 weekends a month) in [Głuchołazy](@/v/gosir-glucholazy.md), a small town near the Polish-Czech border.
+Despite the remote location with limited transport connections, these sessions had decent attendance numbers and attracted both people new to wrestling and talent from backyards like [PpW](@/o/ppw.md) or [DFW](@/o/dfw.md), of which some would later join MZW's roster.
 
-[_American Dream_](@/a/american-dream.md), a documentary feature from 2017, shows Jędruś Bułecka training rookies in Niedźwiedzica, another remote location near the border. Events shown in the film took place in 2014-2015, and therefore show the precursor to PAW.
+[_American Dream_](@/a/american-dream.md), a documentary short from 2017, shows Jędruś Bułecka training rookies in Niedźwiedzica, another remote location near the border. Events shown in the film took place in 2014-2015, and therefore show the precursor to PAW.
 
 ### 2018-2019: Moving to Wrocław
 
-In May 2018 MZW and PAW moved to Wrocław, holding most of their events and training sessions in [Czasoprzestrzeń](@/v/czasoprzestrzen.md), which significantly boosted attendance, and improved the frequency of training.
-After the summer camp of 2018, Jędruś Bułecka retired from his coach duties, leaving the trio of Shadow, Asmund and Justin Joy in charge.
-That lasted for almost another year, until the summer training camp of 2019, after which Justin and Asmund also retired from coaching (the latter also from wrestling in general).
+In May 2018 MZW and PAW moved to Wrocław, holding most of their events and training sessions in [Czasoprzestrzeń](@/v/czasoprzestrzen.md), which significantly boosted attendance and improved the frequency of training.
+After the summer camp of 2018 Jędruś Bułecka retired from his coach duties, leaving the trio of Shadow, Asmund and Justin Joy in charge.
+That lasted for almost another year until the summer training camp of 2019, after which Justin and Asmund also retired from coaching (the latter also from wrestling in general).
 
-This period is also when a social group, later called "[The Greens](@/a/the-greens.md)" formed, composed of both rookies and some of the coaches. The group's members would later become important talent in MZW and other organizations.
+This period also saw the formation of a social group later called "[The Greens](@/a/the-greens.md)", composed of both rookies and some of the coaches. The group's members would later become important talent in MZW and other organizations.
 
 ### 2019-2023: Shadow's solo run, PTW
 
 After Justin and Asmund left, Shadow became the single permanent coach in PAW.
-This reduced the training sessions' frequency down to about once monthly or bimonthly.
-The academy itself relocated to a much smaller venue, located at Aleksandra Ostrowskiego street, which was also the place that the COVID-era [Project Basement](@/e/mzw/2021-03-18-mzw-project-basement-1.md) series was recorded.
-Despite that, PAW continued to hold summer camps in 2020 and 2021, which had worse attendance numbers than before.
+This reduced the training sessions' frequency down to about once per month or two.
+The academy itself relocated to a much smaller venue, located at Aleksandra Ostrowskiego street, which was also the place in which the COVID-era [Project Basement](@/e/mzw/2021-03-18-mzw-project-basement-1.md) series was recorded.
+Despite this, PAW continued to hold summer camps in 2020 and 2021, which had worse attendance numbers than before.
 
 PAW suffered its biggest setback when multiple MZW talent and PAW rookies decided to join the newly created [PTW](@/o/ptw.md) in 2021.
 This also caused another decline in training session frequency. In the later months of 2021 and early 2022, PAW moved its training sessions temporarily to Toruń.
 
-In October 2022, PAW returned to Wrocław and Czasoprzestrzeń, hosting training sessions infrequently, and with little to none social media activity.
-Attendance at these sessions varied between 3-5 rookies every weekend.
+In October 2022, PAW returned to Wrocław and Czasoprzestrzeń, hosting training sessions infrequently and with little to no social media activity.
+Attendance at these sessions varied between three and five rookies every weekend.
 
 ### 2024: Moving to Kępno, revival
 
-Since April 2024, PAW has made yet another move, to Kępno - a small town about an hour's drive east of Wrocław, where they continued their training sessions.
+Since April 2024 PAW has made yet another move, to Kępno - a small town about an hour's drive east of Wrocław, where they continued their training sessions.
 On June 14th, they announced a 5-day wrestling summer camp, scheduled to be held on August 19-24 at the new facility in Kępno.
 On June 29th, a photo was posted on their Facebook page, showing PAW trainees along with multiple ex-[MZW](@/o/mzw.md), ex-[PTW](@/o/ptw.md) and [PpW](@/o/ppw.md) wrestlers.
 
 {% inline_fig(path="paw-jun-2024.webp") %}
 Photo posted on PAW's Fanpage on June 29th 2024. \
-The text reads "Another weekend. Another training session with "new" faces. And one conclusion: The Ring Unites People." \
+The text reads "Another weekend. Another training session with "new" faces. And one conclusion: the ring unites people." \
 Besides PAW trainees, multiple ex-PTW/MZW wrestlers can be seen: [Samson](@/w/samson.md), [Marco Hammers](@/w/marco-hammers.md), [Disco Pablo](@/w/disco-pablo.md), [Dziedzic](@/w/dziedzic.md), [Aron Wake](@/w/aron-wake.md), [Sambor](@/w/sambor.md) and [Rafi Rarytas](@/w/rafi.md).
 {% end %}
 

--- a/content/o/ppw.md
+++ b/content/o/ppw.md
@@ -7,6 +7,7 @@ authors = ["Krzysztof Zych"]
 chrono_root = ["ppw"]
 [extra]
 year_list_start = 2017
+toclevel = 3
 [extra.gallery]
 1 = { path = "backyard_korzenie.jpg", caption = '[Mister Zet](@/w/mister-z.md) (left) and [Gustav Gryffin](@/w/gustav-gryffin.md) in front of presumably the new ring. Text: "Today Mister Z showed me his roots"' }
 2 = { path = "biesiad_dive.jpg", caption = '[Biesiad](@/w/biesiad.md) testing the new ring by diving into some foam padding. Text: What a backyard, (expletive).' }
@@ -23,7 +24,7 @@ The official name is just "PpW Ewenement". The word _ewenement_ means something 
 
 ### History
 
-#### 2010: backyard years
+#### 2010: The backyard years
 
 PpW dates its origins back to 2010, when a group of teenage friends and classmates started emulating their favourite wrestlers. The original arena for their matches was a public playground, and later a common yard which gave the organization its first name: Polski Podwórkowy Wrestling (_Polish Yard Wrestling_ - note that backyards, in the Anglo-Saxon world defined as private enclosed outdoor areas behind terraced houses, are not common in Poland).
 Until about 2014 the primary location was placed next to the intersection of Kuratowski and Arbuzowa streets in Warsaw. The name for this venue was [Placyk PPW](http://ppw-fandom.tpwres.pl/placyk-ppw), and it had no proper ring.
@@ -36,7 +37,7 @@ An actual ring, though undersized, was created in 2017, designed by [Rob Scaffol
 
 Uniquely for the Polish wrestling scene, PpW shares no ancestry with other promotions, many of which can be traced back to [DDW](@/o/ddw.md).
 
-#### 2019: going pro
+#### 2019: Going pro
 
 Probably the first event that PpW held for an open audience (as opposed to just friends and insiders to the backyard scene) was 2019's [2Koła to my nie zarobimy](@/e/ppw/2019-12-07-ppw-2kola-to-my-nie-zarobimy.md), followed by [Brawl For The Puppies](@/e/ppw/2020-02-15-ppw-brawl-for-the-puppies.md).
 The latter event began PpW's pro era. It was the first one to invite foreign guests, and PpW's wrestlers started receiving professional training: first from [Jacob Crane](@/w/jacob-crane.md) and later also by the invited guests who would hold training sessions.
@@ -54,7 +55,7 @@ The involvement of Supron suggest that this may be the very same ring he [bought
 
 (Scroll down to the [gallery](./#gallery) to view screenshots of the stories mentioned.)
 
-### Lost Lore
+### Lost lore
 
 PpW used to have a Wikia page with detailed internal lore and history, including storied feuds, rankings, character backgrounds, past events and videos from the backyard era. This went defunct in 2023. The Internet Archive's Wayback Machine only had an [incomplete version](https://web.archive.org/web/20230422172700/https://ppwofficial.fandom.com/pl/wiki/PPW) available. Snippets could be found in cached results on Google when searching for certain related terms, but most of it was lost.
 

--- a/content/o/ptw-academy.md
+++ b/content/o/ptw-academy.md
@@ -10,7 +10,7 @@ hide_events = true
 
 PTW Academy is the wrestling school associated with [Prime Time Wrestling](@/o/ptw.md).
 
-## Basic Info
+## Basic info
 
 * Years active: 2021-current
 * Locations:
@@ -66,35 +66,32 @@ PTW Academy is the wrestling school associated with [Prime Time Wrestling](@/o/p
 
 ## History
 
-### 2021-2022: Foundation and Celebrity Era
+### 2021-2022: Foundation and the celebrity era
 
 PTW Academy started as a wrestling dojo directly linked to Prime Time Wrestling itself.
 The first training sessions began in early 2021.
 That year's class of rookies was a mix of wrestling enthusiasts, mostly from Silesia, like ex-[MCW](@/o/mcw.md) wrestlers such as Dziedzic & Sinister,
-as well as micro-influencers and people convinced to try wrestling by Pawłowski such as YouTuber TAXI Złotówa, Wiktoria Domżalska and fitness coach Sylwia Cross.
+as well as micro-influencers and people convinced to try wrestling by Pawłowski, such as YouTuber TAXI Złotówa, Wiktoria Domżalska and fitness coach Sylwia Cross.
 Additionally, multiple ex-[MZW](@/o/mzw.md) & [KPW](@/o/kpw.md) wrestlers had transferred to PTW to train there, due to personal reasons and lack of consistency in training schedule after the COVID-19 pandemic.
 
-The original plan for PTW Academy was to attract not only pro wrestling enthusiasts, but also new people, who were unaware of wrestling culture and specifics.
-Pawłowski frequently tried to attract non-wrestling celebrities to attend training sessions, but after [PTW#1: REVOLUCJA](@/e/ptw/2021-10-09-ptw-1-revolucja.md) when these efforts largely failed, that strategy was abandoned and PTW Academy focused more on developing their own stars.
-During that year, some of the talents allied themselves in a group called "Originals", a nickname given to PTW-raised talents under the influence of Pawłowski's teachings and wrestling philosophy.
-Those differences later led to conflict between Originals and other groups, who came to PTW from other organizations (especially "[The Greens](@/a/the-greens.md)") later on.
+The original plan for PTW Academy was to attract not only pro wrestling enthusiasts, but also new people unaware of wrestling culture and specifics.
+Pawłowski frequently tried to attract non-wrestling celebrities to attend training sessions, but after [PTW#1: REVOLUCJA](@/e/ptw/2021-10-09-ptw-1-revolucja.md), when these efforts largely failed, that strategy was abandoned and PTW Academy focused more on developing their own stars.
+During that year some of the wrestlers allied themselves in a group called "the Originals", a nickname given to PTW-raised talent under the influence of Pawłowski's teachings and wrestling philosophy.
+Those differences would later lead to conflicts between the Originals and other groups who came to PTW from other organizations (especially "[The Greens](@/a/the-greens.md)") later on.
 
-### 2022-2023: Golden Era
+### 2022-2023: The golden era
 
-Once the rookies roster stabilized, PTW Academy maintained regular attendance at every training session.
-Due to the unique advantage of owning two wrestling rings in the PTW Performance Center, they often split the attendees into two groups: Rookies and Journeymen (the advanced group), to provide a higher level of training.
-As the federation itself was in good standing with its sponsors, the PTW Academy benefited from that as well. The money allowed them to provide high-grade coaches (such as Justin Joy & John Klinger), and frequent seminaries hosted by former WWE and TNA talent such as Nick Aldis and Axel Tischer.
+Once the rookies' roster stabilized, PTW Academy maintained regular attendance at every training session.
+Due to the unique advantage of owning two wrestling rings in the PTW Performance Center, the attendees were often split into two groups: Rookies and Journeymen (the advanced group), to provide a higher level of training.
+As the federation itself was in good standing with its sponsors, the PTW Academy benefitted from that as well. The money allowed them to provide high-grade coaches (such as Justin Joy & [John Klinger](@/w/bad-bones.md)), and frequent seminaries hosted by former WWE and TNA talent such as Nick Aldis and Axel Tischer.
 
 During this period, training sessions were held almost every weekend, with a few exceptions for the major shows.
 
 ### 2023-2024: Crisis and downsizing
 
 After the departure of [Justin Joy](@/w/justin-joy.md), the Academy lacked a regular experienced coach.
-Most of the training responsibilities were taken up by Taras, Disco Pablo & Nano Lopez,
-with an occasional appearance from Axel Fox or Renegade.
-Overall, attendance at training weekends went slightly down due to circumstances connected directly to PTW itself.
+Most of the training responsibilities were taken up by Taras, Disco Pablo & Nano Lopez, with an occasional appearance from Axel Fox or Renegade.
+Overall, the attendance at training weekends went slightly down due to circumstances connected directly to PTW itself.
 
-PTW Academy, along with the federation itself, changed its location in April 2024, when they moved from [PTW Performance Center](@/v/ptw-targowa.md) in Chorzów,
-to Dworek pod Platanami in Kozłów, a village outside Gliwice.
-During the massive wave of [PTW Exits](@/a/ptw-exits.md) following [PTW#6: Total Blast From The Past](@/e/ptw/2024-05-11-ptw-6.md),
-a significant part of coaching staff, talent and rookies left the federation.
+PTW Academy, along with the federation, changed its location in April 2024, when they moved from [PTW Performance Center](@/v/ptw-targowa.md) in Chorzów to Dworek pod Platanami in Kozłów, a village bordering Gliwice.
+During the massive wave of [PTW Exits](@/a/ptw-exits.md) following [PTW#6: Total Blast From The Past](@/e/ptw/2024-05-11-ptw-6.md), a significant part of coaching staff, talent and rookies left the federation.

--- a/content/o/ptw.md
+++ b/content/o/ptw.md
@@ -56,32 +56,31 @@ These were both veterans of the Polish scene, as well as debuting Polish wrestle
 
 #### The first show
 
-This first show, titled [PTW#1: REVOLUCJA](@/e/ptw/2021-10-09-ptw-1-revolucja.md) was met with positive response, even though some aspects were criticised.
+This first show, titled [PTW#1: REVOLUCJA](@/e/ptw/2021-10-09-ptw-1-revolucja.md), was met with positive response, even though some aspects were criticised.
 Fans praised the starpower, production value and overall high-budget feel.
-The criticism was focused on Pawłowski's character who fans felt was overexposed, inviting influencers to hype up the show, blatantly aggressive sponsor ads, and the booking - with a significant imbalance of starpower and a DQ finish in the main event.
+The criticism was focused on Pawłowski's character, who fans felt was overexposed, inviting influencers to hype up the show, blatantly aggressive sponsor ads, and the booking - with a significant imbalance of starpower and a DQ finish in the main event.
 Most of the Polish talent on that show became cornerstones of PTW's roster, while some notably flopped.
 TV personality and freak fighter Paweł "Trybson" Trybała, initially strongly booked as a non-wrestler entering the business, failed to ever make his PTW return.
 
-The successful show was quickly followed by PTW announcing their Underground shows. The [first one](@/e/ptw/2021-12-19-ptw-underground-1.md) was held in the [PTW Performance Center](@/v/ptw-targowa.md) in Chorzów.
-It kicked off a near-monthly cadence of events in 2022 and 2023: an Underground show on the last Sunday of each month, except when that weekend was already booked for the bigger (numbered) events.
+The successful event was quickly followed by PTW announcing their Underground shows. The [first one](@/e/ptw/2021-12-19-ptw-underground-1.md) was held in the [PTW Performance Center](@/v/ptw-targowa.md) in Chorzów.
+It kicked off a near-monthly series of events in 2022 and 2023: an Underground show on the last Sunday of each month, except when that weekend was already booked for the bigger (numbered) events.
 Underground shows advanced storylines seen in these bigger events, but with significantly less starpower.
 While initially only available to the live public, since Underground 4 they were also streamed live, first on FITE/TrillerTV and later YouTube as well.
 The venue had limited capacity, which was cleverly used to make these events feel more exclusive, only for the most dedicated fans.
 
 ### 2022
 
-Continuing their strong entry into the scene, they started the year with the [second Underground show](@/e/ptw/2022-01-23-ptw-underground-2.md)
+Continuing their strong entry into the scene, PTW started the year with the [second Underground show](@/e/ptw/2022-01-23-ptw-underground-2.md)
 and quickly followed with [PTW#2 Blackout](@/e/ptw/2022-02-19-ptw-2-blackout.md), which was also well received.
 This show had even more starpower than Revolucja, featuring debuts of well-known names like Joe Hendry, Marty Scurll, Matt Sydal and John "Bad Bones" Klinger.
 
-Over the year, PTW continued its steady pace, presenting the monthly Underground shows, and debuting at [Ryucon](@/e/ptw/2022-07-31-ptw-x-ryucon.md), a manga-themed fan convention in Kraków.
-The third major show [Legends](@/e/ptw/2022-11-26-ptw-3-legends.md) was the first one to be held outside Chorzów, in Warsaw.
-Among other notable moments, it featured the first PTW women's match (outside the exclusive Underground shows), where [Diana Strong](@/w/diana-strong.md) competed against two former NXT-UK competitors Xia Brookside and Myla Grace.
-Also at this show, the IMPACT Digital Media Championship was defended, and Santino was named the kayfabe co-owner of PTW, leading to
-a long-standing feud between Bad Bones & Longman vs Pawłowski.
+Over the course of the year, PTW continued its steady pace, presenting the monthly Underground shows, and debuting at [Ryucon](@/e/ptw/2022-07-31-ptw-x-ryucon.md), a manga-themed fan convention in Kraków.
+The third major show, [Legends](@/e/ptw/2022-11-26-ptw-3-legends.md), was the first one to be held outside Chorzów, in Warsaw.
+Among other notable moments, it featured the first PTW women's match (outside the exclusive Underground shows), where [Diana Strong](@/w/diana-strong.md) competed against two former NXT-UK wrestlers, Xia Brookside and Myla Grace.
+Also at this show, the IMPACT Digital Media Championship was defended, and Santino was named the kayfabe co-owner of PTW, leading to a long-standing feud between Bad Bones & Longman vs Pawłowski.
 This show became part of a double-header weekend: on the day before, Warsaw's [PpW Ewenement](@/o/ppw.md) hosted their own event,
-named [Najlepsza Gala w Mieście](@/e/ppw/2022-11-25-ppw-najlepsza-gala-w-miescie.md) (_Best Gala In Town_). This was seen as PpW playfully taking potshots at the rival organization.
-_Legends_ closed PTW's 2022 as their last show of such ambition and scale, until 2024's [Gold Rush](@/e/ptw/2024-02-03-ptw-5-gold-rush.md).
+named [Najlepsza Gala w Mieście](@/e/ppw/2022-11-25-ppw-najlepsza-gala-w-miescie.md) (_The Best Event In Town_). This was seen as PpW playfully taking potshots at the rival organization.
+_Legends_ closed 2022 as PTW's last show of such ambition and scale, until 2024's [Gold Rush](@/e/ptw/2024-02-03-ptw-5-gold-rush.md).
 
 ### 2023
 
@@ -89,7 +88,7 @@ _Legends_ closed PTW's 2022 as their last show of such ambition and scale, until
 
 Prior to the first event, on 21st of September 2021, Kinguin was announced as one of the [sponsors][sponsors-announcement], later becoming the titular sponsor, and was added to the promotion's logo.
 Kinguin is a marketplace selling digital items, primarily game keys and in-game currency.
-The Kinguin mascot became a regular part of the shows, and even an angle with Taxi Złotówa at [PTW#3 Legends](@/e/ptw/2022-11-26-ptw-3-legends.md).
+The Kinguin mascot became a regular part of the shows, and was even included in an angle with Taxi Złotówa at [PTW#3 Legends](@/e/ptw/2022-11-26-ptw-3-legends.md).
 
 Though Kinguin's departure was never officially announced, the titular sponsor was gradually dropped from PTW's branding over the spring/summer of 2023.
 The last Facebook post featuring Kinguin PTW name was from 26th March 2023, a [cover photo change][cover-photo-underground14] announcing [Underground 14](@/e/ptw/2023-04-23-ptw-underground-14.md).
@@ -97,247 +96,239 @@ Afterwards, none of the graphics for the show featured Kinguin in either logo or
 
 #### Fourth major show
 
-After closing 2022 with PTW Legends, PTW continued to hold Underground shows.
-Throughout the first half of the year, they continued at a monthly pace (except January which saw a double-header Underground weekend).
+After closing 2022 with Legends, PTW continued to hold Underground shows.
+Throughout the first half of the year, they continued at a monthly pace (except for January, which saw a double-header Underground weekend).
 On June 25th in Wrocław, PTW held their 4th major show overall and the only one for 2023 - [The Mystery](@/e/ptw/2023-06-25-ptw-4-mystery.md).
-This show saw the crowning of PAKA as the inaugural PTW Tag Team Champions, a storyline involving [Bad Bones](@/w/bad-bones.md) kidnapping Marcin Rzeźniczek, and the formation of what would later become The Sinister Kingdom.
-Foreign starpower was significantly lower than for previous major shows, presumably due to titular sponsor dropping out.
-This was also the first major PTW show to be put behind a pay-wall (supporter functionality of YouTube), with the live stream dropping out so often that it rendered the show unwatchable.
+This event saw the crowning of PAKA as the inaugural PTW Tag Team Champions, a storyline involving [Bad Bones](@/w/bad-bones.md) kidnapping Marcin Rzeźniczek, and the formation of what would later become The Sinister Kingdom.
+Foreign starpower was significantly lower than in previous major shows, presumably due to titular sponsor dropping out.
+This was also the first major PTW show to be put behind a paywall (the supporter functionality of YouTube; the first fight was available for free), with the live stream dropping out so often that it rendered the show unwatchable.
 All these issues caused a lot of controversy, angering the fans who were demanding refunds - which PTW later granted in the form of free tickets and discounts for PTW's merchandise.
 
 #### Crisis and departures
 
 _See also: [PTW Exits](@/a/ptw-exits.md)._
 
-In the aftermath of [PTW #4 Mystery](@/e/ptw/2023-06-25-ptw-4-mystery.md), build-up for the 5th major show started.
+In the aftermath of [PTW#4 Mystery](@/e/ptw/2023-06-25-ptw-4-mystery.md), build-up for the fifth major show started.
 Initially planned for October 2023, the show was postponed indefinitely.
 During that time, multiple talents started to voice their frustration on social media.
-Eventually, [Rafi Rarytas](@/w/rafi.md), [Gabriel Queen](@/w/gabriel-queen.md), [Justin Joy](@/w/justin-joy.md) and [Samson](@/w/samson.md) were all removed from PTW's roster. See Justin's page for a series of screenshots from his social media where he addressed the situation.
+Eventually, [Rafi Rarytas](@/w/rafi.md), [Gabriel Queen](@/w/gabriel-queen.md), [Justin Joy](@/w/justin-joy.md) and [Samson](@/w/samson.md) were all removed from PTW's roster (see Justin's page for a series of screenshots from his social media where he addressed the situation).
 During a [shoot interview][samson-shoot-interview] for the "Wrestling Polska" YouTube channel, Samson stated that he "never earned a single penny" in PTW, that Underground shows were not paid appearances and only the "big" (numbered) events were, with the promotor urging talent to take the "barter in training fee" instead.
 
-During a regular [live stream][supporter-stream-barter] for his YouTube supporters (video requires paid subscription), Pawłowski confirmed the accusations, stating that barter was an option, but always voluntary.
+During a regular [live stream][supporter-stream-barter] for his YouTube supporters (which requires a paid subscription), Pawłowski confirmed the accusations, stating that barter was an option, but always voluntary.
 He also confirmed that PTW wrestlers are not officially contracted and their exclusivity is based on a gentlemen's agreement.
-He emphasized that his goal is to make PTW a fully mainstream promotion, with wrestlers being able to earn their living just based on their PTW role, rather than an alternative, independent route with talent being able to freelance.
+He emphasized that his goal is to make PTW a fully mainstream promotion, with wrestlers being able to earn their living just based on their PTW role, rather than an alternative, independent route, with talent being able to freelance.
 It was also announced that more roster cuts are to follow, especially after "Season One" is finished.
 
 In the beginning of 2024, [Vic Golden](@/w/vic-golden.md) was also quietly removed from the roster page.
-[Robert Star's](@/w/robert-star.md) departure went unnanounced by the promotion, with his profile removed at some point between January and March 2024. During an [interview][robert-star-interview] for Istota Wrestlingu Youtube Channel, Robert confirmed his departure from PTW.
+[Robert Star's](@/w/robert-star.md) departure went unannounced by the promotion, with his profile removed at some point between January and March 2024. During an [interview][robert-star-interview] for the Istota Wrestlingu YouTube channel, Robert confirmed his departure from PTW.
 
-On February 12th, 2024, PTW commentary team member Piotr "Showoff" Małecki announced an indefinite leave from PTW, citing burnout as a reason. Gradually, he severed his ties with the organization, first changing his Twitter/X bio entry to "ex-PTW commentator", and becoming increasingly critical towards them.
+On February 12th, 2024, PTW commentary team member Piotr "Showoff" Małecki announced an indefinite leave from PTW, citing burnout as a reason. Gradually, he severed his ties with the organization, first changing his Twitter/X bio entry to "ex-PTW commentator", and becoming increasingly critical towards the promotion.
 
 #### Expansion into Austria
 
-Throughout 2023, [Krampus](@/w/krampus.md), in addition to his in ring career in PTW, launched a wrestling promotion of his own, WWA (Wrestling World Austria).
+Throughout 2023, [Krampus](@/w/krampus.md), in addition to his in-ring career in PTW, launched a wrestling promotion of his own: Wrestling World Austria (WWA).
 The first set of tapings was announced for September 29th 2023, emanating from City Theater in Hallein, Austria. Among others, the show featured multiple talent from PTW.
-On December 4th 2023, both PTW and WWA [announced][wwa-announcement] that WWA has now become a part of PTW.
+On December 4th 2023, both PTW and WWA [announced][wwa-announcement] that WWA had now become a part of PTW.
 
 The initial name for the this merged promotion was "PTW: WWA" (also stylized as "PTW presents: WWA"), but the organization soon adopted "PTW German" as their [social media name](https://www.facebook.com/ptwwrestlingdeutsch). In addition to covering their own shows, this account reposted PTW's updates concerning events in Poland, but translated to German.
 
 ### 2024
 
 In February 2024, PTW held their fifth major event: [Gold Rush](@/e/ptw/2024-02-03-ptw-5-gold-rush.md), this time in Legionowo, in the Warsaw metropolitan area.
-The Underground shows were also moved to a new location. Initially announced as Gliwice, a historical city in the west of the Silesian metropolis, the actual location turned to be a venue in the neighboring village of Kozłów, about 9km west of the city.
+The Underground shows were also moved to a new location. Initially announced as Gliwice, a historical city in the west of the Silesian metropolis, the actual location turned to be a venue in the neighboring village of Kozłów, about 9 km west of the city.
 This made the Underground shows far less accessible, and sparked some criticism.
-The regular cadence of these shows was also dropped, with only one being announced for April.
-
-The show was followed by [Total Blast From The Past](@/e/ptw/2024-05-11-ptw-6.md) in May.
+They also lost their regularity, with [only one](@/2024-04-13-ptw-underground-21.md) being announced for April.
+That event was followed by [Total Blast From The Past](@/e/ptw/2024-05-11-ptw-6.md) in May.
 
 #### Pawłowski's solo run
 
-On Monday, March 11th 2024, Marcin "Rzeźnik" Rzeźniczek, co-owner of PTW, officially confirmed on his social media that he left PTW and Pawłowski remains the sole owner. Breaking kayfabe (a recent storyline from [Gold Rush](@/e/ptw/2024-02-03-ptw-5-gold-rush.md) revealed him as the mastermind behind Bad Bones and Longman shenanigans), he wished his former partner, and everyone in PTW the best of luck conquering the Polish and world wrestling scenes, and fondly recalled his time in PTW.
+On Monday, March 11th 2024, Marcin "Rzeźnik" Rzeźniczek, co-owner of PTW, officially confirmed on his social media that he left PTW and Pawłowski remains the sole owner. Breaking kayfabe (a recent storyline from [Gold Rush](@/e/ptw/2024-02-03-ptw-5-gold-rush.md) revealed him as the mastermind behind Bad Bones and Longman shenanigans), he wished his former partner, and everyone in PTW, the best of luck conquering the Polish and world wrestling scenes, and fondly recalled his time in PTW.
 
 #### New YouTube show: "Gruby temat"
 
-In March 2024, PTW launched a new format on YouTube, titled "Gruby Temat" (_Fat Topic_ - jokingly referring to Pawłowski's rather large statue). With Pawłowski and Kacper "Ludwiczek" Bociański as hosts, and one special guest for each episode. While Ludwiczek was not previously affiliated with wrestling, he was an MMA fighter on Poland's freak fight scene.
+In March 2024, PTW launched a new format on YouTube, titled "Gruby Temat" (_Fat Topic_ - jokingly referring to Pawłowski's rather large size), with Pawłowski and Kacper "Ludwiczek" Bociański as hosts, and one special guest for each episode. While Ludwiczek was not previously affiliated with wrestling, he was an MMA fighter on Poland's freak fight scene.
 The first guest of this new show was Marcel Gawroński, a popular TikToker who covers Poland's freak fight scene.
 Another episode featured PTW's own [Puncher](@/w/puncher.md), while Polish boxer and UFC women's champion Joanna Jędrzejczyk was the guest in episode 3.
 The format of this show was mostly an interview with the guest, including questions from the audience asked via chat.
 
 #### The Lottery
 
-At the Gold Rush event, Pawłowski revealed a new promotional scheme for PTW: a 2012 Nissan GTR car, the grand prize to be won in a lottery. To circumvent the legal age requirement, lottery tickets were not sold directly. Instead, fans were encouraged to purchase an ebook, which came with a free ticket. These ebooks were short PDF documents (e.g. "[PTW Revolucja](@/e/ptw/2021-10-09-ptw-1-revolucja.md)" at 16 pages), including results from PTW's shows, photos and a short narrative. It was apparent that they were not supposed to provide any useful content, but rather serve as a legal means for distributing lottery tickets. The car was claimed to be worth 600 thousand PLN, or about 140 thousand EUR at the time.
+At the Gold Rush event, Pawłowski revealed a new promotional scheme for PTW: a 2012 Nissan GTR car, the grand prize to be won in a lottery. To circumvent the legal age requirement, lottery tickets were not sold directly. Instead, fans were encouraged to purchase an ebook, which came with a free ticket. These ebooks were short PDF documents (e.g. "[PTW Revolucja](@/e/ptw/2021-10-09-ptw-1-revolucja.md)" at 16 pages), including results from PTW shows, photos and a short narrative. It was apparent that they were not supposed to provide any useful content, but rather serve as a legal means for distributing lottery tickets. The car was claimed to be worth 600.000 PLN, or about 140.000 EUR at the time.
 
-In the following months, leading to [Underground 21](@/e/ptw/2024-04-13-ptw-underground-21.md) and [Total Blast From The Past](@/e/ptw/2024-05-11-ptw-6.md) he promoted the lottery heavily on social media, and in collaboration with various online personalities, most of who had nothing to do with wrestling.
-One such personality was Ludwiczek, the co-host of Gruby temat at that time.
+In the following months leading to [Underground 21](@/e/ptw/2024-04-13-ptw-underground-21.md) and [Total Blast From The Past](@/e/ptw/2024-05-11-ptw-6.md), Pawłowski promoted the lottery heavily on social media and in collaboration with various online personalities, most of whom had no prior connection with wrestling; one such personality was Ludwiczek, the co-host of Gruby Temat at that time.
 Immediately after Underground 21, PTW's social media accounts continued to focus solely on the lottery, while promoting the next major show took a distant second place, restricting itself to revealing the card in a series of posts.
-The organization cared so little for promoting its own show, that it did not even try managing WrestleFans' accidental reveal of the full match card, which was leaked before PTW revealed the final match themselves.
-The leak was accidentally posted by Wrestlefans' newsman Piotr "Sabinq" Gilewski. [Taras](@/w/taras.md) called him out on the mistake on Twitter/X, and in turn revealed that he also was on a lengthy break from PTW, although officially not released yet.
+The organization cared so little for promoting its own show that it did not even try managing the accidental reveal of the full match card, which was leaked on the WrestleFans forum before PTW revealed the final match themselves.
+The leak was accidentally posted by a WrestleFans newsman Piotr "Sabinq" Gilewski. [Taras](@/w/taras.md) called him out on the mistake on Twitter/X, and in turn revealed that he also was on a lengthy break from PTW, although officially not released yet.
 
 #### The Stonoga controversy
 
-On May 8th, in a move mocked by fans and PTW wrestlers alike, notorious Polish businessman and whistleblower Zbigniew Stonoga announced that he bought 1500 tickets for [PTW#6](@/e/ptw/2024-05-11-ptw-6.md), and wants to distribute them for free to his supporters (who sent him money and received a numbered membership card).
-The next day, Stonoga posted photos of himself and the car, as well as short clips of himself on the passenger seat.
+On May 8th, in a move mocked by fans and PTW wrestlers alike, notorious Polish businessman and whistleblower Zbigniew Stonoga announced that he bought 1500 tickets for [PTW#6](@/e/ptw/2024-05-11-ptw-6.md) and wants to distribute them for free to his supporters (who sent him money and received a numbered membership card).
+The next day, Stonoga posted photos of himself and the car, as well as short clips of himself in the passenger seat.
 Ludwiczek also posted a photo of himself and the controversial Stonoga in front of the car.
-Later, he announced handing out 50 tickets, free and for anyone, in person, at a McDonald's restaurant in Legionowo.
-This move prompted PTW wrestler Taras to seemingly cut his ties with the organization, declaring he's finally "quitting this circus".
+Later, Stonoga announced we would hand out 50 free tickets to anyone who approached him in person at a McDonald's in Legionowo.
+This move prompted PTW wrestler [Taras](@/w/taras.md) to seemingly cut his ties with the organization, declaring he's finally "quitting this circus".
 
 #### Backlash
 
-Other PTW personalities, like [Disco Pablo](@/w/disco-pablo.md), the already-mentioned ex-commentator Piotr Małecki, and current commentator Arek Paterek also addressed the situation.
-Their posts ranged from open critique to only vague references. After Pablo and Taras made their comments, fans speculated about Pablo leaving PTW as well, which Pablo strongly denied.
-Some fans also alleged that Taras' current frustration was a result of losing the PTW Tag Team Championship, which he also denied.
+Other PTW personalities, such as [Disco Pablo](@/w/disco-pablo.md), the aforementioned ex-commentator Piotr Małecki, and current commentator Arek Paterek, also addressed the situation.
+Their posts ranged from vague references to open critique. After Pablo and Taras made their comments, fans speculated about Pablo leaving PTW as well, which Pablo strongly denied.
+Some fans also alleged that Taras's current frustration was a result of losing the PTW Tag Team Championship, which he also denied.
 
 The two wrestlers' criticism of PTW was also met with backlash. On PTW's public Facebook group, an account named Jakub Tyczyński (presumably a PTW personality, current or former) accused them of using their good relations with Pawłowski against other wrestlers in the past, and trying to play martyrs now.
 
-This string of PR flops, and apparent lack of interest from PTW, prompted Wrestlefans to pull out of promoting them with immediate effect, only 3 days before the show. And in another unexpected turn of events, some of the fans who received tickets from Stonoga turned out to be [PpW](@/o/ppw.md) wrestlers and personnel. This got them both a free ticket for the show, and some social media exposure, through photos and live video which Stonoga, unfamiliar with the wrestling scene, shared.
+This string of PR flops, and the apparent lack of interest from PTW, prompted WrestleFans to pull out of promoting them with immediate effect, only 3 days before the show. And in another unexpected turn of events, some of the fans who received tickets from Stonoga turned out to be [PpW](@/o/ppw.md) wrestlers and personnel. This got them both free tickets for the show and some social media exposure, through photos and live video which Stonoga, unfamiliar with the wrestling scene, shared.
 
-During this time, PTW remained silent, attempted to control the situation by deleting comments pertaining to the Stonoga situation from the fan group, and continuing to promote... the lottery.
+During this time PTW remained silent, attempted to control the situation by deleting comments pertaining to the Stonoga situation from the fan group, and continued to promote the lottery.
 
 #### The prize draw
 
-On Sunday, May 12th, PTW held the lottery's prize draw, as a live-stream on YouTube.
-Despite PTW's stated goal to provide entertainment for the whole family, this show included controversial guests: Stonoga, cast of reality show "Królowe Życia", spouting distasteful, sexually-charged jokes.
-The lottery's overseeing committee was never shown by the cameras. The lottery failed to achieve its desired goal of popularising PTW - some prize winners, who were called on the phone live as per the lottery's regulations, had no idea who and why called them, and did not recognize the names Pawłowski or PTW. After it was finished, the prize draw show quickly went private on YouTube, and other lottery-related materials started to disappear from the Internet.
+On Sunday, May 12th, PTW held the lottery's prize draw on a YouTube live stream.
+Despite PTW's stated goal of providing entertainment for the whole family, this show included controversial guests: Stonoga and the cast of _Królowe Życia_ ("The Queens of Life") reality show, spouting distasteful, sexually-charged jokes.
+The lottery's overseeing committee was never shown by the cameras. The lottery failed to achieve its desired goal of popularising PTW - some prize winners, who were called on the phone live as per the lottery's regulations, had no idea who called them and why, and did not recognize the names Pawłowski or PTW. After it was finished, the prize draw show quickly went private on YouTube, and other lottery-related materials started to disappear from the Internet (eventually including the lottery website).
 
 #### More high-profile exits
 
 _See also: [PTW Exits](@/a/ptw-exits.md)._
 
 Right after PTW#6, long-time PTW commentator Arkadiusz Paterek confirmed his departure in a [tweet][paterek-tweet].
-On May 25 2024, Paterek and Łukasz "Balik" Baliński (who also does commentary for PTW's events) appeared on the relaunched _WrestleOne_ Youtube channel.
-This channel is ran by wrestling influencer, and one-time freak fighter, Patryk "Patrykos" Domke.
+On May 25th 2024, Paterek and Łukasz "Balik" Baliński (who also does commentary for PTW events) appeared on the relaunched _WrestleOne_ YouTube channel, ran by a wrestling influencer and one-time freak fighter, Patryk "Patrykos" Domke.
 In a livestream originally focused on an upcoming WWE event in Saudi Arabia, both Paterek and Balik briefly mentioned their PTW tenures.
 Around the 13:50 timestamp, Balik confirms his departure from PTW as well.
-According to Paterek, this means that all original commentary team members have now left.
+According to Paterek, this means that all the original commentary team members have now left.
 Later he also stated that Pawłowski failed to even read his farewell message, and claims that Paterek has "stabbed him in the back".
 
 On May 31st, PTW wrestler [Dziedzic](@/w/dziedzic.md) appeared on the [first episode][dziedzic-ngz] of "No Gimmick Zone", a new YouTube show by Błażej "Blaze" Pniewski.
-Blaze, who was a vocal supporter of PTW up to this point, expressed his disappointment at the [Total Blast](@/e/ptw/2024-05-11-ptw-6.md) show, and slowly but surely turned against the project.
+Blaze, who had been a vocal supporter of PTW up to this point, expressed his disappointment with the [Total Blast](@/e/ptw/2024-05-11-ptw-6.md) show, and slowly but surely turned against the project.
 Dziedzic openly appeared under his real name (Kacper Dziedzic), in a shoot-style interview.
-He discussed various backstage topics, from the creation of gimmicks, to issues in PTW and the wider Polish scene.
+He discussed various backstage topics, from the creation of gimmicks to issues in PTW and the wider Polish scene.
 He supported the vision of _Polish Wrestling Without Boundaries_, a phrase which Pawłowski coined but never truly committed to.
 This concept is about inter-promotional cooperation on the Polish scene.
 Dziedzic alleged that, even if Pawłowski disliked his remarks, he will stay loyal to PTW as that's where his heart is.
 He stated that he's going to attend PTW training on the upcoming Sunday, and face possible consequences.
 
-On Sunday June 2nd, a rumor was posted on the PTW Facebook fan group - that Dziedzic, [Sinister](@/w/sinister.md) and [Marcelito](@/w/marcelito.md) have been released by PTW.
-The fans quickly linked these departures with Dziedzic's shoot interview for Blaze.
+On Sunday, June 2nd, a rumor was posted on the PTW Facebook fan group that Dziedzic, [Sinister](@/w/sinister.md) and [Marcelito](@/w/marcelito.md) have been released by PTW.
+The fans quickly linked these departures with the shoot interview of Dziedzic.
 On the next day, Monday June 3rd, Dziedzic confirmed his departure from PTW in a [heartfelt goodbye post][dziedzic-farewell-insta] on Instagram.
 After some teasing on his Instagram Stories, Sinister confirmed the speculations as well. On Wednesday, June 5th 2024, he shared a [farewell post][sinister-farewell-insta] of his own.
 Shortly after that, referee Seweryn also confirmed his departure on his Instagram story.
 
 On June 6th [Boro](@/w/boro.md) added a set of stories on Instagram, titled "PTW Last Dance".
-It contained mostly photos of various moments in PTW he was part of, but also several photos with "the greens" (an insider term for wrestlers from [MZW](@/o/mzw.md) like himself), some of whom already quit PTW.
+It mostly contained photos of various moments in PTW he was part of, but also several photos with ["the Greens"](@/a/the-greens.md) (an insider term for wrestlers from [MZW](@/o/mzw.md), like himself), some of whom had already quit PTW.
 The final image in this set was just a black background with text saying "Merci et au revoir" (Thank you and goodbye), strongly implying that he left as well.
 
 Michał "Mutant" Świątkowski, an inactive PTW wrestler who got shelved just after his return at Gold Rush, seemingly confirmed his exit through Instagram stories.
 He posted a poll, asking fans whether he should continue wrestling in a "new" place, or return to an "old" place, with [PpW](@/o/ppw.md) marked as "new", and [KPW](@/o/kpw.md) as "old".
 
 On June 8th, Legia Łysych, a tag team consisting of [Marco Hammers](@/w/marco-hammers.md) and [Olgierd](@/w/olgierd.md), who never announced leaving PTW, made their surprise debut for [PpW](@/o/ppw.md) at [Ledwo Legalne IV](@/e/ppw/2024-06-08-ppw-ledwo-legalne-4.md).
-On their social media platforms, they still appeared to be signed with PTW, as Marco Hammers feuded with Vincent Caravaggio, and both team members released an Instagram story where the neon lights from their Performance Center venue were clearly visible.
+On their social media platforms they still appeared to be signed with PTW, as Marco Hammers feuded with Vincent Caravaggio, and both team members released an Instagram story where the neon lights from their Performance Center venue were clearly visible.
 For Olgierd, that debut was also a return - he is a PpW original known previously as Hades.
-They answered an open challenge laid out by Pure Gold ([Gabriel Queen](@/w/gabriel-queen.md) and [Vic Golden](@/w/vic-golden.md)).
+The two answered an open challenge issued by Pure Gold ([Gabriel Queen](@/w/gabriel-queen.md) and [Vic Golden](@/w/vic-golden.md)).
 This was the culmination of a storyline started back in PTW, where the two teams joined forces to prevent PAKA from becoming the inaugural Tag Team Champions. That plan failed, and the two teams feuded bitterly over it.
 
-On June 9th, [Sambor](@/w/sambor.md) posted a [black and white photo](https://www.instagram.com/p/C7_u3gIsgSO/) of him and his valet Rusałka, on his Instagram profile. He thanked the organization, Pawłowski himself, the fans, for helping him on his path to becoming a wrestler. This was also interpreted as his exit from PTW.
+On June 9th, [Sambor](@/w/sambor.md) posted a [black and white photo](https://www.instagram.com/p/C7_u3gIsgSO/) of himself and his valet Rusałka on his Instagram profile. He thanked the organization, Pawłowski and the fans for helping him on his path to becoming a wrestler. This was also interpreted as his exit from PTW.
 
 On Thursday June 13th, PTW has taken down the roster section of their page.
 
-In a [Twitch stream](https://www.twitch.tv/videos/2180575222) on June 25th, Pawłowski confirmed that Axel Fox, a popular babyface has also quit the organization. This was the first time this info was shared, as Axel himself did not reveal it before.
+In a [Twitch stream](https://www.twitch.tv/videos/2180575222) on June 25th, Pawłowski confirmed that Axel Fox, a popular babyface, has also quit the organization. This was the first time this info was shared, as Axel himself did not reveal it before.
 
 #### Silence and confusion
 
-As this post-Gold Rush crisis was developing, PTW's social media channels stayed silent.
+As this post-Gold Rush crisis was developing, PTW's social media channels remained silent.
 
 PTW Champion [Puncher](@/w/puncher.md)'s Instagram account posted a cryptic message stating "Chapter closed".
 This led to fans speculating that he may be the next one to leave PTW, but this turned out not to be the case.
-On May 17th 2024, he tweeted a [long statement][puncher-statement], comprising of 3 screenshots where he described his road to championship, all the sacrifices he made, and accepted the blame for PTW 6 and the lottery flop.
+On May 17th 2024, he tweeted a [long statement][puncher-statement] comprising three screenshots where he described his road to championship, all the sacrifices he made, and accepted the blame for the PTW#6 and lottery flops.
 However, he also included passive-aggressive remarks about "disloyal" members of the locker room, and excessive fan criticism halting the growth of wrestling in Poland.
 Reactions to that statement were mixed, ranging from praise to mockery.
 This launched a wave of similar, shorter statements from other roster members, claiming they're going to stay with PTW through thick and thin, and would rather go down together with the organization rather than leave it because of its problems.
 
 PTW's fate was uncertain at that point, with multiple exits and nothing in the way of official announcements.
-With one exception: a tribute post commemorating [John "Bad Bones" Klinger](@/w/bad-bones.md), who died from a heart attack on May 20th.
+With one exception: a tribute post commemorating [John "Bad Bones" Klinger](@/w/bad-bones.md), who died of a heart attack on May 20th.
 
-On May 29th, Ryucon, a manga themed fan meeting (which previously hosted PTW events in [2022](@/e/ptw/2022-07-31-ptw-x-ryucon.md) and [2023](@/e/ptw/2023-07-16-ptw-x-ryucon.md)), [announced][ptw-ryucon-3] that they're hosting a third PTW event.
+On May 29th, Ryucon, a manga-themed fan convention (which previously hosted PTW events in [2022](@/e/ptw/2022-07-31-ptw-x-ryucon.md) and [2023](@/e/ptw/2023-07-16-ptw-x-ryucon.md)), [announced][ptw-ryucon-3] that they're hosting a third PTW event.
 However, as of June 5th, not a single mention on the show was made on PTW's official social media channels.
 The only activity were wrestlers [Marco Hammers](@/w/marco-hammers.md) and Vincent Caravaggio feuding online, building a potential match for that show.
 
 #### Ludwiczek confronts PTW
 
-On May 23, Ludwiczek (co-host of [Gruby Temat](#new-youtube-show-gruby-temat)) took direct shots at PTW in an [instagram post][ludwiczek-vs-ptw-instagram] promoting his upcoming match in Polish freak-fight organization Clout MMA (which Pawłowski was also affiliated with, and appeared as host on their shows).
+On May 23, Ludwiczek (co-host of [Gruby Temat](#new-youtube-show-gruby-temat)) took direct shots at PTW in an [Instagram post][ludwiczek-vs-ptw-instagram] promoting his upcoming match in Polish freak-fight organization Clout MMA (which Pawłowski was also affiliated with, and appeared as host on their shows).
 He claimed to "be ready for everything", and that "working with PTW and Arek [Pawłowski]" made him indestructible.
-In further comments, he bashed PTW, Pawłowski, their ring ("mouldy mat, far from white") and the locker room.
-In response to that, PTW personalities, such as [Taras](@/w/taras.md), [Olgierd](@/w/olgierd.md), [Marco Hammers](@/w/marco-hammers.md) called out the hypocrisy in his words.
-According to them, Ludwiczek received a hefty paycheck, free rides in luxury cars, and enjoyed time with celebrities. Therefore, he had no rights to bash the promotion that only benefitted him, whatever internal problems they may have.
+In further comments he bashed PTW, Pawłowski, their ring ("mouldy mat, far from white") and the locker room.
+In response to that, PTW personalities such as [Taras](@/w/taras.md), [Olgierd](@/w/olgierd.md) and [Marco Hammers](@/w/marco-hammers.md) called out the hypocrisy in his words.
+According to them, Ludwiczek received a hefty paycheck, free rides in luxury cars and enjoyed time with celebrities. Therefore, he had no right to bash the promotion that only benefitted him, whatever internal problems they may have.
 Ludwiczek explained that he was never actually employed by PTW, but rather by an outside investor, and that the lottery was his main focus.
 According to him, "protecting the lottery" was the reason for not confronting Pawłowski and PTW earlier.
-Later, several ex-PTW personalities, e.g. [Samson](@/w/samson.md), [Gabriel Queen](@/w/gabriel-queen.md) and [Justin Joy](@/w/justin-joy.md) joined the thread to express their disdain of Pawłowski.
+Later, several ex-PTW personalities such as [Samson](@/w/samson.md), [Justin Joy](@/w/justin-joy.md) and [Gabriel Queen](@/w/gabriel-queen.md) joined the thread to express their disdain of Pawłowski.
 
-Eventually, both addressed the issue. Pawłowski, in an [interview][pawlowski-tvreklamy] for the TVreklama Youtube channel, expressed his disappointment in Ludwiczek, and called out his laziness and hypocrisy.
+Eventually both sides addressed the issue. Pawłowski, in an [interview][pawlowski-tvreklamy] for the TVreklama YouTube channel, expressed his disappointment in Ludwiczek, and called out his laziness and hypocrisy.
 Ludwiczek, in a [video of his own][ludwiczek-klamstwa-pawlowskiego], retorted by also calling Pawłowski a lazy hypocrite.
 
-On Monday June 3rd, Pawłowski was the host of Clout MMA's conference promoting an upcoming show,
-with competitors confronting each other before the event on Saturday.
-In a segment promoting a handicap match between Ludwiczek & Super Mario (Mariusz Sobczak) vs Albert Sosnowski,
-Ludwiczek cut a promo where he was holding a PTW T-shirt in his hand.
-He declared that he "had worn this gift with pride, until he realized that the person who gave it to him [Pawłowski] was just a fake bitch", spit on the T-shirt and threw it away, then plugged his callout video.
+On Monday, June 3rd, Pawłowski was the host of Clout MMA's conference promoting an upcoming show, with competitors confronting each other before the event on Saturday.
+In a segment promoting a handicap match between Ludwiczek & Super Mario (Mariusz Sobczak) vs Albert Sosnowski, Ludwiczek cut a promo where he was holding a PTW T-shirt in his hand.
+He declared that he "had worn this gift with pride, until he realized that the person who gave it to him [Pawłowski] was just a fake bitch", spat on the T-shirt and threw it away, then plugged his callout video.
 Pawłowski retorted with "then why the fuck are you even speaking".
-The two continued to trash-talk each other, blaming each other, Pawłowski raising his voice to the point of yelling.
-Eventually, Pawłowski made his leave, while Ludwiczek remained in the panel he was invited to.
+The two continued to trash-talk each other, blaming one another and Pawłowski raising his voice to the point of yelling.
+Eventually Pawłowski made his leave, while Ludwiczek remained in the panel he was invited to.
 
 In a [follow-up interview with Puncher][followup-puncher], he called Ludwiczek a liar and asked about a potential fight between them.
 Puncher said that while some people find wrestling to be cringey, he actually finds freak fights cringey, adding "but who wouldn't like to punch Ludwiczek?".
 
-Another [follow-up interview with Pawłowski][followup-pawlowski] had Arkadiusz speaking in a trembling voice about a series
-of recent disasters in his life - health issue, his father's terminal illness, PTW business dwindling.
+Another [follow-up interview with Pawłowski][followup-pawlowski] had Arkadiusz speaking in a trembling voice about a series of recent disasters in his life - health issues, his father's terminal illness, PTW business dwindling.
 He declared that he's not going to stay down on his knees, but instead rebuild his life and PTW, because it's in his nature.
 When discussing the events of the panel, Pawłowski dismissed Ludwiczek's challenge to fight him (presumably in Clout MMA's octagon).
-Asked whether he thought it was legitimate, he replied that it's probably legitimate in Ludwiczek's mind, but that he wants nothing more to do with him, and wants Ludwiczek out of his life forever.
-Answering a question on his future plans, he plugs the upcoming PTW x Ryucon show on July 7th 2024. This is the closest thing to an official announcement for this show that fans got so far. PTW's social media accounts were still silent.
+When asked whether he thought it was legitimate, he replied that it's probably legitimate in Ludwiczek's mind, but that he wants nothing more to do with him, and wants Ludwiczek out of his life forever.
+Answering a question on his future plans, he plugged the upcoming PTW x Ryucon show on July 7th 2024. This is the closest thing to an official announcement for this show that fans got so far. PTW's social media accounts were still silent.
 
 #### Kanał Zero
 
-On Thursday, June 13th, Pawłowski and [Diana Strong](@/w/diana-strong.md) appeared on Kanał Zero's morning show _Pobudka_ (_Wake-up Call_). The show was hosted by Marcin "WuWunio" Sprusiński and Izabella Krzan.
+On Thursday, June 13th, Pawłowski and [Diana Strong](@/w/diana-strong.md) appeared on Kanał Zero's morning show _Pobudka_ ("Wake-up Call"). The show was hosted by Marcin "WuWunio" Sprusiński and Izabella Krzan.
 One of the show's segments was a wrestling-focused interview with the guests. Unexpectedly, the hosts were very well briefed about the Polish scene and PTW's recent problems.
-The first questions were for Diana, about her sports background and the way to pro wrestling, and later the focus moved to Pawłowski.
-WuWunio started inquiring about PTW's state, presenting a list of wrestlers who recently left and mentioned that some of them now wrestle for the competition - [PpW](@/o/ppw.md).
+The first questions were for Diana, regarding her sports background and the way to pro wrestling, and later the focus moved to Pawłowski.
+WuWunio started inquiring about PTW's state, presenting a list of wrestlers who recently left and mentioned that some of them now wrestle for [the competition](@/o/ppw.md).
 Pawłowski, his hand forced, acknowledged the crisis, and confirmed that the lottery and [Total Blast From The Past](@/e/ptw/2024-05-11-ptw-6.md) were flops.
-He spoke about how reading fan's criticism was very painful, because he felt exactly the same. He acknowledged that the wrestlers leaving his organization were great performers and (mostly) very good people.
-Next, he declared that the organization plans to recover from the crisis, starting at the next show [PTW x Ryucon 3](@/e/ptw/2024-07-07-ptw-x-ryucon.md).
-Pawłowski confirmed that the reason for leaving were disagreements about finances, booking and exclusivity. All the while, his words were countered by [Puncher](@/w/puncher.md) aggressively trolling the chat,
-even insulting the same ex-wrestlers Pawłowski was complimenting on screen.
+He spoke about how reading fans' criticism was very painful, because he felt exactly the same. He acknowledged that the wrestlers leaving his organization were great performers and (mostly) very good people.
+He then declared that the organization plans to recover from the crisis starting with the next show, [PTW x Ryucon 3](@/e/ptw/2024-07-07-ptw-x-ryucon.md).
+Pawłowski confirmed that the reason for people leaving were disagreements about finances, booking and exclusivity. All the while, his words were countered by [Puncher](@/w/puncher.md) aggressively trolling the chat, even insulting the same ex-wrestlers Pawłowski was complimenting on-screen.
 
-When Pawłowski agreed that he was the main culprit of the downfall, Krzan pried harder, asking him about the organizations' near bankrupcy. A visibly upset Pawłowski declares he will make amends, but needs some time.
+When Pawłowski agreed that he was the main culprit of the downfall, Krzan pried harder, asking him about the organization's near bankrupcy. A visibly upset Pawłowski declared he will make amends, but needs some time.
 The hosts cut him off with a joke, that the show's previous guest (a Mr Małecki, public officer in charge of bankrupcy and property claims) may be able to help.
-Pawłowski joins in on the joke, but is still visibly shaken. WuWunio inquires about Rzeźniczek's (PTW's cofounder) departure, which Pawłowski confirms but declines to reveal the reasons in his stead.
-In the wrap-up, Diana is asked about why she stayed, after so many others left. She answers that she has always believed in the project, still does and has no problems working with Arek, therefore she chooses to stay.
-More questions about wrestling's technicalities follow, but the live chat is pressing questions about the lottery, and the subject is brought up again.
-Once again, he confirms it was a spectacular fiasco, with the ticket money not even close to covering the prizes. He calls it a crucial error that started a domino effect for PTW
-and confirms that no lottery will be held ever again.
+Pawłowski joins in on the joke, but is still visibly shaken. WuWunio inquires about Rzeźniczek's (PTW's cofounder) departure, which Pawłowski confirms but declines to reveal the reasons in his absence.
+In the wrap-up, Diana was asked why she stayed after so many others left. She answered that she had always believed in the project, still does and has no problems working with Arek, therefore she chooses to stay.
+More questions about wrestling's technicalities followed, but the live chat was pressing questions about the lottery and the subject was brought up again.
+Once again, Pawłowski confirmed it was a spectacular fiasco, with the ticket money not even close to covering the prizes. He called it a crucial error that started a domino effect for PTW and confirmed that no lottery will be held ever again.
 
-To wrap up the show, Pawłowski is asked what is the essence of wrestling (phrased as "Istota Wrestlingu" - possibly a namedrop for a small Youtube channel).
-He answers that connecting people, escapism, and emotional involvement are the key components of pro wrestling's appeal.
+To wrap up the show, Pawłowski was asked what is the essence of wrestling (phrased as "istota wrestlingu" - possibly a namedrop for a [YouTube channel of the same name](https://www.youtube.com/@IstotaWrestlingu/).
+He answered that connecting people, escapism, and emotional involvement are the key components of pro wrestling's appeal.
 
 ## Polish wrestling scene
 
-PTW's initial roster was built from wrestlers previously appearing in [MZW](@/o/mzw.md), [KPW](@/o/kpw.md) or MCW, however PTW itself is known for its lack of interaction with other federations in Poland.
-Talent were strictly prohibited from appearing in any other Polish rings, and any form of cooperation, either as a performer or in a backstage role resulted in "firing" from PTW.
+PTW's initial roster was built from wrestlers previously appearing in [MZW](@/o/mzw.md), [KPW](@/o/kpw.md) or [MCW,](@/o/mcw.md), however PTW itself is known for its lack of interaction with other federations in Poland.
+Talent were strictly prohibited from appearing in any other Polish rings, and any form of cooperation, either as a performer or in a backstage role, resulted in "firing" from PTW.
 One early example of that is [Jacob Crane](@/w/jacob-crane.md), ostensibly fired for "damaging the organization's image".
-That fact was one of the key factors leading to most of the [PTW Exits](@/a/ptw-exits.md), where the talent wanted to have more freedom, and to be able to take bookings from other Polish organizaitions.
-This is similar to KPW's approach. Fans theorize that this isolationist attitude was inherited from [Don Roid](@/w/don-roid.md)'s [DDW](@/o/ddw.md), where Pawłowski learned the ropes. Their attitude towards "backyards" like [PpW](@/o/ppw.md) is also shared with KPW and DDW.
+That fact was one of the key factors leading to most of the [PTW exits](@/a/ptw-exits.md), where the talent wanted to have more freedom and to be able to take bookings from other Polish organizations.
+This is similar to KPW's approach. Fans theorize that this isolationist attitude was inherited from [Don Roid's](@/w/don-roid.md) [DDW](@/o/ddw.md), where Pawłowski learned the ropes. Their attitude towards "backyards" like [PpW](@/o/ppw.md) is also shared with KPW and DDW.
 
 ## Foreign relations
 
-One of the main selling points of PTW, differentiating them from their competition, was sponsors, an actual budget and the ability to bring in a lot of pro wrestlers from abroad.
-At [PTW 3: Legends](@/e/ptw/2022-11-26-ptw-3-legends.md) it was announced that Santino Marella, former long-time WWE star, will become one of the organization's co-owners.
+One of the main selling points of PTW, differentiating them from their competition, were sponsors, an actual budget and the ability to bring in a lot of pro wrestlers from abroad.
+At [PTW 3: Legends](@/e/ptw/2022-11-26-ptw-3-legends.md) it was announced that Santino Marella, former long-time WWE star, would become one of the organization's co-owners.
 This, however, was only a short-lived storyline angle lacking any real payoff, leaving fans confused when Santino made his return at [PTW 5: Gold Rush](@/e/ptw/2024-02-03-ptw-5-gold-rush.md) only as an English-language commentator, and suprise entrant in the Gold Rush Rumble.
 
 Later, PTW entered into collaboration with Austrian wrestler Krampus and his new organization called "World Wrestling Austria".
-That was quickly renamed to _PTW: WWA_, and became a de facto "sister federation" ran by Krampus with assistance from Pawłowski.
+It was quickly renamed to _PTW: WWA_ and became a de facto "sister federation" ran by Krampus with assistance from Pawłowski.
 This cooperation allowed PTW talent to be booked at the PTW: WWA show on 2024-01-05.
 See the [Expansion into Austria](#expansion-into-austria) section above.
 
 PTW also entered a deal with British Revolution Wrestling (BWR), which allowed BWR Champion Scotty Rawk to defend his championship in PTW. In return, [Diana Strong](@/w/diana-strong.md) and [Puncher](@/w/puncher.md) were booked at one of BWR's shows in the UK.
 
-One remarkable deal, between PTW and a bigger promotion, was an agreement with Impact Wrestling, for Joe Hendry to defend his Digital Media Championship against Trent Seven at [Legends](@/e/ptw/2022-11-26-ptw-3-legends.md).
+One remarkable deal between PTW and a bigger promotion was an agreement with Impact Wrestling, for Joe Hendry to defend his Digital Media Championship against Trent Seven at [Legends](@/e/ptw/2022-11-26-ptw-3-legends.md).
 
 ## Championships
 
 | Championship | Current champion(s) | Notes |
 |--|--|--|
 | PTW Championship | [Puncher](@/w/puncher.md) | Inaugural champion, won the championship rumble match at [Gold Rush](@/e/ptw/2024-02-03-ptw-5-gold-rush.md). |
-| PTW Tag Team Championship | Budapest Bastards: [Renegade](@/w/renegade.md) and [Nitro](@/w/nitro.md) | Defeated PAKA: [Disco Pablo](@/w/disco-pablo.md), [Boro](@/w/boro.md), [Taras](@/w/taras.md) at [Gold Rush](@/e/ptw/2024-02-03-ptw-5-gold-rush.md). |
+| PTW Tag Team Championship | Budapest Bastards: [Renegade](@/w/renegade.md) and [Nitro](@/w/nitro.md) | Defeated PAKA: [Disco Pablo](@/w/disco-pablo.md), [Boro](@/w/boro.md) and [Taras](@/w/taras.md) at [Gold Rush](@/e/ptw/2024-02-03-ptw-5-gold-rush.md). |
 
 ## Internet Presence
 
@@ -348,7 +339,7 @@ One remarkable deal, between PTW and a bigger promotion, was an agreement with I
 
 ## References
 
-* [Youtube video of the lottery prize draw](https://www.youtube.com/watch?v=DOgcwDhd53k), unavailable, set to private
+* [YouTube video of the lottery prize draw](https://www.youtube.com/watch?v=DOgcwDhd53k) (unavailable, set to private)
 
 
 [trailer-1-ptw]: https://www.facebook.com/watch/?v=343114510600555&ref=sharing

--- a/content/o/ptw.md
+++ b/content/o/ptw.md
@@ -137,7 +137,7 @@ The initial name for the this merged promotion was "PTW: WWA" (also stylized as 
 In February 2024, PTW held their fifth major event: [Gold Rush](@/e/ptw/2024-02-03-ptw-5-gold-rush.md), this time in Legionowo, in the Warsaw metropolitan area.
 The Underground shows were also moved to a new location. Initially announced as Gliwice, a historical city in the west of the Silesian metropolis, the actual location turned to be a venue in the neighboring village of Kozłów, about 9 km west of the city.
 This made the Underground shows far less accessible, and sparked some criticism.
-They also lost their regularity, with [only one](@/2024-04-13-ptw-underground-21.md) being announced for April.
+They also lost their regularity, with [only one](@/e/ptw/2024-04-13-ptw-underground-21.md) being announced for April.
 That event was followed by [Total Blast From The Past](@/e/ptw/2024-05-11-ptw-6.md) in May.
 
 #### Pawłowski's solo run

--- a/content/o/tbw.md
+++ b/content/o/tbw.md
@@ -2,6 +2,8 @@
 title = "Total Blast Wrestling"
 template = "org_page.html"
 weight = 2
+[extra]
+toclevel = 3
 [taxonomies]
 chrono_root = ["tbw"]
 +++

--- a/content/w/dynamite-dave.md
+++ b/content/w/dynamite-dave.md
@@ -1,4 +1,6 @@
 +++
 title = "Dynamite Dave"
 template = "talent_page.html"
+[taxonomies]
+country = ["DE"]
 +++


### PR DESCRIPTION
Zmodyfikowany tytuł chronologii polskiego wrestlingu
Link do tabeli z mistrzami KPW na Wikipedii
Różne poprawki w PTW

W sumie nie wiem, dlaczego tytuł po angielsku, a tutaj po polsku. Jakoś tak. :D