### PR TITLE
Wyniki PTW UG 22

### DIFF
--- a/const/name-to-flag.yaml
+++ b/const/name-to-flag.yaml
@@ -158,6 +158,7 @@ Kaitlyn: US
 Kamil Kwiecień: PL
 Kamil Leśny: PL
 Kane: ES
+Karol Górski (2): PL # Karol Górski (2) == Sędzia Karol Górski
 Karyna: PL
 Kasandra: PL
 Kat Von Kaige: WALES
@@ -272,7 +273,7 @@ Sebastien: CZ
 Senza Volto: FR
 Sędzia Borys: PL # Sędzia Borys == Sędzia Gocha
 Sędzia Gocha: PL # Sędzia Gocha == Sędzia Borys
-Sędzia Karol Górski: PL
+Sędzia Karol Górski: PL # Sędzia Karol Górski = Karol Górski (2)
 Sędzia Klaudiusz: PL
 Sędzia Kornel: PL # Sędzia Kornel == Kapral Kornel (nieoficjalnie)
 Sędzia Matek: PL

--- a/content/e/kpw/2024-09-07-kpw-godzina-zero-2024.md
+++ b/content/e/kpw/2024-09-07-kpw-godzina-zero-2024.md
@@ -33,6 +33,7 @@ According to KPW's event page, there will be a significant number of foreign tal
 * Chairman Malinowski announced that all three championships would be defended.
 * Starting on June 22, 2024, KPW started daily posts revealing the wrestlers that would appear on the show. One of them was the former champion [Ron Corvus](@/w/ron-corvus.md), last seen at Arena 18.
 * Chemik posted a [video][chemik-video] stating that he did a whole lot of bad things to get [his title](@/c/kpw-old-town-championship.md) and that losing it would be like the end of the world to him. Perhaps tying into the name of the [previous event](@/e/kpw/2024-05-17-kpw-arena-25.md), he said "I did so many bad things that when I stand at the Pearly Gates, Saint Peter himself will kick my ass so hard I'll fly down straight to the ninth circle of hell", adding that the belt constitutes his identity.
+* About a week later [another video][rosetti-video], filmed by an unknown person, showed an angry Rosetti making a phone call to Greg, during which the two argued about the ownership of the [Old Town Championship](@/c/kpw-old-town-championship.md): Rosetti calling it his belt, and Greg firmly stating that it belongs to the Gregorian Branch. After a brief exchange Greg changed the subject, ordering Rosetti to cooperate with [Eryk Lesak](@/w/eryk-lesak.md) during the Magnificent Seven match, because all that matters is that the Championship contract goes to the Gregorian Branch. Greg then hung up, leaving the irritated Rosetti in mid-sentence.
 
 Card based on social media posts.
 
@@ -80,3 +81,4 @@ Card based on social media posts.
 
 [malinowski-video]: https://www.youtube.com/watch?v=dZ1HmSC_iqs
 [chemik-video]: https://www.youtube.com/watch?v=nJ23NvOAGCM
+[rosetti-video]: https://www.youtube.com/watch?v=ddDugsVF4g0

--- a/content/e/mzw/2018-01-14-mzw-big-rumble.md
+++ b/content/e/mzw/2018-01-14-mzw-big-rumble.md
@@ -6,6 +6,10 @@ chronology = ["mzw"]
 venue = ["gosir-glucholazy"]
 [extra]
 city = "Głuchołazy"
+[extra.gallery.1]
+path = "2018-01-14-mzw-big-rumble-plakat.jpg"
+caption = "Official poster"
+source = "Official MZW Facebook"
 +++
 
 This was the last [MZW](@/o/mzw.md) event to be held in [Głuchołazy](@/v/gosir-glucholazy.md), and also another charity event with donations going to WOŚP, coinciding with their 26th annual Grand Finale event. Listings of this event elsewhere on the Internet sometimes add "26th Anniversary", but do not explain what it refers to. It does not refer to MZW's Anniversary, at this time about four years old, but to the Grand Finale.

--- a/content/e/mzw/2024-10-12-mzw-no-time-to-die.md
+++ b/content/e/mzw/2024-10-12-mzw-no-time-to-die.md
@@ -1,6 +1,7 @@
 +++
 title = "MZW No Time to Die"
 template = "event_page.html"
