### PR TITLE
MZW/PpW Żadnych granic - poprawiony link

### DIFF
--- a/content/e/ppw/2023-09-23-ppw_mzw-zadnych-granic.md
+++ b/content/e/ppw/2023-09-23-ppw_mzw-zadnych-granic.md
@@ -34,4 +34,4 @@ source = "Official MZW Facebook"
 
 * [Facebook event page](https://www.facebook.com/events/1031532237862352)
 * [Cagematch event page](https://www.cagematch.net/?id=1&nr=375104)
-* [YouTube playlist](https://youtube.com/playlist?list=PL9jkhNR2Sx8ge-csZg10eYBYqmmANbvAK&si=SvGUMIDMmxBnxnjJ), each match is a separate video
+* [YouTube playlist](https://www.youtube.com/playlist?list=PL9jkhNR2Sx8ge-csZg10eYBYqmmANbvAK), each match is a separate video


### PR DESCRIPTION
Stary link odnosił do czwartego filmiku w playliście, nowy odnosi do samej playlisty.