### PR TITLE
Mateusz Kowalski -> Kakareko

### DIFF
--- a/content/e/ddw/2013-08-17-ddw-8.md
+++ b/content/e/ddw/2013-08-17-ddw-8.md
@@ -20,7 +20,7 @@ source = "[Official DDW Facebook]"
 - ['[Klarys](@/w/klarys.md)', '[Renegade](@/w/renegade.md)', {c: "HCW Championship",
     nc: "No Contest"}]
 - ['[Bianca](@/w/bianca.md)', '[Mira](@/w/mira.md)']
-- ['[Piękny Kawaler](@/w/piekny-kawaler.md)', '[Mateusz Kowalski](@/w/mateusz-kowalski.md)']
+- ['[Piękny Kawaler](@/w/piekny-kawaler.md)', '[Mateusz Kowalski](@/w/mateusz-kakareko.md)']
 - ['[Jędruś Bułecka](@/w/jedrus-bulecka.md)', '[Kamil Aleksander](@/w/kamil-aleksander.md)']
 {% end %}
 

--- a/content/e/ddw/2013-08-25-ddw-charity-event.md
+++ b/content/e/ddw/2013-08-25-ddw-charity-event.md
@@ -14,7 +14,7 @@ chronology = ["ddw"]
 8 = { path = "2013-08-25-ddw-charity-event-08.jpg", caption = "Aurora vs Mira.", source = "Facebook DDW" }
 9 = { path = "2013-08-25-ddw-charity-event-09.jpg", caption = "Aurora vs Mira.", source = "Facebook DDW" }
 10= { path = "2013-08-25-ddw-charity-event-10.jpg", caption = "Mira about to land on Aurora.", source = "Facebook DDW" }
-11= { path = "2013-08-25-ddw-charity-event-11.jpg", caption = "[Luxus](@/w/luxus.md) & [Piękny Kawaler](@/w/piekny-kawaler.md) vs [Mateusz Kowalski](@/w/mateusz-kowalski.md) & [Robert Star](@/w/robert-star.md). Kowalski is holding Kawaler, Luxus and Robert are down on the floor.", source = "Facebook DDW" }
+11= { path = "2013-08-25-ddw-charity-event-11.jpg", caption = "[Luxus](@/w/luxus.md) & [Piękny Kawaler](@/w/piekny-kawaler.md) vs [Mateusz Kowalski](@/w/mateusz-kakareko.md) & [Robert Star](@/w/robert-star.md). Kowalski is holding Kawaler, Luxus and Robert are down on the floor.", source = "Facebook DDW" }
 12= { path = "2013-08-25-ddw-charity-event-12.jpg", caption = "Piękny Kawaler holding Mateusz Kowalski in a delayed vertical suplex.", source = "Facebook DDW" }
 13= { path = "2013-08-25-ddw-charity-event-13.jpg", caption = "Mateusz Kowalski dodges a lariat by Piękny Kawaler. Luxus stands in the corner.", source = "Facebook DDW" }
 14= { path = "2013-08-25-ddw-charity-event-14.jpg", caption = "Robert Star and Luxus, with Piękny Kawaler in the corner.", source = "Facebook DDW" }
@@ -25,7 +25,7 @@ chronology = ["ddw"]
 - ['[Klarys](@/w/klarys.md)', '[Kamil Aleksander](@/w/kamil-aleksander.md)']
 - [Aurora, '[Mira](@/w/mira.md)']
 - - "[Luxus](@/w/luxus.md), [Piękny Kawaler](@/w/piekny-kawaler.md)"
-  - "[Mateusz Kowalski](@/w/mateusz-kowalski.md), [Robert Star](@/w/robert-star.md)"
+  - "[Mateusz Kowalski](@/w/mateusz-kakareko.md), [Robert Star](@/w/robert-star.md)"
   - s: Tag Team Match
 - credits:
     Ring announcer: '[Arkadiusz Pawłowski](@/w/pan-pawlowski.md)'

--- a/content/e/ddw/2013-10-25-ddw-9.md
+++ b/content/e/ddw/2013-10-25-ddw-9.md
@@ -15,13 +15,13 @@ This event was infamous for very low attendance: only around 15 people came to s
 {% card() %}
 - ['[Kaszub](@/w/kaszub.md)', '[Luxus](@/w/luxus.md)', {nc: "No Contest"}]
 - ['[Piękny Kawaler](@/w/piekny-kawaler.md)', '[Robert Star](@/w/robert-star.md)']