+authors = ["M3n747"]
 [taxonomies]
 chronology = ["mzw"]
 venue = ["bakara"]
@@ -14,6 +15,8 @@ source = "Official MZW Facebook"
 
 After a nearly year-long hiatus following their [last event](@/e/ppw/2023-09-23-ppw_mzw-zadnych-granic.md), on August 1 2024 [MZW](@/o/mzw.md) announced a new show, called No Time to Die.
 The show is set to take place in [Bakara](@/v/bakara.md) Community Centre, which last held [MZW Project 7](@/e/mzw/2020-01-18-mzw-project-7-golden-road.md) in 2020, and several other events before.
+
+Like the [previous show](@/e/ppw/2023-09-23-ppw_mzw-zadnych-granic.md), this one is also a collaboration with [PpW Ewenement](@/o/ppw.md), seeing the return of [Gustav Gryffin](@/w/gustav-gryffin.md) and the MZW debut of [Johnny Blade](@/w/johnny-blade.md).
 
 {{ skip_card() }}
 

--- a/content/e/mzw/2024-10-12-mzw-no-time-to-die.md
+++ b/content/e/mzw/2024-10-12-mzw-no-time-to-die.md
@@ -18,7 +18,11 @@ The show is set to take place in [Bakara](@/v/bakara.md) Community Centre, which
 
 Like the [previous show](@/e/ppw/2023-09-23-ppw_mzw-zadnych-granic.md), this one is also a collaboration with [PpW Ewenement](@/o/ppw.md), seeing the return of [Gustav Gryffin](@/w/gustav-gryffin.md) and the MZW debut of [Johnny Blade](@/w/johnny-blade.md). It is also the first MZW show to feature an ex-PTW wrestler, [Dziedzic](@/w/dziedzic.md).
 
-{{ skip_card() }}
+{% card() %}
+- - '[Marco Hammers](@/w/marco-hammers.md)'
+  - '[Samson](@/w/samson.md)'
+    nc: upcoming
+{% end %}
 
 ## References
 

--- a/content/e/mzw/2024-10-12-mzw-no-time-to-die.md
+++ b/content/e/mzw/2024-10-12-mzw-no-time-to-die.md
@@ -21,7 +21,7 @@ Like the [previous show](@/e/ppw/2023-09-23-ppw_mzw-zadnych-granic.md), this one
 {% card() %}
 - - '[Marco Hammers](@/w/marco-hammers.md)'
   - '[Samson](@/w/samson.md)'
-    nc: upcoming
+  - nc: upcoming
 {% end %}
 
 ## References

--- a/content/e/mzw/2024-10-12-mzw-no-time-to-die.md
+++ b/content/e/mzw/2024-10-12-mzw-no-time-to-die.md
@@ -9,14 +9,14 @@ venue = ["bakara"]
 city = "Wrocław"
 [extra.gallery.1]
 path = "2024-10-12-mzw-no-time-to-die.jpg"
-caption = "Official poster. Left to right: [Johnny Blade](@/w/johnny-blade.md) (top), [Shadow](@/w/shadow.md) (bottom), ???, [Matt Buckna](@/w/matt-buckna.md) and [Gustav Gryffin](@/w/gustav-gryffin.md)."
+caption = "Official poster. Left to right: [Johnny Blade](@/w/johnny-blade.md) (top), [Shadow](@/w/shadow.md) (bottom), [Dziedzic](@/w/dziedzic.md), [Matt Buckna](@/w/matt-buckna.md) and [Gustav Gryffin](@/w/gustav-gryffin.md)."
 source = "Official MZW Facebook"
 +++
 
 After a nearly year-long hiatus following their [last event](@/e/ppw/2023-09-23-ppw_mzw-zadnych-granic.md), on August 1 2024 [MZW](@/o/mzw.md) announced a new show, called No Time to Die.
 The show is set to take place in [Bakara](@/v/bakara.md) Community Centre, which last held [MZW Project 7](@/e/mzw/2020-01-18-mzw-project-7-golden-road.md) in 2020, and several other events before.
 
