### PR TITLE
Teczki Kingi i Krystiana Czekaja, komentatorzy/sędziowie/ring announcerzy walk, parę zdjęć

### DIFF
--- a/const/name-to-flag.yaml
+++ b/const/name-to-flag.yaml
@@ -120,6 +120,7 @@ Kinga Różańska: PL # Kinga Miotke == Kinga Różańska
 Koppany: HU
 Kripto: PL
 Krystian Czekaj: PL
+Krystian Malinowski: PL # Krystian Malinowski == Rex Torpeda
 # L/Ł
 Lanny Poffo: CA
 Laurance Roman: DE
@@ -190,6 +191,7 @@ Primate: GB
 Rambo: DO
 Red Scorpion: IT
 Reinbakh: CA
+Rex Torpeda: PL # Rex Torpeda == Krystian Malinowski
 Ricky Sky: SK
 Ritshy Rage: AT
 Robert Dreissker: AT

--- a/content/e/ddw/2014-12-13-ddw-12.md
+++ b/content/e/ddw/2014-12-13-ddw-12.md
@@ -14,6 +14,8 @@ The event was held in a middle school gymnastics hall in Gdańsk, and was a shor
 - ['[Kaszub](@/w/kaszub.md)', '[GREG](@/w/greg.md)']
 - ['[Gracjan Korpo](@/w/gracjan-korpo.md)', '[Fatman](@/w/pan-pawlowski.md)']
 - ['[Kamil Aleksander](@/w/kamil-aleksander.md)', '[Robert Star](@/w/robert-star.md)']
+- credits:
+    Referee: [Krystian Malinowski](@/w/krystian-malinowski.md)
 {% end %}
 
 ### References

--- a/content/e/ddw/2014-12-13-ddw-12.md
+++ b/content/e/ddw/2014-12-13-ddw-12.md
@@ -15,7 +15,7 @@ The event was held in a middle school gymnastics hall in Gdańsk, and was a shor
 - ['[Gracjan Korpo](@/w/gracjan-korpo.md)', '[Fatman](@/w/pan-pawlowski.md)']
 - ['[Kamil Aleksander](@/w/kamil-aleksander.md)', '[Robert Star](@/w/robert-star.md)']
 - credits:
-    Referee: [Krystian Malinowski](@/w/krystian-malinowski.md)
+    Referee: '[Krystian Malinowski](@/w/krystian-malinowski.md)'
 {% end %}
 
 ### References

--- a/content/e/ddw/2015-03-14-ddw-house-show-1.md
+++ b/content/e/ddw/2015-03-14-ddw-house-show-1.md
@@ -11,15 +11,17 @@ venue = ["gimnazjum-8-gdansk"]
 - ["[Gracjan Korpo](@/w/gracjan-korpo.md); [Krzysztof Zasada](@/w/krzysztof-zasada.md)",
   "[Boski Ostrowski](@/w/ostrowski.md)"]
 - ['[Mira](@/w/mira.md)', Kasandra]
-- - ['[GREG](@/w/greg.md)'
-  - [Rex Torpeda](@/w/krystian-malinowski.md)
-  - {s: Battle Royal}]
+- - '[GREG](@/w/greg.md)'
+  - '[Rex Torpeda](@/w/krystian-malinowski.md)'
+  - s: Battle Royal
 - ['[Robert Star](@/w/robert-star.md)', '[Mateusz Kowalski](@/w/mateusz-kowalski.md)']
 - ['[Don Roid](@/w/don-roid.md)', '[Robert Star](@/w/robert-star.md)']
-- ['[Klarys](@/w/klarys.md)', '[Kaszub](@/w/kaszub.md)', '[Piękny Kawaler](@/w/piekny-kawaler.md)',
-  {s: "Three Way Match"}]
+- - '[Klarys](@/w/klarys.md)'
+  - '[Kaszub](@/w/kaszub.md)'
+  - '[Piękny Kawaler](@/w/piekny-kawaler.md)'
+  - s: "Three Way Match"
 - credits:
-    Referee: [Krystian Malinowski](@/w/krystian-malinowski.md)
+    Referee: '[Krystian Malinowski](@/w/krystian-malinowski.md)'
 {% end %}
 
 ### References

--- a/content/e/ddw/2015-03-14-ddw-house-show-1.md
+++ b/content/e/ddw/2015-03-14-ddw-house-show-1.md
@@ -11,7 +11,9 @@ venue = ["gimnazjum-8-gdansk"]
 - ["[Gracjan Korpo](@/w/gracjan-korpo.md); [Krzysztof Zasada](@/w/krzysztof-zasada.md)",
   "[Boski Ostrowski](@/w/ostrowski.md)"]
 - ['[Mira](@/w/mira.md)', Kasandra]
-- ['[GREG](@/w/greg.md)', {s: Battle Royal}]
+- - ['[GREG](@/w/greg.md)'
+  - Rex Torpeda
+  - {s: Battle Royal}]
 - ['[Robert Star](@/w/robert-star.md)', '[Mateusz Kowalski](@/w/mateusz-kowalski.md)']
 - ['[Don Roid](@/w/don-roid.md)', '[Robert Star](@/w/robert-star.md)']
 - ['[Klarys](@/w/klarys.md)', '[Kaszub](@/w/kaszub.md)', '[Piękny Kawaler](@/w/piekny-kawaler.md)',

--- a/content/e/ddw/2015-03-14-ddw-house-show-1.md
+++ b/content/e/ddw/2015-03-14-ddw-house-show-1.md
@@ -12,12 +12,14 @@ venue = ["gimnazjum-8-gdansk"]
   "[Boski Ostrowski](@/w/ostrowski.md)"]
 - ['[Mira](@/w/mira.md)', Kasandra]
 - - ['[GREG](@/w/greg.md)'
-  - Rex Torpeda
+  - [Rex Torpeda](@/w/krystian-malinowski.md)
   - {s: Battle Royal}]
 - ['[Robert Star](@/w/robert-star.md)', '[Mateusz Kowalski](@/w/mateusz-kowalski.md)']
 - ['[Don Roid](@/w/don-roid.md)', '[Robert Star](@/w/robert-star.md)']
 - ['[Klarys](@/w/klarys.md)', '[Kaszub](@/w/kaszub.md)', '[Piękny Kawaler](@/w/piekny-kawaler.md)',
   {s: "Three Way Match"}]
+- credits:
+    Referee: [Krystian Malinowski](@/w/krystian-malinowski.md)
 {% end %}
 
 ### References