-- ['[Bianca](@/w/bianca.md)', '[Kaszub](@/w/kaszub.md)', '[Mateusz Kowalski](@/w/mateusz-kowalski.md)',
+- ['[Bianca](@/w/bianca.md)', '[Kaszub](@/w/kaszub.md)', '[Mateusz Kowalski](@/w/mateusz-kakareko.md)',
   {s: "10 Man Battle Royale"}]
 - ['[Klarys](@/w/klarys.md)', Damian Dunne]
 - ["Aurora, Pacjent", "[Bianca](@/w/bianca.md), [Kamil Aleksander](@/w/kamil-aleksander.md)",
   {s: "Mixed Tag Team Match"}]
 - ['[Jędruś Bułecka](@/w/jedrus-bulecka.md)', '[Straceniec](@/w/shadow.md)']
-- ['[Don Roid](@/w/don-roid.md)', '[Mateusz Kowalski](@/w/mateusz-kowalski.md)', {
+- ['[Don Roid](@/w/don-roid.md)', '[Mateusz Kowalski](@/w/mateusz-kakareko.md)', {
     s: "[Don Roid](@/w/don-roid.md) Open Challenge"}]
 {% end %}
 

--- a/content/e/ddw/2014-08-16-ddw-pokaz-adeptow.md
+++ b/content/e/ddw/2014-08-16-ddw-pokaz-adeptow.md
@@ -15,7 +15,7 @@ This event was a showcase of DDW's newest trainees, and accompanied the bigger [
   "Double G: [GREG](@/w/greg.md), Wielki G", {s: Tag Team Match}]
 - ['[Mira](@/w/mira.md)', '[Bianca](@/w/bianca.md)', {r: DQ}]
 - ['[Robert Star](@/w/robert-star.md)', "[El Homo](@/w/ostrowski.md); Bogdan"]
-- ['[Mateusz Kowalski](@/w/mateusz-kowalski.md)', '[Kaszub](@/w/kaszub.md)']
+- ['[Mateusz Kowalski](@/w/mateusz-kakareko.md)', '[Kaszub](@/w/kaszub.md)']
 {% end %}
 
 ### References

--- a/content/e/ddw/2014-08-17-ddw-all-or-nothing-2.md
+++ b/content/e/ddw/2014-08-17-ddw-all-or-nothing-2.md
@@ -21,7 +21,7 @@ Another big (literally) feature of the event was Polish Giant, an up-and-coming 
       Championship Tournament First Round Match}]
 - ['[Kamil Aleksander](@/w/kamil-aleksander.md)', '[Klarys](@/w/klarys.md)', {s: DDW
       International Championship Tournament First Round Match}]