-Like the [previous show](@/e/ppw/2023-09-23-ppw_mzw-zadnych-granic.md), this one is also a collaboration with [PpW Ewenement](@/o/ppw.md), seeing the return of [Gustav Gryffin](@/w/gustav-gryffin.md) and the MZW debut of [Johnny Blade](@/w/johnny-blade.md).
+Like the [previous show](@/e/ppw/2023-09-23-ppw_mzw-zadnych-granic.md), this one is also a collaboration with [PpW Ewenement](@/o/ppw.md), seeing the return of [Gustav Gryffin](@/w/gustav-gryffin.md) and the MZW debut of [Johnny Blade](@/w/johnny-blade.md). It is also the first MZW show to feature an ex-PTW wrestler, [Dziedzic](@/w/dziedzic.md).
 
 {{ skip_card() }}
 

--- a/content/e/mzw/2024-10-12-mzw-no-time-to-die.md
+++ b/content/e/mzw/2024-10-12-mzw-no-time-to-die.md
@@ -8,7 +8,7 @@ venue = ["bakara"]
 city = "Wrocław"
 [extra.gallery.1]
 path = "2024-10-12-mzw-no-time-to-die.jpg"
-caption = "Official poster."
+caption = "Official poster. Left to right: [Johnny Blade](@/w/johnny-blade.md) (top), [Shadow](@/w/shadow.md) (bottom), ???, [Matt Buckna](@/w/matt-buckna.md) and [Gustav Gryffin](@/w/gustav-gryffin.md)."
 source = "Official MZW Facebook"
 +++
 

--- a/content/e/mzw/2024-10-12-mzw-no-time-to-die.md
+++ b/content/e/mzw/2024-10-12-mzw-no-time-to-die.md
@@ -16,7 +16,7 @@ source = "Official MZW Facebook"
 After a nearly year-long hiatus following their [last event](@/e/ppw/2023-09-23-ppw_mzw-zadnych-granic.md), on August 1 2024 [MZW](@/o/mzw.md) announced a new show, called No Time to Die.
 The show is set to take place in [Bakara](@/v/bakara.md) Community Centre, which last held [MZW Project 7](@/e/mzw/2020-01-18-mzw-project-7-golden-road.md) in 2020, and several other events before.
 
-Like the [previous show](@/e/ppw/2023-09-23-ppw_mzw-zadnych-granic.md), this one is also a collaboration with [PpW Ewenement](@/o/ppw.md), seeing the return of [Gustav Gryffin](@/w/gustav-gryffin.md) and the MZW debut of [Johnny Blade](@/w/johnny-blade.md). It is also the first MZW show to feature an ex-PTW wrestler, [Dziedzic](@/w/dziedzic.md).
+Like the [previous show](@/e/ppw/2023-09-23-ppw_mzw-zadnych-granic.md), this one is also a collaboration with [PpW Ewenement](@/o/ppw.md), seeing the return of [Gustav Gryffin](@/w/gustav-gryffin.md) and the MZW debut of [Johnny Blade](@/w/johnny-blade.md). It is also the first MZW show to feature ex-PTW wrestlers [Dziedzic](@/w/dziedzic.md), [Marco Hammers](@/w/marco-hammers.md) and [Samson](@/w/samson.md).
 
 {% card() %}
 - - '[Marco Hammers](@/w/marco-hammers.md)'

--- a/content/e/ppw/2019-07-13-ppw-kiedys-bedzie-lepiej.md
+++ b/content/e/ppw/2019-07-13-ppw-kiedys-bedzie-lepiej.md
@@ -7,6 +7,8 @@ chronology = ["ppw"]
 city = "Warszawa"
 +++
 
