### PR TITLE
Update ptw-awards.md

### DIFF
--- a/bin/card.py
+++ b/bin/card.py
@@ -56,7 +56,6 @@ class Name:
 
     def __init__(self, name_or_link: str):
         if m := person_link_re.match(name_or_link):
-            print(m)
             # __setattr__ is required boilerplate when using frozen dataclass
             object.__setattr__(self, 'name', m.group('text'))
             object.__setattr__(self, 'link', m.group('target'))

--- a/content/a/ptw-awards.md
+++ b/content/a/ptw-awards.md
@@ -9,7 +9,7 @@ authors = ["Seweryn Pielucha"]
 3 = { path = "ptw-awards-results.png", caption = "Facebook post announcing winners in each category.", source = "Facebook PTW"}
 +++
 
-The PTW Awards (Nagrody podsumowujące rok, loosely translated as _End-Of-Year Awards_) are a PTW initiative where awards, similar to the Academy Awards or WWE-estabilished Slammy Awards, are given to professional wrestlers and other individuals within PTW, such as commentators and referees, for notable achievements during the Year.
+The PTW Awards (Nagrody podsumowujące rok, loosely translated as _End-Of-Year Awards_) are a PTW initiative where awards, similar to the Academy Awards or WWE-estabilished Slammy Awards, are given to professional wrestlers and other individuals within PTW, such as commentators and referees, for notable achievements during the year.
 
 <!-- more -->
 

--- a/content/a/ptw-awards.md
+++ b/content/a/ptw-awards.md
@@ -4,30 +4,30 @@ weight = 6
 template = "base_with_gallery.html"
 authors = ["Seweryn Pielucha"]
 [extra.gallery]
-1 = { path = "hero-of-the-year.webp", caption = "Nominees for the Hero Of The Year category.", source = "Facebook PTW"}
+1 = { path = "hero-of-the-year.webp", caption = "Nominees for the Hero Of the Year category.", source = "Facebook PTW"}
 2 = { path = "ptw-awards-statues.webp", caption = "Awards statues made of acrylic glass, set on the ring in [PTW Performance Center](@/v/ptw-targowa.md)", source = "Facebook PTW"}
 3 = { path = "ptw-awards-results.png", caption = "Facebook post announcing winners in each category.", source = "Facebook PTW"}
 +++
 
-The PTW Awards (Nagrody podsumowujące rok, loosely translated as _End-Of-Year Awards_) are a PTW initiative where awards, similar to the Academy Awards or WWE-estabilished Slammy Awards, are given to professional wrestlers and other individuals within PTW, such as commentators and referees, for notable achievements during the year.
+The PTW Awards (Nagrody podsumowujące rok, loosely translated as _End-Of-Year Awards_) are a PTW initiative where awards, similar to the Academy Awards or WWE-estabilished Slammy Awards, are given to professional wrestlers and other individuals within PTW, such as commentators and referees, for notable achievements during the Year.
 
 <!-- more -->
 
-The awards were originally planned to be hosted annually, at the end of the year.
-However, so far only one edition has been held, in Dec 2022/Jan 2023, to summarize the first chapter of PTW's existence, from [PTW#1: Revolucja](@/e/ptw/2021-10-09-ptw-1-revolucja.md) till the end of 2022.
+The awards were originally planned to be hosted annually, at the end of the Year.
+However, so far only one edition has been held, in Dec 2022/Jan 2023, to summarize the first chapter of PTW's existence, from [PTW#1: Revolucja](@/e/ptw/2021-10-09-ptw-1-revolucja.md) until the end of 2022.
 Fans nominated their candidates by voting with reactions on PTW's Facebook page, which posted selected nominees in multiple categories.
 
 This award ceremony was held during [PTW Underground 12](@/e/ptw/2023-02-26-ptw-underground-12.md).
-Each of the winners was awarded a physical trophy, crafted out of acrylic plastic, depicting a wrestler figure flexing his muscles, joined with the "Kinguin PTW" logo, and individual signatures on the base.
+Each of the winners was awarded a physical trophy, crafted out of acrylic plastic, depicting a wrestler figure flexing his muscles against the "Kinguin PTW" logo, with individual signatures on the base.
 
-Although most of the fan-voting went uninterrupted, there was one category which brewed controversy.
+Although most of the fan-voting went uninterrupted, there was one category which caused controversy.
 While [Sędzia Seweryn](@/w/sedzia-seweryn.md) and Sędzia Matek fought a close battle for the prize, Sędzia Rafał unexpectedly and rapidly gained over 250 reactions.
 Until that moment he had just around 40, compared to his opponents' 150 reactions.
 After a short investigation, it was found that somebody decided to buy around 200 reactions from well-known Vietnamese social media bot farms.