-- ['[Ron Corvus](@/w/ron-corvus.md)', '[Mateusz Kowalski](@/w/mateusz-kowalski.md)',
+- ['[Ron Corvus](@/w/ron-corvus.md)', '[Mateusz Kowalski](@/w/mateusz-kakareko.md)',
   {s: DDW International Championship Tournament First Round Match}]
 - ['[Dover](@/w/dover.md)', '[Luxus](@/w/luxus.md)', {s: Hardcore Match}]
 - ['[Kamil Aleksander](@/w/kamil-aleksander.md)', '[Ron Corvus](@/w/ron-corvus.md)',

--- a/content/e/ddw/2015-03-14-ddw-house-show-1.md
+++ b/content/e/ddw/2015-03-14-ddw-house-show-1.md
@@ -20,12 +20,12 @@ venue = ["gimnazjum-8-gdansk"]
   - '_rookie_ Artur Dzwończak'
   - '[Victor Rosetti](@/w/rosetti.md)'
   - '[Boski Ostrowski](@/w/ostrowski.md)'
-  - '[Mateusz Kowalski](@/w/mateusz-kowalski.md)'
+  - '[Mateusz Kowalski](@/w/mateusz-kakareko.md)'
   - '[_rookie_ Prince Victor](@/w/vic-golden.md)'
   - ???
   - '[_rookie_ David Oliwa](@/w/david-oliwa.md)'
   - s: Battle Royal
-- ['[Robert Star](@/w/robert-star.md)', '[Mateusz Kowalski](@/w/mateusz-kowalski.md)']
+- ['[Robert Star](@/w/robert-star.md)', '[Mateusz Kowalski](@/w/mateusz-kakareko.md)']
 - ['[Don Roid](@/w/don-roid.md)', '[Robert Star](@/w/robert-star.md)']
 - - '[Klarys](@/w/klarys.md)'
   - '[Kaszub](@/w/kaszub.md)'
@@ -47,7 +47,7 @@ _rookie_ [Damian Lambert](@/w/damien-rothschild.md) (being thrown out by Greg) \
 _rookie_ Artur Dzwończak (in red shorts, against the ropes) \
 [Victor Rosetti](@/w/rosetti.md) (in black vest, attacking _rookie_ Artur Dzwończak) \
 [Boski Ostrowski](@/w/ostrowski.md) (in blue trousers) \
-[Mateusz Kowalski](@/w/mateusz-kowalski.md) (holding the top rope) \
+[Mateusz Kowalski](@/w/mateusz-kakareko.md) (holding the top rope) \
 _rookie_ [Prince Victor](@/w/vic-golden.md) (attacking Mateusz Kowalski) \
 unknown (behind _rookie_ Prince Victor) \
 _rookie_ [David Oliwa](@/w/david-oliwa.md) (kneeling, in gaudy undies) \

--- a/content/e/ddw/2015-07-24-ddw-baltikon.md
+++ b/content/e/ddw/2015-07-24-ddw-baltikon.md
@@ -40,7 +40,7 @@ hide_results = true
 31 = { path = "baltikon-greg-ostrowski-bianka.jpg", caption = "Bianca punishing Ostrowski in the corner", source = "Facebook Baltikon / Tarakum Photo" }
 32 = { path = "baltikon-mira-kaszub-kawaler-pin.jpg", caption = "Mira and Kaszub stand in the corner while Kawaler pins Ostrowski", source = "Facebook Baltikon / Tarakum Photo" }
 33 = { path = "baltikon-mira-kaszub-ostrowski-kawaler.jpg", caption = "Kaszub, Ostrowski and Kawaler", source = "Facebook Baltikon / Tarakum Photo" }
-34 = { path = "baltikon-ostrowski-sedzia-kawaler.jpg", caption = "Ostrowski in the corner, Kawaler attacking. Referee in the background strongly resembles [Mateusz Kowalski](@/w/mateusz-kowalski.md)", source = "Facebook Baltikon / Tarakum Photo" }
+34 = { path = "baltikon-ostrowski-sedzia-kawaler.jpg", caption = "Ostrowski in the corner, Kawaler attacking. Referee in the background strongly resembles [Mateusz Kowalski](@/w/mateusz-kakareko.md)", source = "Facebook Baltikon / Tarakum Photo" }
 35 = { path = "baltikon-mira-kaszub-drop.jpg", caption = "Kaszub dropping down from the turnbuckle", source = "Facebook Baltikon / Tarakum Photo" }
 36 = { path = "baltikon-bianka-sedzia-greg-kaszub-kawaler.jpg", caption = "Kawaler dropping Kaszub in his corner.", source = "Facebook Baltikon / Tarakum Photo" }
 

--- a/content/e/kpw/2016-11-26-kpw-arena-4-nowy-rozdzial.md
+++ b/content/e/kpw/2016-11-26-kpw-arena-4-nowy-rozdzial.md
@@ -13,7 +13,7 @@ Nowy Rozdział (_The New Chapter_) was held in Gdańsk, in the gymnastics hall o
 {% card() %}
 - ['[Kaszub](@/w/kaszub.md)', '[Peter Pannache](@/w/peter-pannache.md)', {r: DQ}]
 - - "[Boski Ostrowski](@/w/ostrowski.md), [David Oliwa](@/w/david-oliwa.md); [Mira](@/w/mira.md)"
-  - "[Mateusz Kowalski](@/w/mateusz-kowalski.md), [Victor Rosetti](@/w/rosetti.md)"
+  - "[Mateusz Kowalski](@/w/mateusz-kakareko.md), [Victor Rosetti](@/w/rosetti.md)"
   - s: Tag Team Match
 - ['[Kamil Aleksander](@/w/kamil-aleksander.md)', '[Greg](@/w/greg.md)']
 - ['[Robert Star](@/w/robert-star.md)', '[Damian Lambert](@/w/damien-rothschild.md)']

--- a/content/e/kpw/2017-02-04-kpw-szlamfest.md
+++ b/content/e/kpw/2017-02-04-kpw-szlamfest.md
@@ -16,7 +16,7 @@ The event, and festival, were held in B90, a music and event venue located in a 
 - ['[Robert Star](@/w/robert-star.md)', "[Gracjan Korpo](@/w/gracjan-korpo.md); [Krzysztof
     Zasada](@/w/krzysztof-zasada.md)"]
 - ['[Peter Pannache](@/w/peter-pannache.md)', '[Kamil Aleksander](@/w/kamil-aleksander.md)',
-  '[Mateusz Kowalski](@/w/mateusz-kowalski.md)', '[Victor Rosetti](@/w/rosetti.md)',
+  '[Mateusz Kowalski](@/w/mateusz-kakareko.md)', '[Victor Rosetti](@/w/rosetti.md)',
   {s: Fatal Four Way Match}]
 - ['[Ron Corvus](@/w/ron-corvus.md)', '[Greg](@/w/greg.md)', {s: Hardcore Match}]
 - ['[Bianca](@/w/bianca.md)', '[Mira](@/w/mira.md)', {s: Pillow Fight Match}]

--- a/content/e/kpw/2017-04-08-kpw-arena-6-selekcja.md
+++ b/content/e/kpw/2017-04-08-kpw-arena-6-selekcja.md
@@ -14,7 +14,7 @@ This event featured the wrestling debut of referee Karol Górski in a squash mat
 Several years later, Karol would become [Iskra](@/w/iskra.md) in [Prime Time Wrestling](@/o/ptw.md), debuting at [Underground 6](@/e/ptw/2022-06-26-ptw-underground-6.md).
 
 {% card() %}
-- ['[Kamil Aleksander](@/w/kamil-aleksander.md)', '[Mateusz Kowalski](@/w/mateusz-kowalski.md)']
+- ['[Kamil Aleksander](@/w/kamil-aleksander.md)', '[Mateusz Kowalski](@/w/mateusz-kakareko.md)']
 - ['[Piękny Kawaler](@/w/piekny-kawaler.md)(c)', '[Karol Górski](@/w/iskra.md)', {
     c: "KPW Championship"}]
 - ['[Sawicki](@/w/sawicki.md)', '[Adam Bravo](@/w/adam-bravo.md)']

--- a/content/e/kpw/2017-06-10-kpw-arena-7-wysoka-stawka.md
+++ b/content/e/kpw/2017-06-10-kpw-arena-7-wysoka-stawka.md
@@ -13,7 +13,7 @@ Wysoka Stawka (_High Stakes_) was KPW's seventh Arena event, held in [Klub Atlan
 {% card() %}
 - ['[Robert Star](@/w/robert-star.md)', '[Victor Rosetti](@/w/rosetti.md)']
 - ["[Gracjan Korpo](@/w/gracjan-korpo.md); [Krzysztof Zasada](@/w/krzysztof-zasada.md)",
-  '[Mateusz Kowalski](@/w/mateusz-kowalski.md)']
+  '[Mateusz Kowalski](@/w/mateusz-kakareko.md)']
 - - "Kawaleria: [Kaszub](@/w/kaszub.md), [Greg](@/w/greg.md)"
   - "[David Oliwa](@/w/david-oliwa.md), [Peter Pannache](@/w/peter-pannache.md)"
   - s: Tag Team Match

--- a/content/e/kpw/2017-07-23-kpw-oldtown-2.md
+++ b/content/e/kpw/2017-07-23-kpw-oldtown-2.md
@@ -35,7 +35,7 @@ KPW would return to following editions of OldTown until 2019.
   - [Kamil Aleksander](@/w/kamil-aleksander.md) vs [Victor Rosetti](@/w/rosetti.md)
   - [David Oliwa](@/w/david-oliwa.md) vs [Greg](@/w/greg.md)
   - [Robert Star](@/w/robert-star.md) vs Mika The Polish Punisher
-- Aside from that, there was a three-way fight scheduled between [Mateusz Kowalski](@/w/mateusz-kowalski.md), [Adam Bravo](@/w/adam-bravo.md) and [Piękny Kawaler](@/w/piekny-kawaler.md); plus the hardcore match between [Kaszub](@/w/kaszub.md) and Corvus
+- Aside from that, there was a three-way fight scheduled between [Mateusz Kowalski](@/w/mateusz-kakareko.md), [Adam Bravo](@/w/adam-bravo.md) and [Piękny Kawaler](@/w/piekny-kawaler.md); plus the hardcore match between [Kaszub](@/w/kaszub.md) and Corvus
 - The final two participants of the opening rumble face each other for the KPW OldTown championship in the main event
 - Kawaler appears, declares he's had enough of OldTown and will not take part, only to soon change his mind
 - Corvus powerbombed [Kaszub](@/w/kaszub.md) into a table stacked with lighting tubes to win

--- a/content/e/kpw/2017-08-12-kpw-godzina-zero-2017.md
+++ b/content/e/kpw/2017-08-12-kpw-godzina-zero-2017.md
@@ -29,7 +29,7 @@ The other challenger was Welsh wrestler Wild Boar, by then already a veteran of 
   - '[Boski Ostrowski](@/w/ostrowski.md)'
   - '[David Oliwa](@/w/david-oliwa.md)'
   - '[Gracjan Korpo](@/w/gracjan-korpo.md)'
-  - '[Mateusz Kowalski](@/w/mateusz-kowalski.md)'
+  - '[Mateusz Kowalski](@/w/mateusz-kakareko.md)'
   - '[Sawicki](@/w/sawicki.md)'
   - '[Victor Rosetti](@/w/rosetti.md)'
   - s: "Magnificent Seven No Disqualification Elimination Ladder Match for a KPW Championship

--- a/content/e/kpw/2017-11-18-kpw-arena-8-droga-bez-powrotu.md
+++ b/content/e/kpw/2017-11-18-kpw-arena-8-droga-bez-powrotu.md
@@ -19,7 +19,7 @@ Droga Bez Powrotu (_The Road of No Return_) was the eight Arena show, and the fi
 - - '[David Oliwa](@/w/david-oliwa.md)'
   - '[Kamil Aleksander](@/w/kamil-aleksander.md)'
 - - "[Rosetti](@/w/rosetti.md), [Sawicki](@/w/sawicki.md)"
-  - "[Mateusz Kowalski](@/w/mateusz-kowalski.md), [Adam Bravo](@/w/adam-bravo.md)"
+  - "[Mateusz Kowalski](@/w/mateusz-kakareko.md), [Adam Bravo](@/w/adam-bravo.md)"
   - s: Tag Team Match
 - - "[Robert Star](@/w/robert-star.md)"
   - "[Greg](@/w/greg.md)(c)"

--- a/content/e/kpw/2018-03-10-kpw-arena-9-na-krawedzi.md
+++ b/content/e/kpw/2018-03-10-kpw-arena-9-na-krawedzi.md
@@ -14,7 +14,7 @@ This show was also the debut of the future [Chemik](@/w/chemik.md) - who appeare
 
 {% card() %}
 - - "[Boski Ostrowski](@/w/ostrowski.md), [Peter Pannache](@/w/peter-pannache.md)"
-  - "[Mateusz Kowalski](@/w/mateusz-kowalski.md), [Adam Bravo](@/w/adam-bravo.md)"
+  - "[Mateusz Kowalski](@/w/mateusz-kakareko.md), [Adam Bravo](@/w/adam-bravo.md)"
   - '[Rosetti](@/w/rosetti.md)'
   - s: 2v2v1 Handicap Match
 - ['[Bianca](@/w/bianca.md)', '[Alisa](@/w/alisa.md)']

--- a/content/e/kpw/2018-05-26-kpw-arena-x-kawaleria-vs-sojusz.md
+++ b/content/e/kpw/2018-05-26-kpw-arena-x-kawaleria-vs-sojusz.md
@@ -22,7 +22,7 @@ venue=["gdynia-sports-center"]
 {% card() %}
 - ['[Moloch](@/w/moloch.md)', '[Boski Ostrowski](@/w/ostrowski.md)']
 - ['[Alisa](@/w/alisa.md)', '[Mira](@/w/mira.md)']
-- ['[Mateusz Kakareko](@/w/mateusz-kowalski.md)', '[Gracjan Korpo](@/w/gracjan-korpo.md)']
+- ['[Mateusz Kakareko](@/w/mateusz-kakareko.md)', '[Gracjan Korpo](@/w/gracjan-korpo.md)']
 - - "Team Aleksander: [David Oliwa](@/w/david-oliwa.md), [Kamil Aleksander](@/w/kamil-aleksander.md),
     [Krzysztof Zasada](@/w/krzysztof-zasada.md), [Peter Pannache](@/w/peter-pannache.md)"
   - "Team Greg: [Adam Bravo](@/w/adam-bravo.md), [Greg](@/w/greg.md), [Sawicki](@/w/sawicki.md),
@@ -41,7 +41,7 @@ Attendance: about 300 \
 #### Recap
 
 - Two new girls in catsuits accompany [Moloch](@/w/moloch.md) to the ring. One of them will later make an in-ring debut as [Diana](@/w/diana-strong.md). The other one is Laura, who later trained with [PTW](@/o/ptw.md) but never debuted.
-- Ditching the old persona of Kowalski, [Mateusz Kakareko](@/w/mateusz-kowalski.md) became more aggressive, using a Taekwondo-based style, and broke his losing streak.
+- Ditching the old persona of Kowalski, [Mateusz Kakareko](@/w/mateusz-kakareko.md) became more aggressive, using a Taekwondo-based style, and broke his losing streak.
 - Greg "christened" members of the Kawaleria stable by spitting water on them. This would later become part of his character.
 - [Kamil Aleksander](@/w/kamil-aleksander.md)'s mother was present, and Kamil gave her a rose for Mother's Day (May 26th in Poland)
 - Zasada was eliminated first, then [Kamil Aleksander](@/w/kamil-aleksander.md). With the balance now favouring Team Greg, [Adam Bravo](@/w/adam-bravo.md) pulls out a betrayal by laying down for a pin, showing his middle fingers to Kawaleria.

--- a/content/e/kpw/2018-08-11-kpw-godzina-zero-2018.md
+++ b/content/e/kpw/2018-08-11-kpw-godzina-zero-2018.md
@@ -28,7 +28,7 @@ The event was held on the same day as a footbal match between Arka Gdynia and GÃ
   - '[Gracjan Korpo](@/w/gracjan-korpo.md)'
   - '[Rosetti](@/w/rosetti.md)'
   - '[Moloch](@/w/moloch.md)'
-  - '[Mateusz Kakareko](@/w/mateusz-kowalski.md)'
+  - '[Mateusz Kakareko](@/w/mateusz-kakareko.md)'
   - s: Magnificent Seven No-DQ Elimination Ladder Match for a Championship contract
 - ['[Bianca](@/w/bianca.md)', Sixt]
 - ['[Ron Corvus](@/w/ron-corvus.md)(c)', Tom LaRuffa, {c: KPW Championship}]

--- a/content/e/kpw/2019-01-19-kpw-arena-12-gwiazda-polnocy.md
+++ b/content/e/kpw/2019-01-19-kpw-arena-12-gwiazda-polnocy.md
@@ -21,7 +21,7 @@ The event was almost cancelled due to unrelated but tragic circumstances in the 
 {% card() %}
 - ['[Gracjan Korpo](@/w/gracjan-korpo.md)', '[Kamil Aleksander](@/w/kamil-aleksander.md)',
   {s: "KPW OldTown Championship #1 Contendership Qualifier"}]
-- ['[Moloch](@/w/moloch.md)', '[Mateusz Kakareko](@/w/mateusz-kowalski.md)']
+- ['[Moloch](@/w/moloch.md)', '[Mateusz Kakareko](@/w/mateusz-kakareko.md)']
 - ['[David Oliwa](@/w/david-oliwa.md)', '[Boski Ostrowski](@/w/ostrowski.md)', {s: "KPW
       OldTown Championship #1 Contendership Qualifier"}]
 - ['[Alisa](@/w/alisa.md)', '[Bianca](@/w/bianca.md)', Yuu, {s: Three Way Match}]

--- a/content/w/mateusz-kakareko.md
+++ b/content/w/mateusz-kakareko.md
@@ -1,8 +1,8 @@
 +++
-title = "Mateusz Kowalski"
+title = "Mateusz Kakareko"
 template = "talent_page.html"
 [taxonomies]
 country = ["PL"]
 [extra]
-career_aliases = ["Mateusz Kakareko"]
+career_aliases = ["Mateusz Kowalski"]
 +++


### PR DESCRIPTION
Artysta Zwany Dawniej Kowalskim pod koniec występował jako Mateusz Kakareko, lista powinna odzwierciedlać ostatni gimmick.