### PR TITLE
Update 2022-03-18-kpw-arena-18-powrot-do-przyszlosci.md

### DIFF
--- a/content/e/kpw/2022-03-18-kpw-arena-18-powrot-do-przyszlosci.md
+++ b/content/e/kpw/2022-03-18-kpw-arena-18-powrot-do-przyszlosci.md
@@ -35,7 +35,7 @@ For this event, KPW invited the well-traveled Maltese wrestler Gianni Valletta, 
 - ['[Greg](@/w/greg.md)', '[Ron Corvus](@/w/ron-corvus.md)', {s: "Hardcore Match for
       KPW Championship #1 Contender"}]
 - credits:
-    Referees: '[Krystian Czekaj](@/w/krystian-czekaj.md), Krystian Malinowski (main event)'
+    Referees: '[Krystian Czekaj](@/w/krystian-czekaj.md), Krystian Malinowski'
     Ring announcer: '[Kinga Różańska](@/w/kinga-miotke.md)'
     Commentary: '[Krystian Czekaj](@/w/krystian-czekaj.md)'
 {% end %}


### PR DESCRIPTION
Wywalony nawias za nazwiskiem, bo go uznawało za część ring name'u.