-This escalated into the so-called "Afera Azjatycka" (_Asian Affair_), concluding in Sędzia Rafał's disqualification from the voting, and suspension from referee duties.
+This escalated into the so-called "Afera Azjatycka" (_Asian Scandal_), concluding in Sędzia Rafał's disqualification from the voting, and suspension from referee duties.
 His reputation among PTW's fans and other workers also suffered dramatically.
 
-Later it turned out that the entire thing was orchestrated as a prank by Szymon "Modzel" Modzelewski - a wrestling fan, who wanted to tease PTW and Pawłowski by interfering with the poll results.
+Later it turned out that the entire thing was orchestrated as a prank by Szymon "Modzel" Modzelewski - a wrestling fan who wanted to tease PTW and Pawłowski by interfering with the poll results.
 
 ## Categories awarded
 
@@ -35,20 +35,20 @@ Later it turned out that the entire thing was orchestrated as a prank by Szymon 
 - Bohater Roku (_Hero of the Year_)
 - Złoczyńca Roku (_Villain of the Year_)
 - Debiutant Roku (_Newcomer of the Year_)
-- Mówca Roku (_Wrestler of the Year_)
-- Tag Team Roku (_Wrestler of the Year_)
-- Komentator Roku (_Wrestler of the Year_)
+- Mówca Roku (_Speaker of the Year_)
+- Tag Team Roku (_Tag Team of the Year_)
+- Komentator Roku (_Commentator of the Year_)
 - Wrestlerka Roku (_Female Wrestler of the Year_)
 - Walka Roku (_Match of the Year_)
 - Finisher Roku (_Finisher of the Year_)
 - Moment Roku (_Moment of the Year_)
 - Sędzia Roku (_Referee of the Year_)
 - Konflikt Roku (_Feud of the Year_)