--- a/content/e/ddw/2015-05-02-ddw-house-show-2.md
+++ b/content/e/ddw/2015-05-02-ddw-house-show-2.md
@@ -15,15 +15,19 @@ That organization would reveal itself later in October that year as [KPW](@/o/kp
 
 {% card() %}
 - ['[Piękny Kawaler](@/w/piekny-kawaler.md)', '[Boski Ostrowski](@/w/ostrowski.md)']
-- - ['[Luxus](@/w/luxus.md)'
-  - [Rex Torpeda](@/w/krystian-malinowski.md)
-  - {s: Battle Royal}]
-- ['[Mira](@/w/mira.md)', '[Bianca](@/w/bianca.md)', Kasandra, {s: Triple Threat Match}]
+- - '[Luxus](@/w/luxus.md)'
+  - '[Rex Torpeda](@/w/krystian-malinowski.md)'
+  - s: Battle Royal
+- - '[Mira](@/w/mira.md)'
+  - '[Bianca](@/w/bianca.md)'
+  - Kasandra
+  - s: Triple Threat Match
 - ['[Robert Star](@/w/robert-star.md)', '[GREG](@/w/greg.md)', {s: Hardcore Match}]
-- ['[Kamil Aleksander](@/w/kamil-aleksander.md)', "[Kaszub](@/w/kaszub.md), [Klarys](@/w/klarys.md)",
-  {s: Two On One Handicap Match}]
+- - '[Kamil Aleksander](@/w/kamil-aleksander.md)'
+  - "[Kaszub](@/w/kaszub.md), [Klarys](@/w/klarys.md)"
+  - s: Two On One Handicap Match
 - credits:
-    Referee: [Krystian Malinowski](@/w/krystian-malinowski.md)
+    Referee: '[Krystian Malinowski](@/w/krystian-malinowski.md)'
 {% end %}
 
 ### References

--- a/content/e/ddw/2015-05-02-ddw-house-show-2.md
+++ b/content/e/ddw/2015-05-02-ddw-house-show-2.md
@@ -15,7 +15,9 @@ That organization would reveal itself later in October that year as [KPW](@/o/kp
 
 {% card() %}
 - ['[Piękny Kawaler](@/w/piekny-kawaler.md)', '[Boski Ostrowski](@/w/ostrowski.md)']
-- ['[Luxus](@/w/luxus.md)', {s: Battle Royal}]
+- - ['[Luxus](@/w/luxus.md)'
+  - Rex Torpeda
+  - {s: Battle Royal}]
 - ['[Mira](@/w/mira.md)', '[Bianca](@/w/bianca.md)', Kasandra, {s: Triple Threat Match}]
 - ['[Robert Star](@/w/robert-star.md)', '[GREG](@/w/greg.md)', {s: Hardcore Match}]
 - ['[Kamil Aleksander](@/w/kamil-aleksander.md)', "[Kaszub](@/w/kaszub.md), [Klarys](@/w/klarys.md)",

--- a/content/e/ddw/2015-05-02-ddw-house-show-2.md
+++ b/content/e/ddw/2015-05-02-ddw-house-show-2.md
@@ -16,12 +16,14 @@ That organization would reveal itself later in October that year as [KPW](@/o/kp
 {% card() %}
 - ['[Piękny Kawaler](@/w/piekny-kawaler.md)', '[Boski Ostrowski](@/w/ostrowski.md)']
 - - ['[Luxus](@/w/luxus.md)'
-  - Rex Torpeda
+  - [Rex Torpeda](@/w/krystian-malinowski.md)
   - {s: Battle Royal}]
 - ['[Mira](@/w/mira.md)', '[Bianca](@/w/bianca.md)', Kasandra, {s: Triple Threat Match}]
 - ['[Robert Star](@/w/robert-star.md)', '[GREG](@/w/greg.md)', {s: Hardcore Match}]
 - ['[Kamil Aleksander](@/w/kamil-aleksander.md)', "[Kaszub](@/w/kaszub.md), [Klarys](@/w/klarys.md)",
   {s: Two On One Handicap Match}]
+- credits:
+    Referee: [Krystian Malinowski](@/w/krystian-malinowski.md)
 {% end %}
 
 ### References

--- a/content/e/kpw/2015-11-14-kpw-vs-the-world-hungary-for-kombat.md
+++ b/content/e/kpw/2015-11-14-kpw-vs-the-world-hungary-for-kombat.md
@@ -35,6 +35,7 @@ Most matches were between one wrestler from KPW and one from HCW, a Hungarian wr
   - s: "KPW vs Hungary Nations Cup Round 5 Match"
 - credits:
     Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
+    Referee: [Krystian Malinowski](@/w/krystian-malinowski.md)
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2015-11-14-kpw-vs-the-world-hungary-for-kombat.md
+++ b/content/e/kpw/2015-11-14-kpw-vs-the-world-hungary-for-kombat.md
@@ -34,8 +34,8 @@ Most matches were between one wrestler from KPW and one from HCW, a Hungarian wr
   - "Team Hungary: [Dover](@/w/dover.md)"
   - s: "KPW vs Hungary Nations Cup Round 5 Match"
 - credits:
-    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
-    Referee: [Krystian Malinowski](@/w/krystian-malinowski.md)
+    Ring announcer: '[Arkadiusz Pawłowski](@/w/pan-pawlowski.md)'
+    Referee: '[Krystian Malinowski](@/w/krystian-malinowski.md)'
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2015-11-14-kpw-vs-the-world-hungary-for-kombat.md
+++ b/content/e/kpw/2015-11-14-kpw-vs-the-world-hungary-for-kombat.md
@@ -33,6 +33,8 @@ Most matches were between one wrestler from KPW and one from HCW, a Hungarian wr
 - - "Team KPW: [Kamil Aleksander](@/w/kamil-aleksander.md)"
   - "Team Hungary: [Dover](@/w/dover.md)"
   - s: "KPW vs Hungary Nations Cup Round 5 Match"
+- credits:
+    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2015-12-11-kpw-at-gdynia-game-festival-day-1.md
+++ b/content/e/kpw/2015-12-11-kpw-at-gdynia-game-festival-day-1.md
@@ -19,7 +19,7 @@ and [Day 3](@/e/kpw/2015-12-13-kpw-at-gdynia-game-festival-day-3.md).
 - ['[David Oliwa](@/w/david-oliwa.md)', '[Boski Ostrowski](@/w/ostrowski.md)']
 - ['[Robert Star](@/w/robert-star.md)', '[Greg](@/w/greg.md)']
 - credits:
-    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
+    Ring announcer: '[Arkadiusz Pawłowski](@/w/pan-pawlowski.md)'
 {% end %}
 
 ### References

--- a/content/e/kpw/2015-12-11-kpw-at-gdynia-game-festival-day-1.md
+++ b/content/e/kpw/2015-12-11-kpw-at-gdynia-game-festival-day-1.md
@@ -18,6 +18,8 @@ and [Day 3](@/e/kpw/2015-12-13-kpw-at-gdynia-game-festival-day-3.md).
 - ['[Piękny Kawaler](@/w/piekny-kawaler.md)', '[Kaszub](@/w/kaszub.md)']
 - ['[David Oliwa](@/w/david-oliwa.md)', '[Boski Ostrowski](@/w/ostrowski.md)']
 - ['[Robert Star](@/w/robert-star.md)', '[Greg](@/w/greg.md)']
+- credits:
+    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
 {% end %}
 
 ### References

--- a/content/e/kpw/2015-12-12-kpw-at-gdynia-game-festival-day-2.md
+++ b/content/e/kpw/2015-12-12-kpw-at-gdynia-game-festival-day-2.md
@@ -20,6 +20,8 @@ and [Day 3](@/e/kpw/2015-12-13-kpw-at-gdynia-game-festival-day-3.md).
 - ["[Bianca](@/w/bianca.md), [Gracjan Korpo](@/w/gracjan-korpo.md)", "[Boski Ostrowski](@/w/ostrowski.md),
     [Mira](@/w/mira.md)", {s: "Tag Team Match"}]
 - ['[Damian Lambert](@/w/damien-rothschild.md)', '[Robert Star](@/w/robert-star.md)']
+- credits:
+    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
 {% end %}
 
 ### References

--- a/content/e/kpw/2015-12-12-kpw-at-gdynia-game-festival-day-2.md
+++ b/content/e/kpw/2015-12-12-kpw-at-gdynia-game-festival-day-2.md
@@ -21,7 +21,7 @@ and [Day 3](@/e/kpw/2015-12-13-kpw-at-gdynia-game-festival-day-3.md).
     [Mira](@/w/mira.md)", {s: "Tag Team Match"}]
 - ['[Damian Lambert](@/w/damien-rothschild.md)', '[Robert Star](@/w/robert-star.md)']
 - credits:
-    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
+    Ring announcer: '[Arkadiusz Pawłowski](@/w/pan-pawlowski.md)'
 {% end %}
 
 ### References

--- a/content/e/kpw/2015-12-13-kpw-at-gdynia-game-festival-day-3.md
+++ b/content/e/kpw/2015-12-13-kpw-at-gdynia-game-festival-day-3.md
@@ -19,7 +19,7 @@ and [Day 2](@/e/kpw/2015-12-12-kpw-at-gdynia-game-festival-day-2.md).
     [Luxus](@/w/luxus.md)", {s: "Tag Team Match"}]
 - ['[Piękny Kawaler](@/w/piekny-kawaler.md)', '[David Oliwa](@/w/david-oliwa.md)']
 - credits:
-    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
+    Ring announcer: '[Arkadiusz Pawłowski](@/w/pan-pawlowski.md)'
 {% end %}
 
 ### References

--- a/content/e/kpw/2015-12-13-kpw-at-gdynia-game-festival-day-3.md
+++ b/content/e/kpw/2015-12-13-kpw-at-gdynia-game-festival-day-3.md
@@ -18,6 +18,8 @@ and [Day 2](@/e/kpw/2015-12-12-kpw-at-gdynia-game-festival-day-2.md).
 - ["[Kaszub](@/w/kaszub.md), [Robert Star](@/w/robert-star.md)", "[Greg](@/w/greg.md),
     [Luxus](@/w/luxus.md)", {s: "Tag Team Match"}]
 - ['[Piękny Kawaler](@/w/piekny-kawaler.md)', '[David Oliwa](@/w/david-oliwa.md)']
+- credits:
+    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
 {% end %}
 
 ### References

--- a/content/e/kpw/2016-02-27-kpw-arena-1.md
+++ b/content/e/kpw/2016-02-27-kpw-arena-1.md
@@ -26,8 +26,8 @@ In 2016, a total of four Arena shows were held: three in the first half of the y
 - ["[Kamil Aleksander](@/w/kamil-aleksander.md), [Robert Star](@/w/robert-star.md)",
   "[Greg](@/w/greg.md), [Luxus](@/w/luxus.md)", {s: "Tag Team Match"}]
 - credits:
-    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
-    Referee: [Krystian Malinowski](@/w/krystian-malinowski.md)
+    Ring announcer: '[Arkadiusz Pawłowski](@/w/pan-pawlowski.md)'
+    Referee: '[Krystian Malinowski](@/w/krystian-malinowski.md)'
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2016-02-27-kpw-arena-1.md
+++ b/content/e/kpw/2016-02-27-kpw-arena-1.md
@@ -27,6 +27,7 @@ In 2016, a total of four Arena shows were held: three in the first half of the y
   "[Greg](@/w/greg.md), [Luxus](@/w/luxus.md)", {s: "Tag Team Match"}]
 - credits:
     Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
+    Referee: [Krystian Malinowski](@/w/krystian-malinowski.md)
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2016-02-27-kpw-arena-1.md
+++ b/content/e/kpw/2016-02-27-kpw-arena-1.md
@@ -25,6 +25,8 @@ In 2016, a total of four Arena shows were held: three in the first half of the y
   {nc: "No Contest", s: "KPW Championship #1 Contender Match"}]
 - ["[Kamil Aleksander](@/w/kamil-aleksander.md), [Robert Star](@/w/robert-star.md)",
   "[Greg](@/w/greg.md), [Luxus](@/w/luxus.md)", {s: "Tag Team Match"}]
+- credits:
+    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2016-04-30-kpw-arena-2.md
+++ b/content/e/kpw/2016-04-30-kpw-arena-2.md
@@ -21,6 +21,8 @@ Kawaler's heel faction Kawaleria (_Cavalry_) dominated the show. There was one f
 - ["[Piękny Kawaler](@/w/piekny-kawaler.md)", "[Ron Corvus](@/w/ron-corvus.md)"]
 - ["[Robert Star](@/w/robert-star.md)", "[Kaszub](@/w/kaszub.md)", "[Luxus](@/w/luxus.md)",
   "[Greg](@/w/greg.md)", {s: "KPW Championship Contender Ladder Match"}]
+- credits:
+    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2016-04-30-kpw-arena-2.md
+++ b/content/e/kpw/2016-04-30-kpw-arena-2.md
@@ -22,8 +22,8 @@ Kawaler's heel faction Kawaleria (_Cavalry_) dominated the show. There was one f
 - ["[Robert Star](@/w/robert-star.md)", "[Kaszub](@/w/kaszub.md)", "[Luxus](@/w/luxus.md)",
   "[Greg](@/w/greg.md)", {s: "KPW Championship Contender Ladder Match"}]
 - credits:
-    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
-    Referee: [Krystian Malinowski](@/w/krystian-malinowski.md)
+    Ring announcer: '[Arkadiusz Pawłowski](@/w/pan-pawlowski.md)'
+    Referee: '[Krystian Malinowski](@/w/krystian-malinowski.md)'
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2016-04-30-kpw-arena-2.md
+++ b/content/e/kpw/2016-04-30-kpw-arena-2.md
@@ -23,6 +23,7 @@ Kawaler's heel faction Kawaleria (_Cavalry_) dominated the show. There was one f
   "[Greg](@/w/greg.md)", {s: "KPW Championship Contender Ladder Match"}]
 - credits:
     Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
+    Referee: [Krystian Malinowski](@/w/krystian-malinowski.md)
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2016-06-11-kpw-arena-3.md
+++ b/content/e/kpw/2016-06-11-kpw-arena-3.md
@@ -21,7 +21,7 @@ The event featured DDW character Kamil Leśny joining KPW, as a member of the Ka
 - ['[Piękny Kawaler](@/w/piekny-kawaler.md)', '[Robert Star](@/w/robert-star.md)',
   {s: "KPW Championship Contendership Match"}]
 - credits:
-    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
+    Ring announcer: '[Arkadiusz Pawłowski](@/w/pan-pawlowski.md)'
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2016-06-11-kpw-arena-3.md
+++ b/content/e/kpw/2016-06-11-kpw-arena-3.md
@@ -20,6 +20,8 @@ The event featured DDW character Kamil Leśny joining KPW, as a member of the Ka
 - ['[Kamil Aleksander](@/w/kamil-aleksander.md)', '[Damian Lambert](@/w/damien-rothschild.md)']
 - ['[Piękny Kawaler](@/w/piekny-kawaler.md)', '[Robert Star](@/w/robert-star.md)',
   {s: "KPW Championship Contendership Match"}]
+- credits:
+    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2016-07-23-kpw-oldtown.md
+++ b/content/e/kpw/2016-07-23-kpw-oldtown.md
@@ -24,7 +24,7 @@ KPW held a wrestling exhibition during the event on the penultimate day. Wrestli
     [David Oliwa](@/w/david-oliwa.md)
   - s: 3 vs 2 Handicap Match
 - credits:
-    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
+    Ring announcer: '[Arkadiusz Pawłowski](@/w/pan-pawlowski.md)'
 {% end %}
 
 Attendance: estimated 200.

--- a/content/e/kpw/2016-07-23-kpw-oldtown.md
+++ b/content/e/kpw/2016-07-23-kpw-oldtown.md
@@ -23,6 +23,8 @@ KPW held a wrestling exhibition during the event on the penultimate day. Wrestli
     [Bianca](@/w/bianca.md),
     [David Oliwa](@/w/david-oliwa.md)
   - s: 3 vs 2 Handicap Match
+- credits:
+    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
 {% end %}
 
 Attendance: estimated 200.

--- a/content/e/kpw/2016-08-13-kpw-godzina-zero-2016.md
+++ b/content/e/kpw/2016-08-13-kpw-godzina-zero-2016.md
@@ -34,9 +34,9 @@ The venue for this event was the Hall of Sports in Gdynia, which would become th
 - ['[Bianca](@/w/bianca.md)', Aurora Flame]
 - ['[Piękny Kawaler](@/w/piekny-kawaler.md)', '[Kamil Aleksander](@/w/kamil-aleksander.md)',
   {c: "KPW Championship", s: "2 out of 3 Falls Match"}]
+- credits:
+    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
 {% end %}
-
-Ring announcer: Arkadiusz Pawłowski
 
 #### Recap
 

--- a/content/e/kpw/2016-08-13-kpw-godzina-zero-2016.md
+++ b/content/e/kpw/2016-08-13-kpw-godzina-zero-2016.md
@@ -32,11 +32,13 @@ The venue for this event was the Hall of Sports in Gdynia, which would become th
     [David Oliwa](@/w/david-oliwa.md)", {s: Tag Team Match}]
 - [Jon Ryan, '[Robert Star](@/w/robert-star.md)']
 - ['[Bianca](@/w/bianca.md)', Aurora Flame]
-- ['[Piękny Kawaler](@/w/piekny-kawaler.md)', '[Kamil Aleksander](@/w/kamil-aleksander.md)',
-  {c: "KPW Championship", s: "2 out of 3 Falls Match"}]
+- - '[Piękny Kawaler](@/w/piekny-kawaler.md)'
+  - '[Kamil Aleksander](@/w/kamil-aleksander.md)'
+  - c: "KPW Championship"
+    s: "2 out of 3 Falls Match"
 - credits:
-    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
-    Referee: [Krystian Malinowski](@/w/krystian-malinowski.md)
+    Ring announcer: '[Arkadiusz Pawłowski](@/w/pan-pawlowski.md)'
+    Referee: '[Krystian Malinowski](@/w/krystian-malinowski.md)'
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2016-08-13-kpw-godzina-zero-2016.md
+++ b/content/e/kpw/2016-08-13-kpw-godzina-zero-2016.md
@@ -36,6 +36,7 @@ The venue for this event was the Hall of Sports in Gdynia, which would become th
   {c: "KPW Championship", s: "2 out of 3 Falls Match"}]
 - credits:
     Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
+    Referee: [Krystian Malinowski](@/w/krystian-malinowski.md)
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2016-11-26-kpw-arena-4-nowy-rozdzial.md
+++ b/content/e/kpw/2016-11-26-kpw-arena-4-nowy-rozdzial.md
@@ -20,6 +20,7 @@ Nowy Rozdział (_The New Chapter_) was held in Gdańsk, in the gymnastics hall o
 - ['[Piękny Kawaler](@/w/piekny-kawaler.md)(c)', Elliott Jordan, {c: KPW Championship}]
 - credits:
     Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
+    Referee: [Krystian Malinowski](@/w/krystian-malinowski.md)
 {% end %}
 
 This would be [Damian Lambert](@/w/damien-rothschild.md)'s last appearance for KPW.

--- a/content/e/kpw/2016-11-26-kpw-arena-4-nowy-rozdzial.md
+++ b/content/e/kpw/2016-11-26-kpw-arena-4-nowy-rozdzial.md
@@ -12,15 +12,15 @@ Nowy Rozdział (_The New Chapter_) was held in Gdańsk, in the gymnastics hall o
 
 {% card() %}
 - ['[Kaszub](@/w/kaszub.md)', '[Peter Pannache](@/w/peter-pannache.md)', {r: DQ}]
-- ["[Boski Ostrowski](@/w/ostrowski.md), [David Oliwa](@/w/david-oliwa.md); [Mira](@/w/mira.md)",
-  "[Mateusz Kowalski](@/w/mateusz-kowalski.md), [Victor Rosetti](@/w/rosetti.md)",
-  {s: Tag Team Match}]
+- - "[Boski Ostrowski](@/w/ostrowski.md), [David Oliwa](@/w/david-oliwa.md); [Mira](@/w/mira.md)"
+  - "[Mateusz Kowalski](@/w/mateusz-kowalski.md), [Victor Rosetti](@/w/rosetti.md)"
+  - s: Tag Team Match
 - ['[Kamil Aleksander](@/w/kamil-aleksander.md)', '[Greg](@/w/greg.md)']
 - ['[Robert Star](@/w/robert-star.md)', '[Damian Lambert](@/w/damien-rothschild.md)']
 - ['[Piękny Kawaler](@/w/piekny-kawaler.md)(c)', Elliott Jordan, {c: KPW Championship}]
 - credits:
-    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
-    Referee: [Krystian Malinowski](@/w/krystian-malinowski.md)
+    Ring announcer: '[Arkadiusz Pawłowski](@/w/pan-pawlowski.md)'
+    Referee: '[Krystian Malinowski](@/w/krystian-malinowski.md)'
 {% end %}
 
 This would be [Damian Lambert](@/w/damien-rothschild.md)'s last appearance for KPW.

--- a/content/e/kpw/2016-11-26-kpw-arena-4-nowy-rozdzial.md
+++ b/content/e/kpw/2016-11-26-kpw-arena-4-nowy-rozdzial.md
@@ -18,6 +18,8 @@ Nowy Rozdział (_The New Chapter_) was held in Gdańsk, in the gymnastics hall o
 - ['[Kamil Aleksander](@/w/kamil-aleksander.md)', '[Greg](@/w/greg.md)']
 - ['[Robert Star](@/w/robert-star.md)', '[Damian Lambert](@/w/damien-rothschild.md)']
 - ['[Piękny Kawaler](@/w/piekny-kawaler.md)(c)', Elliott Jordan, {c: KPW Championship}]
+- credits:
+    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
 {% end %}
 
 This would be [Damian Lambert](@/w/damien-rothschild.md)'s last appearance for KPW.

--- a/content/e/kpw/2017-01-14-kpw-arena-v.md
+++ b/content/e/kpw/2017-01-14-kpw-arena-v.md
@@ -20,8 +20,8 @@ The main event featured British wrestler Pastor William Eaver, a former PROGRESS
   "[Gracjan Korpo](@/w/gracjan-korpo.md), [Victor Rosetti](@/w/rosetti.md)", {r: DQ}]
 - ['[Piękny Kawaler](@/w/piekny-kawaler.md)(c)', Pastor William Eaver]
 - credits:
-    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
-    Referee: [Krystian Malinowski](@/w/krystian-malinowski.md)
+    Ring announcer: '[Arkadiusz Pawłowski](@/w/pan-pawlowski.md)'
+    Referee: '[Krystian Malinowski](@/w/krystian-malinowski.md)'
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2017-01-14-kpw-arena-v.md
+++ b/content/e/kpw/2017-01-14-kpw-arena-v.md
@@ -19,9 +19,9 @@ The main event featured British wrestler Pastor William Eaver, a former PROGRESS
 - ["[Boski Ostrowski](@/w/ostrowski.md), [David Oliwa](@/w/david-oliwa.md); [Mira](@/w/mira.md)",
   "[Gracjan Korpo](@/w/gracjan-korpo.md), [Victor Rosetti](@/w/rosetti.md)", {r: DQ}]
 - ['[Piękny Kawaler](@/w/piekny-kawaler.md)(c)', Pastor William Eaver]
+- credits:
+    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
 {% end %}
-
-Ring announcer: Arkadiusz Pawłowski
 
 #### Recap
 

--- a/content/e/kpw/2017-01-14-kpw-arena-v.md
+++ b/content/e/kpw/2017-01-14-kpw-arena-v.md
@@ -21,6 +21,7 @@ The main event featured British wrestler Pastor William Eaver, a former PROGRESS
 - ['[Piękny Kawaler](@/w/piekny-kawaler.md)(c)', Pastor William Eaver]
 - credits:
     Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
+    Referee: [Krystian Malinowski](@/w/krystian-malinowski.md)
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2017-02-04-kpw-szlamfest.md
+++ b/content/e/kpw/2017-02-04-kpw-szlamfest.md
@@ -22,6 +22,8 @@ The event, and festival, were held in B90, a music and event venue located in a 
 - ['[Bianca](@/w/bianca.md)', '[Mira](@/w/mira.md)', {s: Pillow Fight Match}]
 - ["[Kaszub](@/w/kaszub.md), [Piękny Kawaler](@/w/piekny-kawaler.md)", "[Boski Ostrowski](@/w/ostrowski.md),
     [David Oliwa](@/w/david-oliwa.md)", {s: Tag Team Match}]
+- credits:
+    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
 {% end %}
 
 #### Summary

--- a/content/e/kpw/2017-02-04-kpw-szlamfest.md
+++ b/content/e/kpw/2017-02-04-kpw-szlamfest.md
@@ -23,8 +23,8 @@ The event, and festival, were held in B90, a music and event venue located in a 
 - ["[Kaszub](@/w/kaszub.md), [Piękny Kawaler](@/w/piekny-kawaler.md)", "[Boski Ostrowski](@/w/ostrowski.md),
     [David Oliwa](@/w/david-oliwa.md)", {s: Tag Team Match}]
 - credits:
-    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
-    Referee: [Krystian Malinowski](@/w/krystian-malinowski.md)
+    Ring announcer: '[Arkadiusz Pawłowski](@/w/pan-pawlowski.md)'
+    Referee: '[Krystian Malinowski](@/w/krystian-malinowski.md)'
 {% end %}
 
 #### Summary

--- a/content/e/kpw/2017-02-04-kpw-szlamfest.md
+++ b/content/e/kpw/2017-02-04-kpw-szlamfest.md
@@ -24,6 +24,7 @@ The event, and festival, were held in B90, a music and event venue located in a 
     [David Oliwa](@/w/david-oliwa.md)", {s: Tag Team Match}]
 - credits:
     Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
+    Referee: [Krystian Malinowski](@/w/krystian-malinowski.md)
 {% end %}
 
 #### Summary

--- a/content/e/kpw/2017-04-08-kpw-arena-6-selekcja.md
+++ b/content/e/kpw/2017-04-08-kpw-arena-6-selekcja.md
@@ -26,6 +26,8 @@ Several years later, Karol would become [Iskra](@/w/iskra.md) in [Prime Time Wre
   - Leśny
   - '[Peter Pannache](@/w/peter-pannache.md)'
   - s: KPW Championship
+- credits:
+    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2017-04-08-kpw-arena-6-selekcja.md
+++ b/content/e/kpw/2017-04-08-kpw-arena-6-selekcja.md
@@ -28,6 +28,7 @@ Several years later, Karol would become [Iskra](@/w/iskra.md) in [Prime Time Wre
   - s: KPW Championship
 - credits:
     Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
+    Referee: [Krystian Malinowski](@/w/krystian-malinowski.md)
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2017-04-08-kpw-arena-6-selekcja.md
+++ b/content/e/kpw/2017-04-08-kpw-arena-6-selekcja.md
@@ -27,8 +27,8 @@ Several years later, Karol would become [Iskra](@/w/iskra.md) in [Prime Time Wre
   - '[Peter Pannache](@/w/peter-pannache.md)'
   - s: KPW Championship
 - credits:
-    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
-    Referee: [Krystian Malinowski](@/w/krystian-malinowski.md)
+    Ring announcer: '[Arkadiusz Pawłowski](@/w/pan-pawlowski.md)'
+    Referee: '[Krystian Malinowski](@/w/krystian-malinowski.md)'
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2017-06-10-kpw-arena-7-wysoka-stawka.md
+++ b/content/e/kpw/2017-06-10-kpw-arena-7-wysoka-stawka.md
@@ -14,14 +14,16 @@ Wysoka Stawka (_High Stakes_) was KPW's seventh Arena event, held in [Klub Atlan
 - ['[Robert Star](@/w/robert-star.md)', '[Victor Rosetti](@/w/rosetti.md)']
 - ["[Gracjan Korpo](@/w/gracjan-korpo.md); [Krzysztof Zasada](@/w/krzysztof-zasada.md)",
   '[Mateusz Kowalski](@/w/mateusz-kowalski.md)']
-- ["Kawaleria: [Kaszub](@/w/kaszub.md), [Greg](@/w/greg.md)", "[David Oliwa](@/w/david-oliwa.md),
-    [Peter Pannache](@/w/peter-pannache.md)", {s: Tag Team Match}]
+- - "Kawaleria: [Kaszub](@/w/kaszub.md), [Greg](@/w/greg.md)"
+  - "[David Oliwa](@/w/david-oliwa.md), [Peter Pannache](@/w/peter-pannache.md)"
+  - s: Tag Team Match
 - ['[Kamil Aleksander](@/w/kamil-aleksander.md)', '[Adam Bravo](@/w/adam-bravo.md)']
-- ['[Piękny Kawaler](@/w/piekny-kawaler.md)(c)', '[Boski Ostrowski](@/w/ostrowski.md)',
-  {c: KPW Championship}
+- - '[Piękny Kawaler](@/w/piekny-kawaler.md)(c)'
+  - '[Boski Ostrowski](@/w/ostrowski.md)'
+  - c: KPW Championship
 - credits:
-    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
-    Referee: [Krystian Malinowski](@/w/krystian-malinowski.md)]
+    Ring announcer: '[Arkadiusz Pawłowski](@/w/pan-pawlowski.md)'
+    Referee: '[Krystian Malinowski](@/w/krystian-malinowski.md)'
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2017-06-10-kpw-arena-7-wysoka-stawka.md
+++ b/content/e/kpw/2017-06-10-kpw-arena-7-wysoka-stawka.md
@@ -18,9 +18,10 @@ Wysoka Stawka (_High Stakes_) was KPW's seventh Arena event, held in [Klub Atlan
     [Peter Pannache](@/w/peter-pannache.md)", {s: Tag Team Match}]
 - ['[Kamil Aleksander](@/w/kamil-aleksander.md)', '[Adam Bravo](@/w/adam-bravo.md)']
 - ['[Piękny Kawaler](@/w/piekny-kawaler.md)(c)', '[Boski Ostrowski](@/w/ostrowski.md)',
+  {c: KPW Championship}
 - credits:
     Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
-  {c: KPW Championship}]
+    Referee: [Krystian Malinowski](@/w/krystian-malinowski.md)]
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2017-06-10-kpw-arena-7-wysoka-stawka.md
+++ b/content/e/kpw/2017-06-10-kpw-arena-7-wysoka-stawka.md
@@ -18,10 +18,10 @@ Wysoka Stawka (_High Stakes_) was KPW's seventh Arena event, held in [Klub Atlan
     [Peter Pannache](@/w/peter-pannache.md)", {s: Tag Team Match}]
 - ['[Kamil Aleksander](@/w/kamil-aleksander.md)', '[Adam Bravo](@/w/adam-bravo.md)']
 - ['[Piękny Kawaler](@/w/piekny-kawaler.md)(c)', '[Boski Ostrowski](@/w/ostrowski.md)',
+- credits:
+    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
   {c: KPW Championship}]
 {% end %}
-
-Ring announcer: Arkadiusz Pawłowski
 
 #### Recap
 

--- a/content/e/kpw/2017-07-23-kpw-oldtown-2.md
+++ b/content/e/kpw/2017-07-23-kpw-oldtown-2.md
@@ -24,7 +24,7 @@ KPW would return to following editions of OldTown until 2019.
 - ['[Greg](@/w/greg.md)', '[Peter Pannache](@/w/peter-pannache.md)', {c: "KPW OldTown
       Championship"}]
 - credits:
-    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
+    Ring announcer: '[Arkadiusz Pawłowski](@/w/pan-pawlowski.md)'
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2017-07-23-kpw-oldtown-2.md
+++ b/content/e/kpw/2017-07-23-kpw-oldtown-2.md
@@ -23,6 +23,8 @@ KPW would return to following editions of OldTown until 2019.
 - ['[Piękny Kawaler](@/w/piekny-kawaler.md)', '[Adam Bravo](@/w/adam-bravo.md)']
 - ['[Greg](@/w/greg.md)', '[Peter Pannache](@/w/peter-pannache.md)', {c: "KPW OldTown
       Championship"}]
+- credits:
+    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2017-08-12-kpw-godzina-zero-2017.md
+++ b/content/e/kpw/2017-08-12-kpw-godzina-zero-2017.md
@@ -38,6 +38,7 @@ The other challenger was Welsh wrestler Wild Boar, by then already a veteran of 
 - ['[Piękny Kawaler](@/w/piekny-kawaler.md)(c)', Wild Boar, {c: "KPW Championship"}]
 - credits:
     Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
+    Referee: [Krystian Malinowski](@/w/krystian-malinowski.md)
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2017-08-12-kpw-godzina-zero-2017.md
+++ b/content/e/kpw/2017-08-12-kpw-godzina-zero-2017.md
@@ -37,8 +37,8 @@ The other challenger was Welsh wrestler Wild Boar, by then already a veteran of 
 - [Kat Von Kaige, '[Bianca](@/w/bianca.md)']
 - ['[Piękny Kawaler](@/w/piekny-kawaler.md)(c)', Wild Boar, {c: "KPW Championship"}]
 - credits:
-    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
-    Referee: [Krystian Malinowski](@/w/krystian-malinowski.md)
+    Ring announcer: '[Arkadiusz Pawłowski](@/w/pan-pawlowski.md)'
+    Referee: '[Krystian Malinowski](@/w/krystian-malinowski.md)'
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2017-08-12-kpw-godzina-zero-2017.md
+++ b/content/e/kpw/2017-08-12-kpw-godzina-zero-2017.md
@@ -36,9 +36,9 @@ The other challenger was Welsh wrestler Wild Boar, by then already a veteran of 
       Title Match"
 - [Kat Von Kaige, '[Bianca](@/w/bianca.md)']
 - ['[Piękny Kawaler](@/w/piekny-kawaler.md)(c)', Wild Boar, {c: "KPW Championship"}]
+- credits:
+    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
 {% end %}
-
-Ring announcer: Arkadiusz Pawłowski
 
 #### Recap
 

--- a/content/e/kpw/2017-10-22-kpw-world-travel-show.md
+++ b/content/e/kpw/2017-10-22-kpw-world-travel-show.md
@@ -16,6 +16,8 @@ Rojas faced KPW's [Mira](@/w/mira.md) in a mostly unplanned match, consisting of
 {% card() %}
 - ['[Mira](@/w/mira.md)', Carmen Rojas]
 - ['[Robert Star](@/w/robert-star.md)', '[Greg](@/w/greg.md)']
+- credits:
+    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
 {% end %}
 
 ### References

--- a/content/e/kpw/2017-10-22-kpw-world-travel-show.md
+++ b/content/e/kpw/2017-10-22-kpw-world-travel-show.md
@@ -17,7 +17,7 @@ Rojas faced KPW's [Mira](@/w/mira.md) in a mostly unplanned match, consisting of
 - ['[Mira](@/w/mira.md)', Carmen Rojas]
 - ['[Robert Star](@/w/robert-star.md)', '[Greg](@/w/greg.md)']
 - credits:
-    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
+    Ring announcer: '[Arkadiusz Pawłowski](@/w/pan-pawlowski.md)'
 {% end %}
 
 ### References

--- a/content/e/kpw/2017-11-18-kpw-arena-8-droga-bez-powrotu.md
+++ b/content/e/kpw/2017-11-18-kpw-arena-8-droga-bez-powrotu.md
@@ -25,9 +25,10 @@ Droga Bez Powrotu (_The Road of No Return_) was the eight Arena show, and the fi
   - c: "KPW OldTown Championship Match"
     s: "(KPW Championship #1 Contender Match for Robert)"
     r: DQ
+- credits:
+    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
 {% end %}
 
-Ring announcer: Arkadiusz Pawłowski \
 Attendance: about 210
 
 #### Recap

--- a/content/e/kpw/2017-11-18-kpw-arena-8-droga-bez-powrotu.md
+++ b/content/e/kpw/2017-11-18-kpw-arena-8-droga-bez-powrotu.md
@@ -27,6 +27,7 @@ Droga Bez Powrotu (_The Road of No Return_) was the eight Arena show, and the fi
     r: DQ
 - credits:
     Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
+    Referee: [Krystian Malinowski](@/w/krystian-malinowski.md)
 {% end %}
 
 Attendance: about 210

--- a/content/e/kpw/2017-11-18-kpw-arena-8-droga-bez-powrotu.md
+++ b/content/e/kpw/2017-11-18-kpw-arena-8-droga-bez-powrotu.md
@@ -16,7 +16,8 @@ Droga Bez Powrotu (_The Road of No Return_) was the eight Arena show, and the fi
   - '[Peter Pannache](@/w/peter-pannache.md)'
   - '[Gracjan Korpo](@/w/gracjan-korpo.md)'
   - s: KPW OldTown Championship
-- ['[David Oliwa](@/w/david-oliwa.md)', '[Kamil Aleksander](@/w/kamil-aleksander.md)']
+- - '[David Oliwa](@/w/david-oliwa.md)'
+  - '[Kamil Aleksander](@/w/kamil-aleksander.md)'
 - - "[Rosetti](@/w/rosetti.md), [Sawicki](@/w/sawicki.md)"
   - "[Mateusz Kowalski](@/w/mateusz-kowalski.md), [Adam Bravo](@/w/adam-bravo.md)"
   - s: Tag Team Match
@@ -26,8 +27,8 @@ Droga Bez Powrotu (_The Road of No Return_) was the eight Arena show, and the fi
     s: "(KPW Championship #1 Contender Match for Robert)"
     r: DQ
 - credits:
-    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
-    Referee: [Krystian Malinowski](@/w/krystian-malinowski.md)
+    Ring announcer: '[Arkadiusz Pawłowski](@/w/pan-pawlowski.md)'
+    Referee: '[Krystian Malinowski](@/w/krystian-malinowski.md)'
 {% end %}
 
 Attendance: about 210

--- a/content/e/kpw/2018-03-10-kpw-arena-9-na-krawedzi.md
+++ b/content/e/kpw/2018-03-10-kpw-arena-9-na-krawedzi.md
@@ -24,9 +24,10 @@ This show was also the debut of the future [Chemik](@/w/chemik.md) - who appeare
 - ['[Greg](@/w/greg.md)', '[Kaszub](@/w/kaszub.md)', {c: KPW OldTown Championship}]
 - ['[Greg](@/w/greg.md)', '[David Oliwa](@/w/david-oliwa.md)', {c: KPW OldTown Championship,
     s: Hardcore Match}]
+- credits:
+    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
 {% end %}
 
-Ring announcer: Arkadiusz Pawłowski \
 Attendance: estimated 400
 
 #### Recap

--- a/content/e/kpw/2018-03-10-kpw-arena-9-na-krawedzi.md
+++ b/content/e/kpw/2018-03-10-kpw-arena-9-na-krawedzi.md
@@ -21,11 +21,15 @@ This show was also the debut of the future [Chemik](@/w/chemik.md) - who appeare
 - ['[Ron Corvus](@/w/ron-corvus.md)', '[Gracjan Korpo](@/w/gracjan-korpo.md)']
 - ['[Robert Star](@/w/robert-star.md)', '[Kamil Aleksander](@/w/kamil-aleksander.md)',
   {s: "KPW Championship #1 Contender Match"}]
-- ['[Greg](@/w/greg.md)', '[Kaszub](@/w/kaszub.md)', {c: KPW OldTown Championship}]
-- ['[Greg](@/w/greg.md)', '[David Oliwa](@/w/david-oliwa.md)', {c: KPW OldTown Championship,
-    s: Hardcore Match}]
+- - '[Greg](@/w/greg.md)'
+  - '[Kaszub](@/w/kaszub.md)'
+  - c: KPW OldTown Championship
+- - '[Greg](@/w/greg.md)'
+  - '[David Oliwa](@/w/david-oliwa.md)'
+  - c: KPW OldTown Championship
+    s: Hardcore Match
 - credits:
-    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
+    Ring announcer: '[Arkadiusz Pawłowski](@/w/pan-pawlowski.md)'
 {% end %}
 
 Attendance: estimated 400

--- a/content/e/kpw/2018-05-26-kpw-arena-x-kawaleria-vs-sojusz.md
+++ b/content/e/kpw/2018-05-26-kpw-arena-x-kawaleria-vs-sojusz.md
@@ -32,11 +32,11 @@ venue=["gdynia-sports-center"]
   {c: "KPW Championship", s: "Lumberjack Match"}]
 - ['[Ron Corvus](@/w/ron-corvus.md)', '[Piękny Kawaler](@/w/piekny-kawaler.md)(c)',
   {c: "KPW Championship"}]
+- credits:
+    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
 {% end %}
 
 Attendance: about 300 \
-Ring announcer: Arkadiusz Pawłowski
-
 
 #### Recap
 

--- a/content/e/kpw/2018-05-26-kpw-arena-x-kawaleria-vs-sojusz.md
+++ b/content/e/kpw/2018-05-26-kpw-arena-x-kawaleria-vs-sojusz.md
@@ -33,7 +33,7 @@ venue=["gdynia-sports-center"]
 - ['[Ron Corvus](@/w/ron-corvus.md)', '[Piękny Kawaler](@/w/piekny-kawaler.md)(c)',
   {c: "KPW Championship"}]
 - credits:
-    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
+    Ring announcer: '[Arkadiusz Pawłowski](@/w/pan-pawlowski.md)'
 {% end %}
 
 Attendance: about 300 \

--- a/content/e/kpw/2018-07-14-kpw-oldtown-3.md
+++ b/content/e/kpw/2018-07-14-kpw-oldtown-3.md
@@ -30,6 +30,8 @@ In 2018 the event lasted an entire week, between July 13 and 19. KPW held a wres
       Way Match}]
 - ['[Ron Corvus](@/w/ron-corvus.md)(c)', '[Dom Taylor](@/w/dom-taylor.md)', {c: KPW
       Championship}]
+- credits:
+    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
 {% end %}
 
 ### References

--- a/content/e/kpw/2018-07-14-kpw-oldtown-3.md
+++ b/content/e/kpw/2018-07-14-kpw-oldtown-3.md
@@ -26,12 +26,14 @@ In 2018 the event lasted an entire week, between July 13 and 19. KPW held a wres
   - s: "Six Man Tag Team Match"
 - ['[Gracjan Korpo](@/w/gracjan-korpo.md)', '[Adam Bravo](@/w/adam-bravo.md)']
 - ['[Greg](@/w/greg.md)(c)', Lee Rogers, {c: KPW OldTown Championship}]
-- ['[Bianca](@/w/bianca.md)', '[Alisa](@/w/alisa.md)', '[Mira](@/w/mira.md)', {s: Three
-      Way Match}]
+- - '[Bianca](@/w/bianca.md)'
+  - '[Alisa](@/w/alisa.md)'
+  - '[Mira](@/w/mira.md)'
+  - s: Three Way Match
 - ['[Ron Corvus](@/w/ron-corvus.md)(c)', '[Dom Taylor](@/w/dom-taylor.md)', {c: KPW
       Championship}]
 - credits:
-    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
+    Ring announcer: '[Arkadiusz Pawłowski](@/w/pan-pawlowski.md)'
 {% end %}
 
 ### References

--- a/content/e/kpw/2018-08-11-kpw-godzina-zero-2018.md
+++ b/content/e/kpw/2018-08-11-kpw-godzina-zero-2018.md
@@ -29,7 +29,7 @@ The event was held on the same day as a footbal match between Arka Gdynia and GÃ
   - '[Rosetti](@/w/rosetti.md)'
   - '[Moloch](@/w/moloch.md)'
   - '[Mateusz Kakareko](@/w/mateusz-kowalski.md)'
-  - s: Magnificent Seven No-DQ Elimination Ladder Match for
+  - s: Magnificent Seven No-DQ Elimination Ladder Match for a Championship contract
 - ['[Bianca](@/w/bianca.md)', Sixt]
 - ['[Ron Corvus](@/w/ron-corvus.md)(c)', Tom LaRuffa, {c: KPW Championship}]
 - credits:

--- a/content/e/kpw/2018-08-11-kpw-godzina-zero-2018.md
+++ b/content/e/kpw/2018-08-11-kpw-godzina-zero-2018.md
@@ -33,7 +33,7 @@ The event was held on the same day as a footbal match between Arka Gdynia and G�
 - ['[Bianca](@/w/bianca.md)', Sixt]
 - ['[Ron Corvus](@/w/ron-corvus.md)(c)', Tom LaRuffa, {c: KPW Championship}]
 - credits:
-    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
+    Ring announcer: '[Arkadiusz Pawłowski](@/w/pan-pawlowski.md)'
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2018-08-11-kpw-godzina-zero-2018.md
+++ b/content/e/kpw/2018-08-11-kpw-godzina-zero-2018.md
@@ -32,6 +32,8 @@ The event was held on the same day as a footbal match between Arka Gdynia and G√
   - s: Magnificent Seven No-DQ Elimination Ladder Match for
 - ['[Bianca](@/w/bianca.md)', Sixt]
 - ['[Ron Corvus](@/w/ron-corvus.md)(c)', Tom LaRuffa, {c: KPW Championship}]
+- credits:
+    Ring announcer: [Arkadiusz Paw≈Çowski](@/w/pan-pawlowski.md)
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2018-11-03-kpw-arena-11-podwojne-zagrozenie.md
+++ b/content/e/kpw/2018-11-03-kpw-arena-11-podwojne-zagrozenie.md
@@ -37,9 +37,9 @@ Podwójne Zagrożenie (_Double Threat_) was an event by [KPW](@/o/kpw.md), held 
 - ["[Rosetti](@/w/rosetti.md), [Sawicki](@/w/sawicki.md)", "Boska Oliwa: [David Oliwa](@/w/david-oliwa.md),
     [Boski Ostrowski](@/w/ostrowski.md)", {c: "KPW Tag Team Championship", s: "Tournament
       Final Tag Team Match"}]
+- credits:
+    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
 {% end %}
-
-Ring announcer: Arkadiusz Pawłowski
 
 #### Recap
 

--- a/content/e/kpw/2018-11-03-kpw-arena-11-podwojne-zagrozenie.md
+++ b/content/e/kpw/2018-11-03-kpw-arena-11-podwojne-zagrozenie.md
@@ -38,7 +38,7 @@ Podwójne Zagrożenie (_Double Threat_) was an event by [KPW](@/o/kpw.md), held 
     [Boski Ostrowski](@/w/ostrowski.md)", {c: "KPW Tag Team Championship", s: "Tournament
       Final Tag Team Match"}]
 - credits:
-    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
+    Ring announcer: '[Arkadiusz Pawłowski](@/w/pan-pawlowski.md)'
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2019-01-19-kpw-arena-12-gwiazda-polnocy.md
+++ b/content/e/kpw/2019-01-19-kpw-arena-12-gwiazda-polnocy.md
@@ -27,6 +27,8 @@ The event was almost cancelled due to unrelated but tragic circumstances in the 
 - ['[Alisa](@/w/alisa.md)', '[Bianca](@/w/bianca.md)', Yuu, {s: Three Way Match}]
 - ['[Ron Corvus](@/w/ron-corvus.md)(c)', '[Peter Pannache](@/w/peter-pannache.md)',
   {c: "KPW Championship"}]
+- credits:
+    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2019-01-19-kpw-arena-12-gwiazda-polnocy.md
+++ b/content/e/kpw/2019-01-19-kpw-arena-12-gwiazda-polnocy.md
@@ -28,7 +28,7 @@ The event was almost cancelled due to unrelated but tragic circumstances in the 
 - ['[Ron Corvus](@/w/ron-corvus.md)(c)', '[Peter Pannache](@/w/peter-pannache.md)',
   {c: "KPW Championship"}]
 - credits:
-    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
+    Ring announcer: '[Arkadiusz Pawłowski](@/w/pan-pawlowski.md)'
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2019-04-05-kpw-arena-13-capo-di-tutti-capi.md
+++ b/content/e/kpw/2019-04-05-kpw-arena-13-capo-di-tutti-capi.md
@@ -31,7 +31,7 @@ Originally, the tag team champions were scheduled against German wrestlers [Fynn
   - '[Ron Corvus](@/w/ron-corvus.md)(c)'
   - c: KPW Championship
 - credits:
-    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
+    Ring announcer: '[Arkadiusz Pawłowski](@/w/pan-pawlowski.md)'
 {% end %}
 
 ### Recap

--- a/content/e/kpw/2019-04-05-kpw-arena-13-capo-di-tutti-capi.md
+++ b/content/e/kpw/2019-04-05-kpw-arena-13-capo-di-tutti-capi.md
@@ -30,9 +30,9 @@ Originally, the tag team champions were scheduled against German wrestlers [Fynn
 - - '[Robert Star](@/w/robert-star.md)'
   - '[Ron Corvus](@/w/ron-corvus.md)(c)'
   - c: KPW Championship
+- credits:
+    Ring announcer: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md)
 {% end %}
-
-Ring announcer: Arkadiusz Pawłowski
 
 ### Recap
 

--- a/content/e/kpw/2019-06-15-kpw-arena-14-nastepny-poziom.md
+++ b/content/e/kpw/2019-06-15-kpw-arena-14-nastepny-poziom.md
@@ -32,9 +32,10 @@ This event had a major foreign guest - British wrestler Mark Haskins, who by the
   - '[Ron Corvus](@/w/ron-corvus.md)'
   - '[Kamil Aleksander](@/w/kamil-aleksander.md)'
   - '[Sawicki](@/w/sawicki.md)'
-  - {c: KPW Championship, s: Elimination Match}
-  - credits:
-    Ring announcer: [Kinga Różańska](@/w/kinga-miotke.md) 
+  - c: KPW Championship
+    s: Elimination Match
+- credits:
+    Ring announcer: '[Kinga Różańska](@/w/kinga-miotke.md)'
 {% end %}
 
 ### Recap

--- a/content/e/kpw/2019-06-15-kpw-arena-14-nastepny-poziom.md
+++ b/content/e/kpw/2019-06-15-kpw-arena-14-nastepny-poziom.md
@@ -33,6 +33,8 @@ This event had a major foreign guest - British wrestler Mark Haskins, who by the
   - '[Kamil Aleksander](@/w/kamil-aleksander.md)'
   - '[Sawicki](@/w/sawicki.md)'
   - {c: KPW Championship, s: Elimination Match}
+  - credits:
+    Ring announcer: [Kinga Różańska](@/w/kinga-miotke.md) 
 {% end %}
 
 ### Recap

--- a/content/e/kpw/2019-07-13-kpw-oldtown-4.md
+++ b/content/e/kpw/2019-07-13-kpw-oldtown-4.md
@@ -15,6 +15,7 @@ In 2019, the event was held between July 8 and 13. Additionally, on the followin
 The foreign guests for this event were all from Germany: the experienced Lucas Robinson and two relatively new but estabilished wrestlers Crowchester and Matthias Bernstein. [Fynn Freyhart](@/w/fynn-freyhart.md) also returned to take on one half of the KPW Tag Team Champions.
 
 {% card() %}
+- d: Day 1
 - ['[Moloch](@/w/moloch.md)', Crowchester]
 - ['[Piękny Kawaler](@/w/piekny-kawaler.md)', Lucas Robinson]
 - ['[Dom Taylor](@/w/dom-taylor.md)', '[Chemik](@/w/chemik.md)', Matthias Bernstein,
@@ -22,11 +23,12 @@ The foreign guests for this event were all from Germany: the experienced Lucas R
 - ['[Fynn Freyhart](@/w/fynn-freyhart.md)', '[Rosetti](@/w/rosetti.md)']
 - ["[David Oliwa](@/w/david-oliwa.md)(c)", '[Greg](@/w/greg.md)', {c: KPW OldTown
       Championship}]
+- d: Day 2
 - ['[Greg](@/w/greg.md)', '[Boski Ostrowski](@/w/ostrowski.md)']
 - ['[Moloch](@/w/moloch.md)', {s: Four on One Handicap Match}]
 - ['[Robert Star](@/w/robert-star.md)', '[Kamil Aleksander](@/w/kamil-aleksander.md)']
 - credits:
-    Ring announcer: [Kinga Różańska](@/w/kinga-miotke.md)
+    Ring announcer: '[Kinga Różańska](@/w/kinga-miotke.md)'
 {% end %}
 
 The first five matches listed (up to the title defense) were held on day 1, the rest on day 2.

--- a/content/e/kpw/2019-07-13-kpw-oldtown-4.md
+++ b/content/e/kpw/2019-07-13-kpw-oldtown-4.md
@@ -25,6 +25,8 @@ The foreign guests for this event were all from Germany: the experienced Lucas R
 - ['[Greg](@/w/greg.md)', '[Boski Ostrowski](@/w/ostrowski.md)']
 - ['[Moloch](@/w/moloch.md)', {s: Four on One Handicap Match}]
 - ['[Robert Star](@/w/robert-star.md)', '[Kamil Aleksander](@/w/kamil-aleksander.md)']
+- credits:
+    Ring announcer: [Kinga Różańska](@/w/kinga-miotke.md)
 {% end %}
 
 The first five matches listed (up to the title defense) were held on day 1, the rest on day 2.

--- a/content/e/kpw/2019-07-13-kpw-oldtown-4.md
+++ b/content/e/kpw/2019-07-13-kpw-oldtown-4.md
@@ -31,8 +31,6 @@ The foreign guests for this event were all from Germany: the experienced Lucas R
     Ring announcer: '[Kinga Różańska](@/w/kinga-miotke.md)'
 {% end %}
 
-The first five matches listed (up to the title defense) were held on day 1, the rest on day 2.
-
 ### References
 
 * [Cagematch event page, day 1](https://www.cagematch.net/?id=1&nr=319861)

--- a/content/e/kpw/2019-08-17-kpw-godzina-zero-2019.md
+++ b/content/e/kpw/2019-08-17-kpw-godzina-zero-2019.md
@@ -46,6 +46,8 @@ In the woman's match, we got another debut: [Diana](@/w/diana-strong.md), who pr
 - - '[Robert Star](@/w/robert-star.md)(c)'
   - '[Piękny Kawaler](@/w/piekny-kawaler.md)'
   - {c: KPW Championship, s: Career vs Career Last Man Standing Match}
+- credits:
+    Ring announcer: [Kinga Różańska](@/w/kinga-miotke.md)
 {% end %}
 
 #### Aftermath

--- a/content/e/kpw/2019-08-17-kpw-godzina-zero-2019.md
+++ b/content/e/kpw/2019-08-17-kpw-godzina-zero-2019.md
@@ -45,9 +45,10 @@ In the woman's match, we got another debut: [Diana](@/w/diana-strong.md), who pr
   - c: KPW OldTown Championship
 - - '[Robert Star](@/w/robert-star.md)(c)'
   - '[Piękny Kawaler](@/w/piekny-kawaler.md)'
-  - {c: KPW Championship, s: Career vs Career Last Man Standing Match}
+  - c: KPW Championship
+    s: Career vs Career Last Man Standing Match
 - credits:
-    Ring announcer: [Kinga Różańska](@/w/kinga-miotke.md)
+    Ring announcer: '[Kinga Różańska](@/w/kinga-miotke.md)'
 {% end %}
 
 #### Aftermath

--- a/content/e/kpw/2019-11-16-kpw-arena-15-swieza-krew.md
+++ b/content/e/kpw/2019-11-16-kpw-arena-15-swieza-krew.md
@@ -29,7 +29,7 @@ venue=["gdynia-sports-center"]
 - ['[Robert Star](@/w/robert-star.md)(c)', Reinbakh, {c: KPW Championship Match}]
 - credits:
     Commentary: Marek Łojek, Mateusz Mazurowski
-    Ring announcer: [Kinga Różańska](@/w/kinga-miotke.md)
+    Ring announcer: '[Kinga Różańska](@/w/kinga-miotke.md)'
 {% end %}
 
 ### References

--- a/content/e/kpw/2019-11-16-kpw-arena-15-swieza-krew.md
+++ b/content/e/kpw/2019-11-16-kpw-arena-15-swieza-krew.md
@@ -27,9 +27,10 @@ venue=["gdynia-sports-center"]
   - '[Greg](@/w/greg.md)'
   - {c: KPW OldTown Championship, s: Three Way Match}
 - ['[Robert Star](@/w/robert-star.md)(c)', Reinbakh, {c: KPW Championship Match}]
+- credits:
+    Commentary: Marek Łojek, Mateusz Mazurowski
+    Ring announcer: [Kinga Miotke](@/w/kinga-miotke.md)
 {% end %}
-
-Commentary: Marek Łojek, Mateusz Mazurowski
 
 ### References
 

--- a/content/e/kpw/2019-11-16-kpw-arena-15-swieza-krew.md
+++ b/content/e/kpw/2019-11-16-kpw-arena-15-swieza-krew.md
@@ -29,7 +29,7 @@ venue=["gdynia-sports-center"]
 - ['[Robert Star](@/w/robert-star.md)(c)', Reinbakh, {c: KPW Championship Match}]
 - credits:
     Commentary: Marek Łojek, Mateusz Mazurowski
-    Ring announcer: [Kinga Miotke](@/w/kinga-miotke.md)
+    Ring announcer: [Kinga Różańska](@/w/kinga-miotke.md)
 {% end %}
 
 ### References

--- a/content/e/kpw/2020-02-01-kpw-arena-16-polowanie.md
+++ b/content/e/kpw/2020-02-01-kpw-arena-16-polowanie.md
@@ -32,8 +32,8 @@ We saw one debuting wrestler: Piotr "Opol" Opolski. Another foreign guest this t
 {% end %}
 - credits:
     Commentary: Marek Łojek, Mateusz Mazurowski
-    Ring announcer: [Kinga Różańska](@/w/kinga-miotke.md)
-    Referee: [Karol Górski](@/w/Iskra.md)
+    Ring announcer: '[Kinga Różańska](@/w/kinga-miotke.md)'
+    Referee: '[Karol Górski](@/w/iskra.md)'
 
 #### Aftermath
 

--- a/content/e/kpw/2020-02-01-kpw-arena-16-polowanie.md
+++ b/content/e/kpw/2020-02-01-kpw-arena-16-polowanie.md
@@ -33,6 +33,7 @@ We saw one debuting wrestler: Piotr "Opol" Opolski. Another foreign guest this t
 - credits:
     Commentary: Marek Łojek, Mateusz Mazurowski
     Ring announcer: [Kinga Różańska](@/w/kinga-miotke.md)
+    Referee: [Karol Górski](@/w/Iskra.md)
 
 #### Aftermath
 

--- a/content/e/kpw/2021-08-21-kpw-arena-17-odrodzenie.md
+++ b/content/e/kpw/2021-08-21-kpw-arena-17-odrodzenie.md
@@ -24,9 +24,9 @@ Originally [Chemik](@/w/chemik.md) was to face [Fynn Freyhart](@/w/fynn-freyhart
 - ['[Greg](@/w/greg.md)', Crowchester]
 - ['[David Oliwa](@/w/david-oliwa.md)(c)', Michael Kovac, {c: KPW OldTown Championship}]
 - credits:
-    Referee: [Krystian Czekaj](@/w/krystian-czekaj.md)
-    Ring announcer: [Kinga Różańska](@/w/kinga-miotke.md)
-    Commentary: [Krystian Czekaj](@/w/krystian-czekaj.md)
+    Referee: '[Krystian Czekaj](@/w/krystian-czekaj.md)'
+    Ring announcer: '[Kinga Różańska](@/w/kinga-miotke.md)'
+    Commentary: '[Krystian Czekaj](@/w/krystian-czekaj.md)'
 {% end %}
 
 #### Recap and aftermath

--- a/content/e/kpw/2021-08-21-kpw-arena-17-odrodzenie.md
+++ b/content/e/kpw/2021-08-21-kpw-arena-17-odrodzenie.md
@@ -26,6 +26,7 @@ Originally [Chemik](@/w/chemik.md) was to face [Fynn Freyhart](@/w/fynn-freyhart
 - credits:
     Referee: [Krystian Czekaj](@/w/krystian-czekaj.md)
     Ring announcer: [Kinga Różańska](@/w/kinga-miotke.md)
+    Commentary: [Krystian Czekaj](@/w/krystian-czekaj.md)
 {% end %}
 
 #### Recap and aftermath

--- a/content/e/kpw/2022-03-18-kpw-arena-18-powrot-do-przyszlosci.md
+++ b/content/e/kpw/2022-03-18-kpw-arena-18-powrot-do-przyszlosci.md
@@ -37,6 +37,7 @@ For this event, KPW invited the well-traveled Maltese wrestler Gianni Valletta, 
 - credits:
     Referee: [Krystian Czekaj](@/w/krystian-czekaj.md)
     Ring announcer: [Kinga Różańska](@/w/kinga-miotke.md)
+    Commentary: [Krystian Czekaj](@/w/krystian-czekaj.md)
 {% end %}
 
 #### Recap and aftermath

--- a/content/e/kpw/2022-03-18-kpw-arena-18-powrot-do-przyszlosci.md
+++ b/content/e/kpw/2022-03-18-kpw-arena-18-powrot-do-przyszlosci.md
@@ -35,9 +35,9 @@ For this event, KPW invited the well-traveled Maltese wrestler Gianni Valletta, 
 - ['[Greg](@/w/greg.md)', '[Ron Corvus](@/w/ron-corvus.md)', {s: "Hardcore Match for
       KPW Championship #1 Contender"}]
 - credits:
-    Referees: [Krystian Czekaj](@/w/krystian-czekaj.md), Krystian Malinowski (main event)
-    Ring announcer: [Kinga Różańska](@/w/kinga-miotke.md)
-    Commentary: [Krystian Czekaj](@/w/krystian-czekaj.md)
+    Referees: '[Krystian Czekaj](@/w/krystian-czekaj.md), Krystian Malinowski (main event)'
+    Ring announcer: '[Kinga Różańska](@/w/kinga-miotke.md)'
+    Commentary: '[Krystian Czekaj](@/w/krystian-czekaj.md)'
 {% end %}
 
 #### Recap and aftermath

--- a/content/e/kpw/2022-03-18-kpw-arena-18-powrot-do-przyszlosci.md
+++ b/content/e/kpw/2022-03-18-kpw-arena-18-powrot-do-przyszlosci.md
@@ -35,7 +35,7 @@ For this event, KPW invited the well-traveled Maltese wrestler Gianni Valletta, 
 - ['[Greg](@/w/greg.md)', '[Ron Corvus](@/w/ron-corvus.md)', {s: "Hardcore Match for
       KPW Championship #1 Contender"}]
 - credits:
-    Referee: [Krystian Czekaj](@/w/krystian-czekaj.md)
+    Referees: [Krystian Czekaj](@/w/krystian-czekaj.md), Krystian Malinowski (main event)
     Ring announcer: [Kinga Różańska](@/w/kinga-miotke.md)
     Commentary: [Krystian Czekaj](@/w/krystian-czekaj.md)
 {% end %}
@@ -45,6 +45,7 @@ For this event, KPW invited the well-traveled Maltese wrestler Gianni Valletta, 
 * [Rosetti](@/w/rosetti.md) no-showed Lesak, who announced that he will now face the brothers alone.
 * After taking a frog splash and escaping a pin, Lesak left the ring, flipping the bird at his opponents and the ref, which led to a count-out.
 * [Chemik](@/w/chemik.md) entered carrying a wooden cross to the ring, and referenced the vows he made at the previous event. During the fight, Rosetti appeared, unaware that he missed his scheduled appeareance, which distracted the ref enough for Chemik to perform a backstabber and Last Rites to grab his first win.
+* In a nostalgic throwback to 2017's [Szlamfest](@/e/kpw/2017-02-04-kpw-szlamfest.md), Chairman Krystian Malinowski was a special guest referee for the main event. Szlamfest also featured a hardcore match between Greg and Ron Corvus, and Krystian Malinowski was the referee at the time.
 
 ### References
 

--- a/content/e/kpw/2022-06-10-kpw-arena-19-oko-za-oko.md
+++ b/content/e/kpw/2022-06-10-kpw-arena-19-oko-za-oko.md
@@ -21,9 +21,9 @@ Originally the Austrian wrestler Martn Pain was set to face [Greg](@/w/greg.md) 
 - ['[David Oliwa](@/w/david-oliwa.md)', '[Fynn Freyhart](@/w/fynn-freyhart.md)', {
     s: "KPW Championship #1 Contender Best Two Out Of Three Falls Match"}]
 - credits:
-    Referee: [Krystian Czekaj](@/w/krystian-czekaj.md)
-    Ring announcer: [Kinga Różańska](@/w/kinga-miotke.md)
-    Commentary: [Krystian Czekaj](@/w/krystian-czekaj.md)
+    Referee: '[Krystian Czekaj](@/w/krystian-czekaj.md)'
+    Ring announcer: '[Kinga Różańska](@/w/kinga-miotke.md)'
+    Commentary: '[Krystian Czekaj](@/w/krystian-czekaj.md)'
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2022-06-10-kpw-arena-19-oko-za-oko.md
+++ b/content/e/kpw/2022-06-10-kpw-arena-19-oko-za-oko.md
@@ -23,6 +23,7 @@ Originally the Austrian wrestler Martn Pain was set to face [Greg](@/w/greg.md) 
 - credits:
     Referee: [Krystian Czekaj](@/w/krystian-czekaj.md)
     Ring announcer: [Kinga Różańska](@/w/kinga-miotke.md)
+    Commentary: [Krystian Czekaj](@/w/krystian-czekaj.md)
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2022-06-18-kpw-pyrkon-2022.md
+++ b/content/e/kpw/2022-06-18-kpw-pyrkon-2022.md
@@ -13,18 +13,19 @@ In 2022, one of the Saturday attractions was wrestling, by KPW. It was well rece
 This was not the only fan convention that year to feature wrestling. [PTW](@/o/ptw.md) appeared at the primarily anime-focused Ryucon at the end of July in Kraków. Both organizations would return next year as well. The International Fair itself was also no stranger to wrestling, having already hosted PpW as part of a [craft beer fair](@/e/ppw/2021-07-30-ppw-poznan-supershow.md) in 2021, and would see them [again](@/e/ppw/2023-11-24-ppw-piwo-przyjacielem-wrestlingu.md) in 2023.
 
 {% card() %}
-- ["The Fux Brothers: [Filip Fux](@/w/filip-fux.md), [Michał Fux](@/w/michal-fux.md)",
-  "[Chemik](@/w/chemik.md), [Eryk Lesak](@/w/eryk-lesak.md)", {s: Tag Team Match}]
+- - "The Fux Brothers: [Filip Fux](@/w/filip-fux.md), [Michał Fux](@/w/michal-fux.md)"
+  - "[Chemik](@/w/chemik.md), [Eryk Lesak](@/w/eryk-lesak.md)"
+  - s: Tag Team Match
 - ['[Darius](@/w/darius.md)', '[Zefir](@/w/zefir.md)']
 - [Ricky Sky, Matthias Bernstein]
 - ['[David Oliwa](@/w/david-oliwa.md)', Fabio Ferrari]
 - ['[Fynn Freyhart](@/w/fynn-freyhart.md)', '[Greg](@/w/greg.md)', {nc: Draw}]
-- ["[David Oliwa](@/w/david-oliwa.md), [Fynn Freyhart](@/w/fynn-freyhart.md), [Zefir](@/w/zefir.md)",
-  "[Chemik](@/w/chemik.md), [Eryk Lesak](@/w/eryk-lesak.md), [Greg](@/w/greg.md)",
-  {s: Six Man Tag Team Match}]
+- - "[David Oliwa](@/w/david-oliwa.md), [Fynn Freyhart](@/w/fynn-freyhart.md), [Zefir](@/w/zefir.md)"
+  - "[Chemik](@/w/chemik.md), [Eryk Lesak](@/w/eryk-lesak.md), [Greg](@/w/greg.md)"
+  - s: Six Man Tag Team Match
 - credits:
-    Referee: [Krystian Czekaj](@/w/krystian-czekaj.md)
-    Ring announcer: [Kinga Różańska](@/w/kinga-miotke.md)
+    Referee: '[Krystian Czekaj](@/w/krystian-czekaj.md)'
+    Ring announcer: '[Kinga Różańska](@/w/kinga-miotke.md)'
 {% end %}
 
 ### References

--- a/content/e/kpw/2022-07-30-kpw-tattoo-konwent-2022-day1.md
+++ b/content/e/kpw/2022-07-30-kpw-tattoo-konwent-2022-day1.md
@@ -16,13 +16,15 @@ Swedish wrestler Steinbolt was the foreign guest this time, along with now regul
 - ['[Greg](@/w/greg.md)', '[Filip Fux](@/w/filip-fux.md)']
 - ['[David Oliwa](@/w/david-oliwa.md)', Steinbolt]
 - ['[Michał Fux](@/w/michal-fux.md)', '[Eryk Lesak](@/w/eryk-lesak.md)']
-- ['[Zefir](@/w/zefir.md)', '[Darius](@/w/darius.md)', '[Leon Lato](@/w/leon-lato.md)',
-  {s: Three Way Match}]
+- - '[Zefir](@/w/zefir.md)'
+  - '[Darius](@/w/darius.md)'
+  - '[Leon Lato](@/w/leon-lato.md)'
+  - s: Three Way Match
 - ["[Chemik](@/w/chemik.md), [Eryk Lesak](@/w/eryk-lesak.md)", "The Fux Brothers:
     [Filip Fux](@/w/filip-fux.md), [Michał Fux](@/w/michal-fux.md)"]
 - credits:
-    Referee: [Krystian Czekaj](@/w/krystian-czekaj.md)
-    Ring announcer: [Kinga Różańska](@/w/kinga-miotke.md)
+    Referee: '[Krystian Czekaj](@/w/krystian-czekaj.md)'
+    Ring announcer: '[Kinga Różańska](@/w/kinga-miotke.md)'
 {% end %}
 
 

--- a/content/e/kpw/2022-07-31-kpw-tattoo-konwent-2022-day2.md
+++ b/content/e/kpw/2022-07-31-kpw-tattoo-konwent-2022-day2.md
@@ -17,11 +17,12 @@ Swedish wrestler Steinbolt was the foreign guest this time, along with now regul
 - ['[Greg](@/w/greg.md)', '[Michał Fux](@/w/michal-fux.md)']
 - ['[Zefir](@/w/zefir.md)', {s: Battle Royal}]
 - ['[Filip Fux](@/w/filip-fux.md)', Steinbolt]
-- ["[Darius](@/w/darius.md), [Zefir](@/w/zefir.md)", "[Chemik](@/w/chemik.md), [Eryk
-    Lesak](@/w/eryk-lesak.md)", {s: Tag Team Match}]
+- - "[Darius](@/w/darius.md), [Zefir](@/w/zefir.md)"
+  - "[Chemik](@/w/chemik.md), [Eryk Lesak](@/w/eryk-lesak.md)"
+  - s: Tag Team Match
 - credits:
-    Referee: [Krystian Czekaj](@/w/krystian-czekaj.md)
-    Ring announcer: [Kinga Różańska](@/w/kinga-miotke.md)
+    Referee: '[Krystian Czekaj](@/w/krystian-czekaj.md)'
+    Ring announcer: '[Kinga Różańska](@/w/kinga-miotke.md)'
 {% end %}
 
 

--- a/content/e/kpw/2022-09-17-kpw-godzina-zero-2022.md
+++ b/content/e/kpw/2022-09-17-kpw-godzina-zero-2022.md
@@ -59,6 +59,7 @@ The foreign guests for the event were:
 - credits:
     Referee: [Krystian Czekaj](@/w/krystian-czekaj.md)
     Ring announcer: [Kinga Miotke](@/w/kinga-miotke.md)
+    Commentary: [Krystian Czekaj](@/w/krystian-czekaj.md)
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2022-09-17-kpw-godzina-zero-2022.md
+++ b/content/e/kpw/2022-09-17-kpw-godzina-zero-2022.md
@@ -54,12 +54,13 @@ The foreign guests for the event were:
 - - '[Greg](@/w/greg.md)'
   - '[David Oliwa](@/w/david-oliwa.md)'
   - {s: Three Stages of Hell Match, c: KPW Championship}
-- ['[Rosetti](@/w/rosetti.md)', '[David Oliwa](@/w/david-oliwa.md)(c)', {c: KPW OldTown
-      Championship}]
+- - '[Rosetti](@/w/rosetti.md)'
+  - '[David Oliwa](@/w/david-oliwa.md)(c)'
+  - c: KPW OldTown Championship
 - credits:
-    Referee: [Krystian Czekaj](@/w/krystian-czekaj.md)
-    Ring announcer: [Kinga Miotke](@/w/kinga-miotke.md)
-    Commentary: [Krystian Czekaj](@/w/krystian-czekaj.md)
+    Referee: '[Krystian Czekaj](@/w/krystian-czekaj.md)'
+    Ring announcer: '[Kinga Miotke](@/w/kinga-miotke.md)'
+    Commentary: '[Krystian Czekaj](@/w/krystian-czekaj.md)'
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2022-12-16-kpw-arena-20.md
+++ b/content/e/kpw/2022-12-16-kpw-arena-20.md
@@ -41,6 +41,7 @@ The floating faces also refer to the movie - the "I made My Family Disappear" sc
 - credits:
     Referee: [Krystian Czekaj](@/w/krystian-czekaj.md)
     Ring announcer: [Kinga Miotke](@/w/kinga-miotke.md)
+    Commentary: [Krystian Czekaj](@/w/krystian-czekaj.md)
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2022-12-16-kpw-arena-20.md
+++ b/content/e/kpw/2022-12-16-kpw-arena-20.md
@@ -39,9 +39,9 @@ The floating faces also refer to the movie - the "I made My Family Disappear" sc
   - "The Fux Brothers: [Filip Fux](@/w/filip-fux.md), [Michał Fux](@/w/michal-fux.md)"
   - c: KPW Tag Team Championship
 - credits:
-    Referee: [Krystian Czekaj](@/w/krystian-czekaj.md)
-    Ring announcer: [Kinga Miotke](@/w/kinga-miotke.md)
-    Commentary: [Krystian Czekaj](@/w/krystian-czekaj.md)
+    Referee: '[Krystian Czekaj](@/w/krystian-czekaj.md)'
+    Ring announcer: '[Kinga Miotke](@/w/kinga-miotke.md)'
+    Commentary: '[Krystian Czekaj](@/w/krystian-czekaj.md)'
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2023-02-24-kpw-arena-21.md
+++ b/content/e/kpw/2023-02-24-kpw-arena-21.md
@@ -29,6 +29,7 @@ The event had one new foreign guest: Japanese wrestler Shigehiro Irie, by that t
 - credits:
     Referee: [Krystian Czekaj](@/w/krystian-czekaj.md)
     Ring announcer: [Kinga Miotke](@/w/kinga-miotke.md)
+    Commentary: [Krystian Czekaj](@/w/krystian-czekaj.md)
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2023-02-24-kpw-arena-21.md
+++ b/content/e/kpw/2023-02-24-kpw-arena-21.md
@@ -20,16 +20,20 @@ The event had one new foreign guest: Japanese wrestler Shigehiro Irie, by that t
 
 {% card() %}
 - ['[Michał Fux](@/w/michal-fux.md)', '[Chemik](@/w/chemik.md)']
-- ['[Dom Taylor](@/w/dom-taylor.md)', '[Rosetti](@/w/rosetti.md)', {r: Double Count
-      Out}]
-- ["Die Ordnung: [Veit Müller](@/w/veit-mueller.md), [Hans Schulte](@/w/hans-schulte.md)",
-  "[Leon Lato](@/w/leon-lato.md), [Zefir](@/w/zefir.md)"]
+- - '[Dom Taylor](@/w/dom-taylor.md)'
+  - '[Rosetti](@/w/rosetti.md)'
+  - r: Double Count Out
+- - "Die Ordnung: [Veit Müller](@/w/veit-mueller.md), [Hans Schulte](@/w/hans-schulte.md)"
+  - "[Leon Lato](@/w/leon-lato.md), [Zefir](@/w/zefir.md)"
+  - s: Tag Team Match
 - ['[David Oliwa](@/w/david-oliwa.md)', '[Eryk Lesak](@/w/eryk-lesak.md)']
-- ['[Greg](@/w/greg.md)(c)', Shigehiro Irie, {c: KPW Championship}]
+- - '[Greg](@/w/greg.md)(c)'
+  - Shigehiro Irie
+  - c: KPW Championship
 - credits:
-    Referee: [Krystian Czekaj](@/w/krystian-czekaj.md)
-    Ring announcer: [Kinga Miotke](@/w/kinga-miotke.md)
-    Commentary: [Krystian Czekaj](@/w/krystian-czekaj.md)
+    Referee: '[Krystian Czekaj](@/w/krystian-czekaj.md)'
+    Ring announcer: '[Kinga Miotke](@/w/kinga-miotke.md)'
+    Commentary: '[Krystian Czekaj](@/w/krystian-czekaj.md)'
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2023-05-19-kpw-arena-22.md
+++ b/content/e/kpw/2023-05-19-kpw-arena-22.md
@@ -26,9 +26,9 @@ The event had one returning foreign guest: Lee Rogers, one half of the British B
 - ['[David Oliwa](@/w/david-oliwa.md)', '[Michał Fux](@/w/michal-fux.md)']
 - ['[Rosetti](@/w/rosetti.md)(c)', Zak Knight, {r: Submission, c: KPW OldTown Championship}]
 - credits:
-    Referee: [Krystian Czekaj](@/w/krystian-czekaj.md)
-    Ring announcer: [Kinga Miotke](@/w/kinga-miotke.md)
-    Commentary: [Krystian Czekaj](@/w/krystian-czekaj.md)
+    Referee: '[Krystian Czekaj](@/w/krystian-czekaj.md)'
+    Ring announcer: '[Kinga Miotke](@/w/kinga-miotke.md)'
+    Commentary: '[Krystian Czekaj](@/w/krystian-czekaj.md)'
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2023-05-19-kpw-arena-22.md
+++ b/content/e/kpw/2023-05-19-kpw-arena-22.md
@@ -28,6 +28,7 @@ The event had one returning foreign guest: Lee Rogers, one half of the British B
 - credits:
     Referee: [Krystian Czekaj](@/w/krystian-czekaj.md)
     Ring announcer: [Kinga Miotke](@/w/kinga-miotke.md)
+    Commentary: [Krystian Czekaj](@/w/krystian-czekaj.md)
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2023-06-17-kpw-pyrkon-2023.md
+++ b/content/e/kpw/2023-06-17-kpw-pyrkon-2023.md
@@ -34,8 +34,8 @@ This event had no new foreign guests. Fans saw German wrestler Flexos in his sec
   - '[Zefir](@/w/zefir.md)'
   - s: Battle Royal
 - credits:
-    Referee: [Krystian Czekaj](@/w/krystian-czekaj.md)
-    Ring announcer: [Kinga Miotke](@/w/kinga-miotke.md)
+    Referee: '[Krystian Czekaj](@/w/krystian-czekaj.md)'
+    Ring announcer: '[Kinga Miotke](@/w/kinga-miotke.md)'
 {% end %}
 
 #### Results

--- a/content/e/kpw/2023-08-18-kpw-godzina-zero-2023.md
+++ b/content/e/kpw/2023-08-18-kpw-godzina-zero-2023.md
@@ -45,8 +45,8 @@ All three championships were defended and two changed hands. The Magnificent Sev
   - s: Championship Contract Battle Royal
 - [Red Scorpion, '[Greg](@/w/greg.md)(c)', {c: KPW Championship, r: Submission}]
 - credits:
-    Referee: [Krystian Czekaj](@/w/krystian-czekaj.md)
-    Ring announcer: [Kinga Miotke](@/w/kinga-miotke.md)
+    Referee: '[Krystian Czekaj](@/w/krystian-czekaj.md)'
+    Ring announcer: '[Kinga Miotke](@/w/kinga-miotke.md)'
 {% end %}
 
 

--- a/content/e/kpw/2023-11-24-kpw-arena-23.md
+++ b/content/e/kpw/2023-11-24-kpw-arena-23.md
@@ -30,13 +30,13 @@ KPW invited one new foreign guest: young Austrian wrestler Ritshy Rage. Returnin
 - credits:
     Referee: [Krystian Czekaj](@/w/krystian-czekaj.md)
     Ring announcer: [Kinga Miotke](@/w/kinga-miotke.md)
-    Commentary: [Krystian Czekaj](@/w/krystian-czekaj.md)
+    Commentary: [Krystian Czekaj](@/w/krystian-czekaj.md) (see below)
 {% end %}
 
 #### Recap
 
 * Rosetti presented the new KPW OldTown Championship belt, which has a more traditional, leather plate design. However, he declined to fight due to injury, but found a replacement in another member of the Gregorian Branch faction, Eryk Lesak, returning after a long absence.
-* After the event, Chairman Krystian Malinowski announced that subsequent events would be broadcast (taped) on the FightBox TV channel, which specializes in all sorts of combat sports, including wrestling. The first event to be shown on FightBox was indeed Arena 23, but not until April 2024. The event was broadcast without commentary.
+* After the event, Chairman Krystian Malinowski announced that subsequent events would be broadcast (taped) on the FightBox TV channel, which specializes in all sorts of combat sports, including wrestling. The first event to be shown on FightBox was indeed Arena 23, but not until April 2024. The event was broadcast without commentary - while it was recorded, the TV opted not to use it. KPW later [uploaded the main event to their YouTube channel](https://www.youtube.com/watch?v=U0dykUP3Rlw), with the commentary in place.
 
 ### References
 

--- a/content/e/kpw/2023-11-24-kpw-arena-23.md
+++ b/content/e/kpw/2023-11-24-kpw-arena-23.md
@@ -30,6 +30,7 @@ KPW invited one new foreign guest: young Austrian wrestler Ritshy Rage. Returnin
 - credits:
     Referee: [Krystian Czekaj](@/w/krystian-czekaj.md)
     Ring announcer: [Kinga Miotke](@/w/kinga-miotke.md)
+    Commentary: [Krystian Czekaj](@/w/krystian-czekaj.md)
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2023-11-24-kpw-arena-23.md
+++ b/content/e/kpw/2023-11-24-kpw-arena-23.md
@@ -28,15 +28,15 @@ KPW invited one new foreign guest: young Austrian wrestler Ritshy Rage. Returnin
 - ['[Filip Fux](@/w/filip-fux.md)', '[David Oliwa](@/w/david-oliwa.md)']
 - [Red Scorpion(c), '[Leon Lato](@/w/leon-lato.md)', c: KPW Championship]
 - credits:
-    Referee: [Krystian Czekaj](@/w/krystian-czekaj.md)
-    Ring announcer: [Kinga Miotke](@/w/kinga-miotke.md)
-    Commentary: [Krystian Czekaj](@/w/krystian-czekaj.md) (see below)
+    Referee: '[Krystian Czekaj](@/w/krystian-czekaj.md)'
+    Ring announcer: '[Kinga Miotke](@/w/kinga-miotke.md)'
+    Commentary: '[Krystian Czekaj](@/w/krystian-czekaj.md) (see below)'
 {% end %}
 
 #### Recap
 
 * Rosetti presented the new KPW OldTown Championship belt, which has a more traditional, leather plate design. However, he declined to fight due to injury, but found a replacement in another member of the Gregorian Branch faction, Eryk Lesak, returning after a long absence.
-* After the event, Chairman Krystian Malinowski announced that subsequent events would be broadcast (taped) on the FightBox TV channel, which specializes in all sorts of combat sports, including wrestling. The first event to be shown on FightBox was indeed Arena 23, but not until April 2024. The event was broadcast without commentary - while it was recorded, the TV opted not to use it. KPW later [uploaded the main event to their YouTube channel](https://www.youtube.com/watch?v=U0dykUP3Rlw), with the commentary in place.
+* After the event, Chairman Krystian Malinowski announced that subsequent events would be broadcast (taped) on the FightBox TV channel, which specializes in all sorts of combat sports, including wrestling. The first event to be shown on FightBox was indeed Arena 23, but not until April 2024. The event was broadcast without commentary - while it was recorded, the TV station opted not to use it. KPW later [uploaded the main event to their YouTube channel](https://www.youtube.com/watch?v=U0dykUP3Rlw), with commentary in place.
 
 ### References
 

--- a/content/e/kpw/2024-02-16-kpw-arena-24-zagrozenie-lawinowe.md
+++ b/content/e/kpw/2024-02-16-kpw-arena-24-zagrozenie-lawinowe.md
@@ -29,8 +29,8 @@ The event's name refers to the nickname of WxW wrestler Robert "The Avalanche" D
   - "[Chemik](@/w/chemik.md), [Eryk Lesak](@/w/eryk-lesak.md)"
   - {s: Hair vs Mustache Tag Team Match, c: KPW Tag Team Championship}
 - credits:
-    Referee: [Krystian Czekaj](@/w/krystian-czekaj.md)
-    Ring announcer: [Kinga Miotke](@/w/kinga-miotke.md)
+    Referee: '[Krystian Czekaj](@/w/krystian-czekaj.md)'
+    Ring announcer: '[Kinga Miotke](@/w/kinga-miotke.md)'
 {% end %}
 
 #### Recap

--- a/content/e/kpw/2024-05-17-kpw-arena-25.md
+++ b/content/e/kpw/2024-05-17-kpw-arena-25.md
@@ -43,8 +43,8 @@ Foreign wrestlers performing at this event were:
   - c: KPW OldTown Championship
     s: Four Way Match
 - credits:
-    Referee: [Krystian Czekaj](@/w/krystian-czekaj.md)
-    Ring announcer: [Kinga Miotke](@/w/kinga-miotke.md)
+    Referee: '[Krystian Czekaj](@/w/krystian-czekaj.md)'
+    Ring announcer: '[Kinga Miotke](@/w/kinga-miotke.md)'
 {% end %}
 
 ### Recap

--- a/content/e/kpw/2024-06-15-kpw-pyrkon-2024.md
+++ b/content/e/kpw/2024-06-15-kpw-pyrkon-2024.md
@@ -25,8 +25,8 @@ In [his video][malinowski-video], Chairman Malinowski announced that Greg would 
   - "Die Ordnung: [Veit Müller](@/w/veit-mueller.md), [Hans Schulte](@/w/hans-schulte.md)"
   - s: Non Title Tag Team Match
 - credits:
-    Referee: [Krystian Czekaj](@/w/krystian-czekaj.md)
-    Ring announcer: [Kinga Miotke](@/w/kinga-miotke.md)
+    Referee: '[Krystian Czekaj](@/w/krystian-czekaj.md)'
+    Ring announcer: '[Kinga Miotke](@/w/kinga-miotke.md)'
 {% end %}
 
 #### Results

--- a/content/w/don-roid-md
+++ b/content/w/don-roid-md
@@ -1,4 +1,0 @@
-+++
-title = "Don Roid"
-template = "talent_page.html"
-+++

--- a/content/w/kinga-miotke.md
+++ b/content/w/kinga-miotke.md
@@ -14,9 +14,12 @@ career_aliases = ["Kinga Różańska"]
 
 Kinga Miotke is the current ring announcer for KPW.
 
-Kinga started out as a trainee in KPW's wrestling school, but had to abandon her trainings due to a neck injury. Instead of becoming a wrestler, she would conduct interviews with wrestlers on the backstage and with fans after shows, and eventually she'd take on her role as the ring announcer, starting with [Arena 14](@/2019-06-15-kpw-arena-14-nastepny-poziom.md), taking over from [Arek Pawłowski](@/w/pan-pawlowski.md) who left the promotion after [Arena 13](@/e/kpw/2019-04-05-kpw-arena-13-capo-di-tutti-capi.md). At first she appeared under the ring name "Kinga Różańska", but beginning with [Godzina Zero 2022](@/e/kpw/2022-09-17-kpw-godzina-zero-2022.md) she started using her real name, Kinga Miotke. She is the fist and, as of 2024, the only female announcer on the Polish wrestling scene.
+Kinga started out as a trainee in KPW's wrestling school, but had to abandon her trainings due to a neck injury.
+Instead of becoming a wrestler, she would conduct interviews with wrestlers on the backstage and with fans after shows, and eventually she'd take on her role as the ring announcer, starting with [Arena 14](@/e/kpw/2019-06-15-kpw-arena-14-nastepny-poziom.md), taking over from [Arek Pawłowski](@/w/pan-pawlowski.md) who left after [Arena 13](@/e/kpw/2019-04-05-kpw-arena-13-capo-di-tutti-capi.md).
+At first she appeared under the ring name "Kinga Różańska", but beginning with [Godzina Zero 2022](@/e/kpw/2022-09-17-kpw-godzina-zero-2022.md) she started using her real name, Kinga Miotke.
+She is the first and, as of 2024, the only female announcer on the Polish wrestling scene.
 
 
 ### References
 
-- [Café Bianca - Odcinek #6](https://www.youtube.com/watch?v=khdgqlnAVPo) (a interview with Kinga, in Polish)
+- [Café Bianca - Odcinek #6](https://www.youtube.com/watch?v=khdgqlnAVPo) (an interview with Kinga, in Polish)

--- a/content/w/kinga-miotke.md
+++ b/content/w/kinga-miotke.md
@@ -8,7 +8,8 @@ country = ["PL"]
 [extra]
 career_aliases = ["Kinga Różańska"]
 [extra.gallery]
-1 = { path = "kinga-miotke-arena-18.jpg", caption = 'Kinga opening KPW Arena 18.', source = "M3n747" }
+1 = { path = "kinga-miotke-arena-18.jpg", caption = 'Kinga Różańska opens KPW Arena 18.', source = "M3n747" }
+2 = { path = "kinga-miotke-arena-20.jpg", caption = 'Kinga Miotke opens KPW Arena 20.', source = "M3n747" }
 +++
 
 Kinga Miotke is the current ring announcer for KPW.

--- a/content/w/krystian-czekaj.md
+++ b/content/w/krystian-czekaj.md
@@ -5,10 +5,12 @@ authors = ["M3n747"]
 template = "talent_page.html"
 [taxonomies]
 country = ["PL"]
+[extra.gallery]
 1 = { path = "krystian-czekaj-koszulka.jpg", caption = 'Krystian Czekaj in his T-shirt.', source = "mfotografika" }
-
 +++
 
-Krystian Czekaj is the current referee and commentator for Kombat Pro Wrestling. He took on both roles beginning with [Arena 17](@/kpw/2021-08-21-kpw-arena-17-odrodzenie.md) and has been consistently refereeing and commenting ever since. He is the only person on the Polish wrestling scene to serve such a dual duty.
+Krystian Czekaj is the current referee and commentator for Kombat Pro Wrestling.
+He took on both roles beginning with [Arena 17](@e/kpw/2021-08-21-kpw-arena-17-odrodzenie.md) and has been consistently refereeing and commenting ever since.
+Krystian is the only person on the Polish wrestling scene to serve such a dual duty.
 
 He is also the only Polish referee to sell his own merchandise: a T-shirt saying _Sędzia chuj_ ("Referee dick") - a reference to the crude but popular chant, often heard when the audience is dissatisfied with the ref's decisions, or his apparent lack of perception of heels' dirty tactics.

--- a/content/w/krystian-malinowski.md
+++ b/content/w/krystian-malinowski.md
@@ -13,7 +13,7 @@ career_aliases = ["Rex Torpeda"]
 
 Krystian Malinowski is the chairman of [Kombat Pro Wrestling](@/o/kpw.md).
 
-Beginning as a trainee in [Do Or Die Wrestling](@/o/ddw.md), he wrestled in two shows before switching his role to that of a referee. After DDW folded and KPW took its place, Malinowski continued refereeing for the new promotion, along with [Karol Górski](@/w/iskra.md) and, now and then, by Artur Dzwończak.
+Beginning as a trainee in [Do Or Die Wrestling](@/o/ddw.md), he wrestled in two shows before switching his role to that of a referee. After DDW folded and KPW took its place, Malinowski continued refereeing for the new promotion, along with [Karol Górski](@/w/iskra.md) and, from time to time, also Artur Dzwończak.
 
 Before [Arena 12](e/kpw/2019-01-19-kpw-arena-12-gwiazda-polnocy.md), KPW announced that a new chairman would be elected, and Malinowski threw his name in the hat as a candidate, alongside [Krzysztof Zasada](@/w/krzysztof-zasada.md) and [Piękny Kawaler](@/w/piekny-kawaler.md).
 Eventually he secured the new position at [Arena 13](@/e/kpw/2019-04-05-kpw-arena-13-capo-di-tutti-capi.md) and his previous duties as a referee were taken over by Dariusz Łępicki.

--- a/content/w/krystian-malinowski.md
+++ b/content/w/krystian-malinowski.md
@@ -1,0 +1,24 @@
++++
+title = "Krystian Malinowski"
+weight = 0
+authors = ["M3n747"]
+template = "talent_page.html"
+[extra]
+career_aliases = ["Rex Torpeda"]
+[taxonomies]
+country = ["PL"]
+1 = { path = "krystian-malinowski-teczka.jpg", caption = 'Krystian Malinowski with his briefcase at Arena 22.', source = "Migawki z Puszki" }
+
++++
+
+Krystian Malinowski is the chairman of [Kombat Pro Wrestling](@/o/kpw.md).
+
+Beginning as a trainee in [Do Or Die Wrestling](@/o/ddw.md), he wrestled in two shows before switching his role to that of a referee. After DDW folded and KPW took its place, Malinowski continued refereeing for the new promotion, along with [Karol Górski](@/w/iskra.md) and, sporadically, Artur Dzwończak.
+
+Before [Arena 12](e/kpw/2019-01-19-kpw-arena-12-gwiazda-polnocy.md), KPW announced that a new chairman would be elected, and Malinowski threw his name in the hat as a candidate, alongside [Krzysztof Zasada](@/w/krzysztof-zasada.md) and [Piękny Kawaler](@/w/piekny-kawaler.md). Eventually he secured the new position at [Arena 13](@/e/kpw/2019-04-05-kpw-arena-13-capo-di-tutti-capi.md) and his previous duties as a referee were taken over by Dariusz Łępicki.
+
+
+### References
+* [Malinowski's election spot](https://www.youtube.com/watch?v=gMZ7cTC5HLo)
+* [Electorial debate at Arena 12](https://www.youtube.com/watch?v=X55YrndRQeo)
+* [Election results announced at Arena 13](https://www.youtube.com/watch?v=VohxgOEblPE)

--- a/content/w/krystian-malinowski.md
+++ b/content/w/krystian-malinowski.md
@@ -3,19 +3,20 @@ title = "Krystian Malinowski"
 weight = 0
 authors = ["M3n747"]
 template = "talent_page.html"
-[extra]
-career_aliases = ["Rex Torpeda"]
 [taxonomies]
 country = ["PL"]
+[extra]
+career_aliases = ["Rex Torpeda"]
+[extra.gallery]
 1 = { path = "krystian-malinowski-teczka.jpg", caption = 'Krystian Malinowski with his briefcase at Arena 22.', source = "Migawki z Puszki" }
-
 +++
 
 Krystian Malinowski is the chairman of [Kombat Pro Wrestling](@/o/kpw.md).
 
-Beginning as a trainee in [Do Or Die Wrestling](@/o/ddw.md), he wrestled in two shows before switching his role to that of a referee. After DDW folded and KPW took its place, Malinowski continued refereeing for the new promotion, along with [Karol Górski](@/w/iskra.md) and, sporadically, Artur Dzwończak.
+Beginning as a trainee in [Do Or Die Wrestling](@/o/ddw.md), he wrestled in two shows before switching his role to that of a referee. After DDW folded and KPW took its place, Malinowski continued refereeing for the new promotion, along with [Karol Górski](@/w/iskra.md) and, now and then, by Artur Dzwończak.
 
-Before [Arena 12](e/kpw/2019-01-19-kpw-arena-12-gwiazda-polnocy.md), KPW announced that a new chairman would be elected, and Malinowski threw his name in the hat as a candidate, alongside [Krzysztof Zasada](@/w/krzysztof-zasada.md) and [Piękny Kawaler](@/w/piekny-kawaler.md). Eventually he secured the new position at [Arena 13](@/e/kpw/2019-04-05-kpw-arena-13-capo-di-tutti-capi.md) and his previous duties as a referee were taken over by Dariusz Łępicki.
+Before [Arena 12](e/kpw/2019-01-19-kpw-arena-12-gwiazda-polnocy.md), KPW announced that a new chairman would be elected, and Malinowski threw his name in the hat as a candidate, alongside [Krzysztof Zasada](@/w/krzysztof-zasada.md) and [Piękny Kawaler](@/w/piekny-kawaler.md).
+Eventually he secured the new position at [Arena 13](@/e/kpw/2019-04-05-kpw-arena-13-capo-di-tutti-capi.md) and his previous duties as a referee were taken over by Dariusz Łępicki.
 
 
 ### References

--- a/content/w/zefir.md
+++ b/content/w/zefir.md
@@ -4,5 +4,5 @@ template = "talent_page.html"
 [taxonomies]
 country = ["PL"]
 [extra.gallery]
-1 = { path = "zefir-fire.jpg", caption = 'Zefir's signature firery entrance, KPW Arena 17.', source = "M3n747" }
+1 = { path = "zefir-fire.jpg", caption = "Zefir's signature firery entrance, KPW Arena 17.", source = "M3n747" }
 +++


### PR DESCRIPTION
Arena 14 - poprawione rozszerzenie pliku z plakatem
Zdjęcie Zefira
Nowe artykuły: Kinga Miotke, Krystian Czekaj
Linki do Kingi i Krystiana w wydarzeniach KPW
Dodano Kingę w Arenach 14-16
Dodano Pana Pawłowskiego wszędzie wcześniej
Dodano Krystiana Czekaja jako komentatora stosownych gal
Dodano Krystiana Malinowskiego jako sędziego w Arenie 18