### PR TITLE
M3n747-update-miasta-WWE

### DIFF
--- a/content/e/wwe/2011-11-11-wwe-smackdown-house-show.md
+++ b/content/e/wwe/2011-11-11-wwe-smackdown-house-show.md
@@ -6,7 +6,7 @@ authors = ["M3n747"]
 chronology = ["international", "wwe"]
 venue = ["ergo-arena"]
 [extra]
-city = "Gdańsk", "Sopot"
+city = ["Gdańsk", "Sopot"]
 [extra.gallery]
 1 = { path = "2011-11-11-wwe-smackdown-house-show.jpg", caption = "WWE in Gdańsk/Sopot", source = "MyWrestling.com.pl" }
 +++

--- a/content/e/wwe/2011-11-11-wwe-smackdown-house-show.md
+++ b/content/e/wwe/2011-11-11-wwe-smackdown-house-show.md
@@ -5,6 +5,8 @@ authors = ["M3n747"]
 [taxonomies]
 chronology = ["international", "wwe"]
 venue = ["ergo-arena"]
+[extra]
+city = "Gdańsk", "Sopot"
 [extra.gallery]
 1 = { path = "2011-11-11-wwe-smackdown-house-show.jpg", caption = "WWE in Gdańsk/Sopot", source = "MyWrestling.com.pl" }
 +++

--- a/content/e/wwe/2012-04-12-wwe-raw-house-show.md
+++ b/content/e/wwe/2012-04-12-wwe-raw-house-show.md
@@ -5,6 +5,8 @@ authors = ["M3n747"]
 [taxonomies]
 chronology = ["international", "wwe"]
 venue = ["ergo-arena"]
+[extra]
+city = "Gdańsk", "Sopot"
 [extra.gallery]
 1 = { path = "2012-04-12-wwe-raw-house-show.jpg", caption = "WWE in Gdańsk/Sopot", source = "MyWrestling.com.pl" }
 +++

--- a/content/e/wwe/2012-04-12-wwe-raw-house-show.md
+++ b/content/e/wwe/2012-04-12-wwe-raw-house-show.md
@@ -6,7 +6,7 @@ authors = ["M3n747"]
 chronology = ["international", "wwe"]
 venue = ["ergo-arena"]
 [extra]
-city = "Gdańsk", "Sopot"
+city = ["Gdańsk", "Sopot"]
 [extra.gallery]
 1 = { path = "2012-04-12-wwe-raw-house-show.jpg", caption = "WWE in Gdańsk/Sopot", source = "MyWrestling.com.pl" }
 +++

--- a/content/e/wwe/2013-04-27-wwe-raw-house-show.md
+++ b/content/e/wwe/2013-04-27-wwe-raw-house-show.md
@@ -5,6 +5,8 @@ authors = ["M3n747"]
 [taxonomies]
 chronology = ["international", "wwe"]
 venue = ["atlas-arena"]
+[extra]
+city = "Łódź"
 [extra.gallery]
 1 = { path = "2013-04-27-wwe-raw-house-show.jpg", caption = "WWE in Łódź", source = "MyWrestling.com.pl" }
 +++

--- a/content/e/wwe/2013-04-27-wwe-raw-house-show.md
+++ b/content/e/wwe/2013-04-27-wwe-raw-house-show.md
@@ -6,7 +6,7 @@ authors = ["M3n747"]
 chronology = ["international", "wwe"]
 venue = ["atlas-arena"]
 [extra]
-city = "Łódź"
+city = ["Łódź"]
 [extra.gallery]
 1 = { path = "2013-04-27-wwe-raw-house-show.jpg", caption = "WWE in Łódź", source = "MyWrestling.com.pl" }
 +++

--- a/content/e/wwe/2015-04-15-wwe-live.md
+++ b/content/e/wwe/2015-04-15-wwe-live.md
@@ -5,6 +5,8 @@ authors = ["M3n747"]
 [taxonomies]
 chronology = ["international", "wwe"]
 venue = ["torwar"]
+[extra]
+city = "Warszawa"
 [extra.gallery]
 1 = { path = "2015-04-15-wwe-live.jpg", caption = "WWE in Warsaw", source = "MyWrestling.com.pl" }
 +++

--- a/content/e/wwe/2015-04-15-wwe-live.md
+++ b/content/e/wwe/2015-04-15-wwe-live.md
@@ -6,7 +6,7 @@ authors = ["M3n747"]
 chronology = ["international", "wwe"]
 venue = ["torwar"]
 [extra]
-city = "Warszawa"
+city = ["Warszawa"]
 [extra.gallery]
 1 = { path = "2015-04-15-wwe-live.jpg", caption = "WWE in Warsaw", source = "MyWrestling.com.pl" }
 +++


### PR DESCRIPTION
Dodane miasta. W pierwszych dwóch galach po dwa, bo ERGO Arena mieści się na granicy Gdańska i Sopotu, na Placu Dwóch Miast. Ciekawe, która poczta to obsługuje.