-- Gala Roku (_Show of the Year_**
+- Gala Roku (_Show of the Year_)
 
 ### Results of fan-voting in each category
 
-#### Wrestler of The Year
+#### Wrestler of the Year
 
 1. [Puncher](@/w/puncher.md) - 441 votes
 2. [Justin Joy](@/w/justin-joy.md) - 365 votes
@@ -56,7 +56,7 @@ Later it turned out that the entire thing was orchestrated as a prank by Szymon 
 4. Matt Sydal - 54 votes
 5. [Krampus](@/w/krampus.md) - 27 votes
 
-#### Hero of The Year
+#### Hero of the Year
 
 1. [Axel Fox](@/w/axel-fox.md) - 215 votes
 2. Samuray Del Sol - 40 votes
@@ -64,7 +64,7 @@ Later it turned out that the entire thing was orchestrated as a prank by Szymon 
 4. [Nano Lopez](@/w/nano-lopez.md) - 19 votes
 5. [Disco Pablo](@/w/disco-pablo.md) - 8 votes
 
-#### Villain of The Year
+#### Villain of the Year
 
 1. [Sinister](@/w/sinister.md) - 165
 2. [Bad Bones](@/w/bad-bones.md) - 60
@@ -72,7 +72,7 @@ Later it turned out that the entire thing was orchestrated as a prank by Szymon 
 4. Puncher - 36
 5. [Gabriel Queen](@/w/gabriel-queen.md) - 14
 
-#### Newcomer of The Year
+#### Newcomer of the Year
 
 1. [Vic Golden](@/w/vic-golden.md) - 130
 2. [Wiktor Longman](@/w/wiktor-longman.md) - 93
@@ -80,7 +80,7 @@ Later it turned out that the entire thing was orchestrated as a prank by Szymon 
 4. [Spartan](@/w/spartan.md) - 33
 5. [Aron Wake](@/w/aron-wake.md) - 11
 
-#### Speaker of The Year
+#### Speaker of the Year
 
 1. Puncher - 219
 2. [TAXI Złotówa](@/w/taxi-zlotowa.md) - 83
@@ -88,13 +88,13 @@ Later it turned out that the entire thing was orchestrated as a prank by Szymon 
 4. Sinister - 24
 5. Axel Fox - 19
 
-#### Tag Team of The Year
+#### Tag Team of the Year
 
 1. Pure Gold (Gabriel Queen & Vic Golden) - 172
 2. PAKA (Disco Pablo, Taras & [Boro](@/w/boro.md)) - 124
 3. Bright Lights ([Marcelito](@/w/marcelito.md) & [Karol "Iskra" Górski](@/w/iskra.md)) - 25
 
-#### Commentator of The Year
+#### Commentator of the Year
 
 1. Arek Paterek - 171
 2. Łukasz Baliński - 75
@@ -102,7 +102,7 @@ Later it turned out that the entire thing was orchestrated as a prank by Szymon 
 4. Santino - 35
 5. Lewis Costello - 12
 
-#### Female Wrestler of The Year
+#### Female Wrestler of the Year
 
 1. [Diana Strong](@/w/diana-strong.md) - 135
 2. Myla Grace - 86
@@ -110,7 +110,7 @@ Later it turned out that the entire thing was orchestrated as a prank by Szymon 
 4. Helena Sixt - 3
 5. Gaya Glass - 0
 
-#### Show of The Year
+#### Show of the Year
 
 1. [PTW#3: Legends](@/e/ptw/2022-11-26-ptw-3-legends.md) - 170
 2. [PTW#1: REVOLUCJA](@/e/ptw/2021-10-09-ptw-1-revolucja.md) - 13
@@ -118,7 +118,7 @@ Later it turned out that the entire thing was orchestrated as a prank by Szymon 
 4. [PTW X RyuCon](@/e/ptw/2022-07-31-ptw-x-ryucon.md) - 4
 5. [PTW Underground 8](@/e/ptw/2022-09-25-ptw-underground-8.md) - 2
 
-#### Match of The Year
+#### Match of the Year
 
 1. Justin Joy vs Axel Fox - Legends - 165
 2. Matt Sydal vs Samuray Del Sol - Legends - 25
@@ -126,29 +126,29 @@ Later it turned out that the entire thing was orchestrated as a prank by Szymon 
 4. [Jonny Storm](@/w/jonny-storm.md) vs Jody Fleisch - Revolucja - 7
 5. Axel Tischer vs Bad Bones - Blackout - 7
 
-#### Finisher of The Year
+#### Finisher of the Year
 
-1. Puncher - Wylew (WINNER) - 174
+1. Puncher - Wylew - 174
 2. [Robert Star](@/w/robert-star.md) - Stallion Cutter - 137
 3. PAKA - Blok 3D - 31
 4. [Spartan](@/w/spartan.md) - Spartan Bomb - 28
 5. Nano Lopez - Last Plane to Spain - 14
 
-#### Moment of The Year
+#### Moment of the Year
 
-1. Justin Joy & Axel Fox's Reunion - 93
-2. Drop of Joy on the table - 58
-3. Krampus's chokeslamming Nano through the table - 15
+1. Justin Joy & Axel Fox's reunion - 93
+2. Joy dropped on a table - 58
+3. Krampus chokeslamming Nano through a table - 15
 4. PAKA's 6-man suplex - 9
 5. Santino's Cobra - 9
 
-#### Referee of The Year
+#### Referee of the Year
 
 1. [Sędzia Seweryn](@/w/sedzia-seweryn.md) - 174
 2. Sędzia Matek - 149
 3. Sędzia Rafał - 234 pre-disqualification (36 excluding paid bot votes)
 
-#### Feud of The Year
+#### Feud of the Year
 
 1. Axel Fox vs Justin Joy - 88
 2. Nano Lopez vs Sinister - 60

--- a/content/a/ptw-awards.md
+++ b/content/a/ptw-awards.md
@@ -13,7 +13,7 @@ The PTW Awards (Nagrody podsumowujące rok, loosely translated as _End-Of-Year A
 
 <!-- more -->
 
-The awards were originally planned to be hosted annually, at the end of the Year.
+The awards were originally planned to be hosted annually, at the end of the year.
 However, so far only one edition has been held, in Dec 2022/Jan 2023, to summarize the first chapter of PTW's existence, from [PTW#1: Revolucja](@/e/ptw/2021-10-09-ptw-1-revolucja.md) until the end of 2022.
 Fans nominated their candidates by voting with reactions on PTW's Facebook page, which posted selected nominees in multiple categories.
 


### PR DESCRIPTION
Drobiazgi
Affair -> Scandal, bo to jednak bliższe polskiej "aferze" ("affair" to bardziej "sprawa" czy "wydarzenie" - znacznie 'spokojniejsze' słowo, w każdym razie) Tłumaczenia nazw kategorii
Usunięto "WINNER" przy finisherze Punchera - pierwsze miejsce i tak to sugeruje, zresztą nigdzie indziej tego przypisku nie ma Kapitalizacja odse^H^H^H^Hrodzajników