+"Kiedyś będzie lepiej" (_One Day It's Gonna Be Better_) was PpW's penultimate backyard show and the last one to be held in the open air.
+
 {% card() %}
 - ["[Mister Z](@/w/mister-z.md)", "[Osamu](@/w/osamu.md)", {s: Hardcore Match}]
 - ['[Direk](@/w/direk.md)', '[Rob Scaffold](@/w/rob-scaffold.md)', {s: Hardcore Match}]

--- a/content/e/ppw/2022-03-12-ppw-mistrz-jest-tylko-jeden.md
+++ b/content/e/ppw/2022-03-12-ppw-mistrz-jest-tylko-jeden.md
@@ -13,9 +13,8 @@ source = "[Official PpW Facebook]"
 +++
 
 {% card() %}
-- - "[Royal Striker](@/w/royal-striker.md); [Direk](@/w/direk.md)"
-  - "[Isnorr](@/w/isnorr.md)"
-  - nc: No Contest
+- - "[Isnorr](@/w/isnorr.md)"
+  - "[Royal Striker](@/w/royal-striker.md); [Direk](@/w/direk.md)"
     n: Direk forced Isnorr to fight Striker as a condition of facing him later in the evening
 - - "[Adam Wong](@/w/adam-wong.md)"
   - "[Ricardo Diesel](@/w/ricardo-diesel.md)"

--- a/content/e/ppw/2022-03-12-ppw-mistrz-jest-tylko-jeden.md
+++ b/content/e/ppw/2022-03-12-ppw-mistrz-jest-tylko-jeden.md
@@ -15,7 +15,7 @@ source = "[Official PpW Facebook]"
 {% card() %}
 - - "[Isnorr](@/w/isnorr.md)"
   - "[Royal Striker](@/w/royal-striker.md); [Direk](@/w/direk.md)"
-    n: Direk forced Isnorr to fight Striker as a condition of facing him later in the evening.
+  - n: Direk forced Isnorr to fight Striker as a condition of facing him later in the evening.
 - - "[Adam Wong](@/w/adam-wong.md)"
   - "[Ricardo Diesel](@/w/ricardo-diesel.md)"
 - - "[Bill Feager](@/w/feager.md)"

--- a/content/e/ppw/2022-03-12-ppw-mistrz-jest-tylko-jeden.md
+++ b/content/e/ppw/2022-03-12-ppw-mistrz-jest-tylko-jeden.md
@@ -15,7 +15,7 @@ source = "[Official PpW Facebook]"
 {% card() %}
 - - "[Isnorr](@/w/isnorr.md)"
   - "[Royal Striker](@/w/royal-striker.md); [Direk](@/w/direk.md)"
-    n: Direk forced Isnorr to fight Striker as a condition of facing him later in the evening
+    n: Direk forced Isnorr to fight Striker as a condition of facing him later in the evening.
 - - "[Adam Wong](@/w/adam-wong.md)"
   - "[Ricardo Diesel](@/w/ricardo-diesel.md)"
 - - "[Bill Feager](@/w/feager.md)"

--- a/content/e/ppw/2023-09-23-ppw_mzw-zadnych-granic.md
+++ b/content/e/ppw/2023-09-23-ppw_mzw-zadnych-granic.md
@@ -34,4 +34,4 @@ source = "Official MZW Facebook"
 
 * [Facebook event page](https://www.facebook.com/events/1031532237862352)
 * [Cagematch event page](https://www.cagematch.net/?id=1&nr=375104)
-* [YouTube playlist](https://youtube.com/playlist?list=PL9jkhNR2Sx8ge-csZg10eYBYqmmANbvAK&si=SvGUMIDMmxBnxnjJ), each match is a separate video
+* [YouTube playlist](https://www.youtube.com/playlist?list=PL9jkhNR2Sx8ge-csZg10eYBYqmmANbvAK), each match is a separate video

--- a/content/e/ppw/2024-04-20-ppw-ewenement-haze.md
+++ b/content/e/ppw/2024-04-20-ppw-ewenement-haze.md
@@ -14,7 +14,7 @@ city = "Warszawa"
 Ewenement Haze was an event by [PpW Ewenement](@/o/ppw.md), taking place on Saturday April 20, 2024.
 The original venue was to be [Waldorffa 25](@/v/waldorffa25.md), but due to miscommunication, it turned out that it's already booked for the night, and PpW had to find a replacement.
 The new venue was Praga Centrum, a music and event venue with a large outdoor garden, located in Warsaw's Praga district.
-According to Facebook posts, the ring wast to be set outdoors, later the plans changed and the show was held indoors after all.
+According to Facebook posts, the ring wast to be set outdoors (for the first time since [Kiedyś będzie lepiej](@/e/ppw/2019-07-13-ppw-kiedys-bedzie-lepiej.md)), but only two days before the show the plans had to be changed due to the weather conditions and the show was held indoors after all.
 The set featured a full stage and elevated ramp leading to the ring, with full size titan-tron display playing videos for wrestler's entrances.
 The event's name refers to cannabis, whose many strains are often named "Something + Haze".
 This in turn, is a reference to the date, which, together with the number 420 are often associated with cannabis culture.

--- a/content/e/ppw/2024-06-08-ppw-ledwo-legalne-4.md
+++ b/content/e/ppw/2024-06-08-ppw-ledwo-legalne-4.md
@@ -10,14 +10,14 @@ city = "Warszawa"
 [extra.gallery]
 1 = { path = "plakat_ll4.jpg", caption = "Show poster, released on Apr 28, 2024 on Facebook. Pictured in the first row are: [Johnny Blade](@/w/johnny-blade.md), [Stanisław Van Dobroniak](@/w/stanislaw-van-dobroniak.md) with the [Ultraviolent championship](@/c/ppw-european-ultraviolent-championship.md) belt, [Alex Arthur](@/w/alex-arthur.md). In the second row: [Goblin](@/w/goblin.md), [Biesiad Strong](@/w/biesiad.md), [Bill Feager](@/w/feager.md) with the [PpW Championship](@/c/ppw-championship.md), [Mister Z](@/w/mister-z.md) and [Gustav Gryffin](@/w/gustav-gryffin.md).", source = "Official PpW Facebook"}
 2 = { path = "robert_star_is_ewenement.jpg", caption = "Graphics announcing Robert Star, released on May 11, 2024 on Facebook.", source="Official PpW Facebook"}
-3 = { path = "legia-entrance.jpg", caption = "Legia Łysych's surprise appearance. Titantron display shows scene from [PTW Underground 17](@/e/ptw/2023-09-03-ptw-underground-17.md).", source = "Krzysztof Zych" }
+3 = { path = "legia-entrance.jpg", caption = "Legia Łysych's surprise appearance. Titantron display shows a scene from [PTW Underground 17](@/e/ptw/2023-09-03-ptw-underground-17.md).", source = "Krzysztof Zych" }
 4 = { path = "robert-star-mic.jpg", caption = "[Robert Star](@/w/robert-star.md) with his UEWA belt.", source = "Krzysztof Zych" }
 5 = { path = "mef-the-death.jpg", caption = "Sigmarson's opponent Mef the Death.", source = "Krzysztof Zych" }
 6 = { path = "biesiad-ladder.jpg", caption = "[Biesiad Strong](@/w/biesiad.md) with a ladder.", source = "Krzysztof Zych"}
 7 = { path = "gustav-goblin.jpg", caption = "[Gustav Gryffin](@/w/gustav-gryffin.md) putting a barbed wire crown on [Goblin](@/w/goblin.md).", source = "Krzysztof Zych"}
 8 = { path = "biesiad-619-gustav.jpg", caption = "[Biesiad](@/w/biesiad.md) landing a 619 on [Gustav Gryffin](@/w/gustav-gryffin.md).", source = "Krzysztof Zych"}
 9 = { path = "kornel-ppw-uv.jpg", caption = "Referee Kornel holding the PpW European Ultraviolent Championship upside-down.", source = "Krzysztof Zych"}
-10 = { path = "johnny-blade.jpg", caption = "[Johnny Blade](@/w/johnny-blade.md), with [Dobroniak](@/w/stanislaw-van-dobroniak.md) behind.", source = "Krzysztof Zych" }
+10 = { path = "johnny-blade.jpg", caption = "[Johnny Blade](@/w/johnny-blade.md), with [Dobroniak](@/w/stanislaw-van-dobroniak.md) behind him.", source = "Krzysztof Zych" }
 11 = { path = "alex-arthur.jpg", caption = "[Alex Arthur](@/w/alex-arthur.md) inserting himself into the main event.", source = "Krzysztof Zych"}
 +++
 

--- a/content/e/ptw/2024-08-25-ptw-underground-22.md
+++ b/content/e/ptw/2024-08-25-ptw-underground-22.md
@@ -6,7 +6,6 @@ authors = ["Szymon Iwulski"]
 chronology = ["ptw", "underground"]
 venue = ["dworek-kozlow"]
 [extra]
-hide_results = true
 city = "Kozłów"
 [extra.gallery.poster]
 path = "ptwu22-poster.webp"
@@ -29,33 +28,29 @@ One new face making her debut for PTW will be Harley Hudson, English wrestler fr
 
 ### Change in ticketing
 
-On August 7th, PTW announced a "partnership" with ticket platforms Going and empik. Their previous ticket platform was kupbilecik (also used by [KPW](@/o/kpw.md)).
-For the first time ever, PTW introduced VIP tickets for an Underground show, in a very limited number of 20 seats. With a premium price (150PLN, or about 35EUR at the time, twice the regular ticket cost) they also promise a premium experience: ringside seats, snacks, drinks, merchandise discounts. This new ticket policy seems to disregard the "first come first serve" principle that PTW always followed in regards to seats at the Underground shows.
+On August 7th, PTW announced a "partnership" with ticket platforms Going and Empik, making a switch from their previous ticket platform, KupBilecik (also used by [KPW](@/o/kpw.md)).
+For the first time ever, PTW introduced VIP tickets for an Underground show, in a very limited number of 20 seats. With a premium price (150&nbsp;PLN, or about 35&nbsp;EUR at the time; twice the regular ticket cost) they also promise a premium experience: ringside seats, snacks, drinks and merchandise discounts. This new ticket policy seems to disregard the "first come first served" principle that PTW always followed in regards to seats at the Underground shows.
 
 {% card(predicted=true) %}
-- - Maverick
-  - '[Puncher](@/w/puncher.md)'
-  - nc: upcoming
-    c: 'WWA Championship'
-- - '[Vincent Caravaggio](@/w/vincent-caravaggio.md)'
-  - '[Max Speed](@/w/max-speed.md)'
-  - nc: upcoming
 - - '["Starboy" Nano Lopez](@/w/nano-lopez.md)'
-  - '???'
-  - nc: upcoming
-- - '[Spartan](@/w/spartan.md)'
-  - Svedberg
-  - nc: upcoming
-- - Miyagi Shida
+  - 'Blaze'
+- - 'Miyagi Shida'
   - g: true
-    s: Contract Signing
+    s: Contract signing
+- - '[Alex Brave](@/w/sedzia-rafal.md)'
+  - 'Miyagi Shida'
 - - 'Budapest Bastards: [Nitro](@/w/nitro.md), [Renegade](@/w/renegade.md)'
   - 'Gulyas Bros: Gulyás Öcsi, Gulyás Vilmos'
   - c: '[PTW Tag Team Championship](@/c/ptw-tag-team-championship.md)'
-    nc: upcoming
 - - '[Diana Strong](@/w/diana-strong.md)'
   - 'Harley Hudson'
-  - nc: upcoming
+- - '[Vincent Caravaggio](@/w/vincent-caravaggio.md)'
+  - '[Max Speed](@/w/max-speed.md)'
+- - '[Spartan](@/w/spartan.md)'
+  - 'Svedberg'
+- - '[Puncher](@/w/puncher.md)'
+  - 'Maverick'
+    c: 'WWA Championship'
 {% end %}
 
 ### References

--- a/content/e/ptw/2024-08-25-ptw-underground-22.md
+++ b/content/e/ptw/2024-08-25-ptw-underground-22.md
@@ -25,6 +25,7 @@ One new face making her debut for PTW will be Harley Hudson, English wrestler fr
 
 * On July 19 2024, PTW updated their Facebook cover photo, confirming dates for both the camp and the show. The training camp will start on Sunday August 18, and the show is to be held on the next Sunday, August 25.
 * On August 8th, the official poster was revealed, prominently featuring Maverick and [Puncher](@/w/puncher.md) suggesting a main event between the two. A couple of days later, on August 13, this was announced as a title match for the WWA Championship.
+* As of 21st of August there's been no word whether or not the event would be streamed live.
 
 ### Change in ticketing
 
@@ -49,7 +50,7 @@ For the first time ever, PTW introduced VIP tickets for an Underground show, in 
   - g: true
     s: Contract Signing
 - - 'Budapest Bastards: [Nitro](@/w/nitro.md), [Renegade](@/w/renegade.md)'
-  - 'Gulyas Bros: Gulyas Öcsi, Gulyas Vilmos'
+  - 'Gulyas Bros: Gulyás Öcsi, Gulyás Vilmos'
   - c: '[PTW Tag Team Championship](@/c/ptw-tag-team-championship.md)'
     nc: upcoming
 - - '[Diana Strong](@/w/diana-strong.md)'

--- a/content/e/ptw/2024-08-25-ptw-underground-22.md
+++ b/content/e/ptw/2024-08-25-ptw-underground-22.md
@@ -31,7 +31,7 @@ One new face making her debut for PTW will be Harley Hudson, English wrestler fr
 On August 7th, PTW announced a "partnership" with ticket platforms Going and Empik, making a switch from their previous ticket platform, KupBilecik (also used by [KPW](@/o/kpw.md)).
 For the first time ever, PTW introduced VIP tickets for an Underground show, in a very limited number of 20 seats. With a premium price (150&nbsp;PLN, or about 35&nbsp;EUR at the time; twice the regular ticket cost) they also promise a premium experience: ringside seats, snacks, drinks and merchandise discounts. This new ticket policy seems to disregard the "first come first served" principle that PTW always followed in regards to seats at the Underground shows.
 
-{% card(predicted=true) %}
+{% card() %}
 - - '["Starboy" Nano Lopez](@/w/nano-lopez.md)'
   - 'Blaze'
 - - 'Miyagi Shida'
@@ -39,6 +39,8 @@ For the first time ever, PTW introduced VIP tickets for an Underground show, in 
     s: Contract signing
 - - '[Alex Brave](@/w/sedzia-rafal.md)'
   - 'Miyagi Shida'
+- - 'Rust'
+  - 'LaVonce'
 - - 'Budapest Bastards: [Nitro](@/w/nitro.md), [Renegade](@/w/renegade.md)'
   - 'Gulyas Bros: Gulyás Öcsi, Gulyás Vilmos'
   - c: '[PTW Tag Team Championship](@/c/ptw-tag-team-championship.md)'

--- a/content/e/ptw/2024-08-25-ptw-underground-22.md
+++ b/content/e/ptw/2024-08-25-ptw-underground-22.md
@@ -25,7 +25,7 @@ One new face making her debut for PTW will be Harley Hudson, English wrestler fr
 
 * On July 19 2024, PTW updated their Facebook cover photo, confirming dates for both the camp and the show. The training camp will start on Sunday August 18, and the show is to be held on the next Sunday, August 25.
 * On August 8th, the official poster was revealed, prominently featuring Maverick and [Puncher](@/w/puncher.md) suggesting a main event between the two. A couple of days later, on August 13, this was announced as a title match for the WWA Championship.
-* As of 21st of August there's been no word whether or not the event would be streamed live.
+* PTW officially confirmed the show would not be aired live, but taped to be later aired on Fite/Triller, YouTube and an undisclosed TV station. This marks PTW's TV debut as well as the first time they tape a show - all prior shows were either live, or not broadcast at all.
 
 ### Change in ticketing
 

--- a/content/e/ptw/2024-08-25-ptw-underground-22.md
+++ b/content/e/ptw/2024-08-25-ptw-underground-22.md
@@ -50,7 +50,7 @@ For the first time ever, PTW introduced VIP tickets for an Underground show, in 
   - 'Svedberg'
 - - '[Puncher](@/w/puncher.md)'
   - 'Maverick'
-    c: 'WWA Championship'
+  - c: 'WWA Championship'
 {% end %}
 
 ### References

--- a/content/e/ptw/2024-08-25-ptw-underground-22.md
+++ b/content/e/ptw/2024-08-25-ptw-underground-22.md
@@ -49,7 +49,7 @@ For the first time ever, PTW introduced VIP tickets for an Underground show, in 
   - g: true
     s: Contract Signing
 - - 'Budapest Bastards: [Nitro](@/w/nitro.md), [Renegade](@/w/renegade.md)'
-  - '???'
+  - 'Gulyas Bros: Gulyas Öcsi, Gulyas Vilmos'
   - c: '[PTW Tag Team Championship](@/c/ptw-tag-team-championship.md)'
     nc: upcoming
 - - '[Diana Strong](@/w/diana-strong.md)'

--- a/content/o/ptw.md
+++ b/content/o/ptw.md
@@ -176,9 +176,21 @@ On Thursday June 13th, PTW has taken down the roster section of their page.
 
 In a [Twitch stream](https://www.twitch.tv/videos/2180575222) on June 25th, Pawłowski confirmed that Axel Fox, a popular babyface, has also quit the organization. This was the first time this info was shared, as Axel himself did not reveal it before.
 
-#### Soft reboot: new venue in Kozłów
+#### Soft reboot: Ryucon, new co-owner
 
-On August 15 2024, Łukasz Okoński, who's the owner of Dworek Pod Platanem where [Underground 21](@/e/ptw/2024-04-13-ptw-underground-21.md) and [22](@/e/ptw/2024-08-25-ptw-underground-22.md) were held, posted a sneak peek of the revamped PTW arena on his Instagram profile @lukasz_prezes_okonski.
+Breaking the silence, Pawłowski promised that the Ryucon show will be a new opening for PTW.
+The non-televised show included many new faces, both from [PTW Academy](@/o/ptw-academy.md) and foreign free agents.
+During the show, Łukasz "Prezes" Okoński, owner of Dworek Pod Platanem where [Underground 21](@/e/ptw/2024-04-13-ptw-underground-21.md) was held, was announced as PTW's new co-owner.
+This change was not reflected in official registration documents (as of August 21 2024), where Pawłowski remains the sole shareholder and director of PTW's commercial entity, and the sole board member of PTW's other legal entity, a non-profit association.
+Nevertheless, Okoński's increased involvement was noticeable, as he was actively promoting PTW on social media.
+
+On August 14, 2024, Pawłowski hosted a show for the local TV channel TVT, titled "Czas na Wrestling" (_Time for Wrestling_).
+It featured a panel where Pawłowski led the discussion with two guests: Okoński, who commented on his increased involvement, and [Spartan](@/w/spartan.md) who was asked mostly about the technical aspects of wrestling.
+
+#### Post-Ryucon: New venue
+
+PTW's third [Ryucon](@/e/ptw/2024-07-07-ptw-x-ryucon.md) show also saw the announcement of PTW Summer Camp, culminating with [another show](@/e/ptw/2024-08-25-ptw-underground-22.md), once again held in Kozłów, which now appeared to be PTW's new base of operations.
+On August 15, 2024, Okoński posted a sneak peek of the revamped PTW arena on his Instagram profile @lukasz_prezes_okonski.
 The venue is divided in two by a set of curtains. Workout equipment can be found in one section, while the other features a wrestling ring, a number of tables and wall decorations depicting major PTW characters like [Diana](@/w/diana-strong.md), [Spartan](@/w/spartan.md), [Puncher](@/w/puncher.md) and Babathunder.
 
 ## Polish wrestling scene

--- a/content/w/goblin.md
+++ b/content/w/goblin.md
@@ -3,4 +3,6 @@ title = "Goblin"
 template = "talent_page.html"
 [taxonomies]
 country = ["PL"]
+[extra.gallery]
+1 = { path = "goblin.jpg", caption = "Goblin before his Wild West-themed match at [Miasto Bezprawia](@/e/ppw/2024-02-10-ppw-miasto-bezprawia.md).", source = "Official PpW Facebook" }
 +++

--- a/content/w/isnorr.md
+++ b/content/w/isnorr.md
@@ -5,4 +5,6 @@ template = "talent_page.html"
 country = ["PL"]
 [extra]
 career_aliases = ["Norris"]
+[extra.gallery]
+1 = { path = "isnorr.jpg", caption = "Isnorr towering over [Goblin](@/w/goblin.md) and Benny Bacchus at [Ewenement Haze](@/e/ppw/2024-04-20-ppw-ewenement-haze.md).", source = "Official PpW Facebook" }
 +++


### PR DESCRIPTION
Źródło:
https://mywrestling.com.pl/ptw-underground-22-face-off-wyniki-live/

Na razie Alex Brave zalinkowany jako Sędzia Rafał, póki nie ma klepniętego #347.