### PR TITLE
Karta GZ'24, Roth i Johnson name-to-flag

### DIFF
--- a/const/name-to-flag.yaml
+++ b/const/name-to-flag.yaml
@@ -116,13 +116,9 @@ Karyna: PL
 Kasandra: PL
 Kat Von Kaige: WALES
 Kevin Williams: SCOTLAND
-Kinga Miotke: PL
-Kinga Różańska: PL # Kinga Miotke == Kinga Różańska
 Koppany: HU
 Král Slova Kuba: CZ
 Kripto: PL
-Krystian Czekaj: PL
-Krystian Malinowski: PL # Krystian Malinowski == Rex Torpeda
 # L/Ł
 Lanny Poffo: CA
 Laurance Roman: DE
@@ -186,7 +182,6 @@ Pete Dunne: GB
 Peter Tihanyi: HU
 PG Hooker: HU
 Piotr Opolski: PL
-Piotr "Showoff" Małecki: PL
 PJ Black: ZA
 Polish Giant: PL
 Primate: GB
@@ -194,7 +189,6 @@ Primate: GB
 Rambo: DO
 Red Scorpion: IT
 Reinbakh: CA
-Rex Torpeda: PL # Rex Torpeda == Krystian Malinowski
 Ricky Sky: SK
 Ritshy Rage: AT
 Robert Dreissker: AT
@@ -235,7 +229,7 @@ Svedberg: SE
 Szymon Kolanus: PL
 # T
 TAXI Złotówa: PL
-Terry Shadow (impostor): PL
+Terry Shadow (impostor): PL # wyjątkowo nieprzekonywająco zamaskowany Rob Scaffold, ale oficjalnie tego nie wiadomo :P
 The Grannatic: DE
 TJ Charles: IE
 Tom Fulton: SCOTLAND

--- a/const/name-to-flag.yaml
+++ b/const/name-to-flag.yaml
@@ -4,6 +4,7 @@ Ahmed Chaer: DE
 Akira: PL
 Alex Berkner: AT
 Alex Tamatou: AT
+Alexander Roth: ENGLAND
 Amale: FR
 Amsker: CZ
 Andrzej Supron: PL
@@ -198,6 +199,7 @@ Ricky Sky: SK
 Ritshy Rage: AT
 Robert Dreissker: AT
 Robert Kaiser: DE
+Roy Johnson: ENGLAND
 Rusałka: PL
 Rust: IT
 Ryan Smile: ENGLAND

--- a/content/e/kpw/2024-09-07-kpw-godzina-zero-2024.md
+++ b/content/e/kpw/2024-09-07-kpw-godzina-zero-2024.md
@@ -30,7 +30,11 @@ According to KPW's event page, there will be a significant number of foreign tal
 * Chairman Malinowski announced that all three championships would be defended.
 * Starting on June 22, 2024, KPW started daily posts revealing the wrestlers that would appear on the show. One of them was the former champion [Ron Corvus](@/w/ron-corvus.md), last seen at Arena 18.
 
-{{ skip_card() }}
+{% card() %}
+- - "Bracia Fux: [Filip Fux](@/w/filip-fux.md), [Michał Fux](@/w/michal-fux.md)"
+  - "The 87: Alexander Roth, Roy Johnson"
+  - {c: KPW Tag Team Championship}
+{% end %}
 
 #### Recap
 


### PR DESCRIPTION
Dodana pierwsza walka na karcie
Roth i Johnson na liście imion