### PR TITLE
New article PTW Championship

### DIFF
--- a/content/a/ptw-championship.md
+++ b/content/a/ptw-championship.md
@@ -15,13 +15,13 @@ The PTW Championship is a professional wrestling championship created and promot
 
 ## History
 
-The title was created at [PTW#3: Legends](@/e/ptw/2022-11-26-ptw-3-legends.md) in November 2022, by [Arkadiusz Pawłowski](@/w/pan-pawlowski.md) - PTW's owner and GM.
-Along with the title, GM Pawłowski announced a 20-person Gold Rush Rumble match (a variation of a Battle Royal match), which took place in February 2024 during [PTW#5: Gold Rush](@/e/ptw/2024-02-03-ptw-5-gold-rush.md).
+The title was created at [PTW#3: Legends](@/e/ptw/2022-11-26-ptw-3-legends.md) in November 2022, by [Arkadiusz Pawłowski](@/w/pan-pawlowski.md) - PTW's owner and General Manager.
+Along with the title, Pawłowski announced a 20-person Gold Rush Rumble match (a variation of a Battle Royal match), which took place in February 2024 during [PTW#5: Gold Rush](@/e/ptw/2024-02-03-ptw-5-gold-rush.md).
 The match was won by Dawid "Puncher" Seńko, who then became the inaugural PTW Champion.
 
-## Belt Design
+## Belt design
 
-The championship belt design is inspired by WWE's World Heavyweight Championship, both the modern variation, and the classic Big Gold Belt dating back to WCW.
+The championship belt design is inspired by WWE's World Heavyweight Championship, both the modern variation, and the classic Big Gold Belt dating back to the National Wrestling Alliance (NWA).
 Like the historic Big Gold Belt, the title has three large black and gold plates on a black leather strap.
 All three plates include gold filigree, and each plate is outlined with a rope trim to represent the three ropes of a wrestling ring.
 The central plate shows a large globe, with a black rim and "Prime Time Wrestling" and "Champion" engravings. Next to it, on both sides, are engravings of a wrestling ring.

--- a/content/a/ptw-championship.md
+++ b/content/a/ptw-championship.md
@@ -1,0 +1,42 @@
++++
+title = "PTW Championship"
+weight = 5
++++
+
+The PTW Championship is a professional wrestling championship created and promoted by [Prime Time Wrestling](@/o/ptw.md) as their top championship.
+
+## Statistics
+
+* First champion: [Puncher](@/w/puncher.md)
+* Most reigns: Puncher (1)
+* Longest reign: Puncher (170+ days)
+* Oldest Champion: Puncher (27 years, 298 days)
+* Heaviest Champion: Puncher (102kg)
+
+## History
+
+The title was created at [PTW#3: Legends](@/e/ptw/2022-11-26-ptw-3-legends.md) in November 2022, by [Arkadiusz Pawłowski](@/w/pan-pawlowski.md) - PTW's owner and GM.
+Along with the title, GM Pawłowski announced a 20-person Gold Rush Rumble match (a variation of a Battle Royal match), which took place in February 2024 during [PTW#5: Gold Rush](@/e/ptw/2024-02-03-ptw-5-gold-rush.md).
+The match was won by Dawid "Puncher" Seńko, who then became the inaugural PTW Champion.
+
+## Belt Design
+
+The championship belt design is inspired by WWE's World Heavyweight Championship, both the modern variation, and the classic Big Gold Belt dating back to WCW.
+Like the historic Big Gold Belt, the title has three large black and gold plates on a black leather strap.
+All three plates include gold filigree, and each plate is outlined with a rope trim to represent the three ropes of a wrestling ring.
+The central plate shows a large globe, with a black rim and "Prime Time Wrestling" and "Champion" engravings. Next to it, on both sides, are engravings of a wrestling ring.
+
+## Championship defences
+
+{% free_card() %}
+- - 'Puncher(c)'
+  - Marius Al-Ani
+  - s: Champion vs Champion Match
+    en: '[PTW Underground 21](@/e/ptw/2024-04-13-ptw-underground-21.md)'
+    ed: 2024-04-13
+- - 'Puncher(c)'
+  - Miyagi Shida
+  - s: Puncher's Open Challenge
+    en: '[PTW x RyuCon 3](@/e/ptw/2024-07-07-ptw-x-ryucon.md)'
+    ed: 2024-07-07
+{% end %}

--- a/content/o/ptw.md
+++ b/content/o/ptw.md
@@ -283,7 +283,7 @@ One remarkable deal between PTW and a bigger promotion was an agreement with Imp
 
 | Championship | Current champion(s) | Notes |
 |--|--|--|
-| PTW Championship | [Puncher](@/w/puncher.md) | Inaugural champion, won the championship rumble match at [Gold Rush](@/e/ptw/2024-02-03-ptw-5-gold-rush.md). |
+| [PTW Championship](@/a/ptw-championship.md) | [Puncher](@/w/puncher.md) | Inaugural champion, won the championship rumble match at [Gold Rush](@/e/ptw/2024-02-03-ptw-5-gold-rush.md). |
 | PTW Tag Team Championship | Budapest Bastards: [Renegade](@/w/renegade.md) and [Nitro](@/w/nitro.md) | Defeated PAKA: [Disco Pablo](@/w/disco-pablo.md), [Boro](@/w/boro.md) and [Taras](@/w/taras.md) at [Gold Rush](@/e/ptw/2024-02-03-ptw-5-gold-rush.md). |
 
 ## Internet presence

--- a/sass/tables.sass
+++ b/sass/tables.sass
@@ -25,6 +25,9 @@ ul.column-rule
   grid-template-rows: auto
   grid-template-columns: 3em auto minmax(12em, auto)
 
+  &.free-card
+    grid-template-columns: 10em auto minmax(12em, auto)
+
   .match, .header, .delim
     display: grid
     grid-template-columns: subgrid
@@ -34,7 +37,7 @@ ul.column-rule
     span
       padding: 0.1em 0.3em
 
-    .n
+    .n, .ed
       text-align: right
 
     .nt

--- a/templates/free_card_result_row.html
+++ b/templates/free_card_result_row.html
@@ -1,0 +1,70 @@
+{% set final = row | last %}
+{% set winner = row | first %}
+{% if final is object %}
+  {% set others = row | slice(start=1, end=-1) %}
+  {% set title = final | get(key="c", default="") %}
+  {% set stip = final | get(key="s", default="") %}
+  {% set segment = final | get(key="g", default=false) %}
+  {% set result = final | get(key="r", default="") %}
+  {% set nc = final | get(key="nc", default=false) %}
+  {% set notes = final | get(key="n", default=[]) %}
+  {% set event_name = final | get(key="en", default=false) %}
+  {% set event_date = final | get(key="ed", default=false) %}
+{% else %}
+  {% set others = row | slice(start=1) %}
+  {% set title = "" %}
+  {% set stip = "" %}
+  {% set segment = false %}
+  {% set result = "" %}
+  {% set nc = false %}
+  {% set notes = [] %}
+  {% set event_name = false %}
+  {% set event_date = "" %}
+{% endif %}
+{% set bodies = others | length %}
+{% if final is object and final.nc %}
+    {% set sep = "<strong>vs</strong>" %}
+{% else %}
+    {% set sep = "<strong>d.</strong>" %}
+{% endif %}
+<li class="match">
+    <span class="ed">{{ event_date }}</span>
+    <span class="p">
+        {% if segment %}
+          <strong>Segment:</strong> {{ winner | markdown(inline=true) | safe }}{% if others -%}, {{ others | join(sep=", ") | markdown(inline=true) | safe }}{% endif %}
+        {% else %}
+          {% if bodies == 0 %}
+            Winner:
+          {% endif %}
+          {{ winner | markdown(inline=true) | safe }}
+          {% if bodies > 0 %}
+              {{ sep | safe }}
+              {{ others | join(sep=" and ") | markdown(inline=true) | safe }}
+          {% endif %}
+          {% if result %}
+              via {{ final.r }}
+          {% elif nc %}
+              - {{ final.nc }}
+          {% endif %}
+        {% endif %}
+        {% if notes is string %}
+          <span class="nt">NOTE: {{ notes | markdown(inline=true) | safe }}</span>
+        {% elif notes %}
+          <span class="nt">
+            NOTES:<br/>
+            <ul>
+              {% for note in notes %}
+                <li>{{ note | markdown(inline=true) | safe }}</li>
+              {% endfor %}
+            </ul>
+          </span>
+        {% endif %}
+    </span>
+    <span class="c">
+        {{ title | markdown(inline=true) | safe }}
+        {{ stip | markdown(inline=true) | safe }}
+        {% if event_name %}
+          <small>at {{ event_name | markdown(inline=true) | safe }}</small>
+        {% endif %}
+    </span>
+</li>

--- a/templates/shortcodes/free_card.html
+++ b/templates/shortcodes/free_card.html
@@ -1,0 +1,16 @@
+{% set data = load_data(literal=body,format="yaml") %}
+
+<ul class="card free-card">
+    <li class="header">
+        <span class="n">Date</span>
+        <span class="p">Results</span>
+        <span class="c">Details</span>
+    </li>
+{% for row in data %}
+  {% if row is object %}
+    {% include "object_row.html" %}
+  {% else %}
+    {% include "free_card_result_row.html" %}
+  {% endif %}
+{% endfor %}
+</ul>


### PR DESCRIPTION
#236 

This introduces a new shortcode, `free_card`, which works much like the `card` shortcode used in event cards. However, it 's slightly different:
- doesn't number matches, instead it shows a date
- doesn't have a result toggle, always shows results
- accepts two extra flags: `ed` event date `YYYY-MM-DD` and `en` event name, which is a text or Markdown link to the event page

This new article is linked from PTW in the "Championships" section, in the table.