### PR TITLE
Posters and extra pics for DFW

### DIFF
--- a/content/e/dfw/2016-08-20-dfw-tournament-of-dreams-2.md
+++ b/content/e/dfw/2016-08-20-dfw-tournament-of-dreams-2.md
@@ -6,6 +6,10 @@ authors = ["Krzysztof Zych"]
 chronology = ["dfw"]
 [extra]
 city = "Toruń"
+[extra.gallery.poster]
+path = "dfw-tournament-of-dreams-poster.webp"
+caption = "Official poster"
+source = "Facebook @DreamFactoryWrestling"
 +++
 
 The Tournament of Dreams was a two-part event to crown the first ever [DFW](@/o/dfw.md) champion. The first round of matches was held in [June](@/e/dfw/2016-06-11-dfw-tournament-of-dreams-1.md), and the finals (this event) on Saturday August 20, 2016.

--- a/content/e/dfw/2017-02-14-dfw-love-hurts-wrestling-even-more.md
+++ b/content/e/dfw/2017-02-14-dfw-love-hurts-wrestling-even-more.md
@@ -5,6 +5,10 @@ template = "event_page.html"
 chronology = ["dfw"]
 [extra]
 city = "Toruń"
+[extra.gallery.poster]
+path = "dfw-love-hurts-poster.webp"
+caption = "Official poster"
+source = "Facebook @DreamFactoryWrestling"
 +++
 
 This was a Valentine's day event from 2017. Held once again in ZSGH which previously saw wrestling during its [Open Days](@/e/dfw/2016-04-22-dfw-zsgh-open-days.md), this event is notable for being the debut of [DFW's](@/o/dfw.md) first and only female wrestler Hekate.

--- a/content/e/dfw/2017-04-23-dfw-recent-dreams.md
+++ b/content/e/dfw/2017-04-23-dfw-recent-dreams.md
@@ -6,6 +6,14 @@ authors = ["Krzysztof Zych"]
 chronology = ["dfw"]
 [extra]
 city = "Toruń"
+[extra.gallery.poster]
+path = "dfw-recent-dreams-poster-2.webp"
+caption = "Official poster, with [Revage](@/w/rafael-kid.md) and [Chris Hunter](@/w/chris-hunter.md)"
+source = "Facebook @DreamFactoryWrestling"
+[extra.gallery.sm-graphic]
+path = "dfw-recent-dreams-poster.webp"
+caption = "Social media graphic announcing the event"
+source = "Facebook @DreamFactoryWrestling"
 +++
 
 [DFW's](@/o/dfw.md) Recent Dreams was held on Sunday, April 23 2017, once again in the sports hall of Toruń's university campus. The previous event to be held there was the second half of [Tournament of Dreams](@/e/dfw/2016-08-20-dfw-tournament-of-dreams-2.md).

--- a/content/e/dfw/2017-06-17-dfw-crosswords-city.md
+++ b/content/e/dfw/2017-06-17-dfw-crosswords-city.md
@@ -6,6 +6,10 @@ authors = ["Krzysztof Zych"]
 chronology = ["dfw"]
 [extra]
 city = "Krzyżówki"
+[extra.gallery.poster]
+path = "dfw-crosswords-city-plakat.webp"
+caption = "Official poster"
+source = "Facebook @DreamFactoryWrestling"
 +++
 
 Crosswords City by [Dream Factory Wrestling](@/o/dfw.md) was a sideshow accompanying a community festival, the Firemen's Picnic. It took place on Saturday, June 17, 2017 in Krzyżówki, a village about 20&nbsp;km north of Włocławek, in the Kuyavia-Pomerania region of Poland. The event was held outdoors, on the village's sports and events grounds neighboring the local Fire brigade's location.

--- a/content/e/dfw/2017-09-30-dfw-anniversary.md
+++ b/content/e/dfw/2017-09-30-dfw-anniversary.md
@@ -6,6 +6,10 @@ authors = ["Krzysztof Zych"]
 chronology = ["dfw"]
 [extra]
 city = "Toruń"
+[extra.gallery.poster]
+path = "dfw-anniversary-poster.webp"
+caption = "Official poster"
+source = "Facebook @DreamFactoryWrestling"
 +++
 
 Anniversary was an event that celebrated DFW's second anniversary, held on Saturday, September 30, 2017. The name was a bit of a stretch as it was the second anniversary, but only when counting from [DFW @ Kaszczorek](@/e/dfw/2015-09-20-dfw-showcase.md) which was DFW's second show rather than first. Counting from the first show, the second anniversary was instead much closer to [Crosswords City](@/e/dfw/2017-06-17-dfw-crosswords-city.md).

--- a/content/e/dfw/2018-06-09-dfw-crosswords-city-2.md
+++ b/content/e/dfw/2018-06-09-dfw-crosswords-city-2.md
@@ -5,6 +5,10 @@ template = "event_page.html"
 chronology = ["dfw"]
 [extra]
 city = "Krzyżówki"
+[extra.gallery.poster]
+path = "dfw-crosswords-city-2-poster.webp"
+caption = "Official poster"
+source = "Facebook @DreamFactoryWrestling"
 +++
 
 The final event from [DFW](@/o/dfw.md) was held almost three years after their first one, on Saturday, June 9th 2018. The venue and occasion was once more a community festival in Krzyżówki, where the previous [Crosswords City](@/e/dfw/2017-06-17-dfw-crosswords-city.md) took place.

--- a/content/o/dfw.md
+++ b/content/o/dfw.md
@@ -17,7 +17,7 @@ caption = """
 DFW wrestlers reimagined as characters from Powerpuff Girls.
 Top row: [Chris Hunter](@/w/chris-hunter.md), [Revage](@/w/rafael-kid.md), [PJ Blake](@/w/pj-blake.md);
 second row: [Norris](@/w/isnorr.md), [Direk](@/w/direk.md), [Corin Mear](@/w/corin-mear.md);
-last row: [Rob Scaffold](@/w/rob-scaffold.md), [Charlie](@/w/madman-charlie.md), Malmo Buruto.
+last row: [Rob Scaffold](@/w/rob-scaffold.md), [Charlie](@/w/madman-charlie.md), [Malmo Buruto](@/w/malmo-buruto.md).
 This was sold in DFW's online merch store as T-shirts and a cup, and the characters were used on social media for some events in 2017. Norris wore a T-shirt with his character, as part of his ring gear at some point.
 """
 source = "dreamfactorywrestling.cupsell.pl"

--- a/content/o/dfw.md
+++ b/content/o/dfw.md
@@ -10,6 +10,17 @@ toclevel = 3
 [extra.gallery]
 1 = { path = "pas-dfw.jpg", caption = "The damaged DFW Championship belt plate. As of 2024, it was kept at [PpW](@/o/ppw.md)'s training facilities."}
 2 = { path = "mjt1-pas-dfw.jpg", caption = "A fan holding the DFW Championship belt at [PpW Mistrz Jest Tylko Jeden](@/e/ppw/2022-03-12-ppw-mistrz-jest-tylko-jeden.md)"}
+pas = { path = "pas-dfw-caly.webp", caption = "The DFW Championship belt in good condition.", source = "Facebook @DreamFactoryWrestling" }
+[extra.gallery.atomowki]
+path = "dfw-atomowki.webp"
+caption = """
+DFW wrestlers reimagined as characters from Powerpuff Girls.
+Top row: [Chris Hunter](@/w/chris-hunter.md), [Revage](@/w/rafael-kid.md), [PJ Blake](@/w/pj-blake.md);
+second row: [Norris](@/w/isnorr.md), [Direk](@/w/direk.md), [Corin Mear](@/w/corin-mear.md);
+last row: [Rob Scaffold](@/w/rob-scaffold.md), [Charlie](@/w/madman-charlie.md), Malmo Buruto.
+This was sold in DFW's online merch store as T-shirts and a cup, and the characters were used on social media for some events in 2017. Norris wore a T-shirt with his character, as part of his ring gear at some point.
+"""
+source = "dreamfactorywrestling.cupsell.pl"
 +++
 
 Dream Factory Wrestling was a short-lived wrestling organization from Toruń, established in 2015.


### PR DESCRIPTION
This pull request adds official posters and social media graphics to various event pages for Dream Factory Wrestling (DFW) and updates the gallery in the DFW organization page. The most important changes include adding new images and captions to enhance the visual content of the event pages, and updating the gallery section in the organization page to include new images and descriptions.

Enhancements to event pages:

* [`content/e/dfw/2016-08-20-dfw-tournament-of-dreams-2.md`](diffhunk://#diff-d10d07cf7217df069c50306745edf050c5fa4f66a5ab73492f768e6282d6f4feR9-R12): Added an official poster with a caption and source.
* [`content/e/dfw/2017-02-14-dfw-love-hurts-wrestling-even-more.md`](diffhunk://#diff-bca759a418ad4d7978face47632fc737808c2294595a2aadc62f220cd950829cR8-R11): Added an official poster with a caption and source.
* [`content/e/dfw/2017-04-23-dfw-recent-dreams.md`](diffhunk://#diff-b9e7ebd290e0c36712997bccd69da073e4fef2ee2f7812428f3b4e7263e542f2R9-R16): Added an official poster and a social media graphic with captions and sources.
* [`content/e/dfw/2017-06-17-dfw-crosswords-city.md`](diffhunk://#diff-d36e4a56dd00df3db735c9a619659e2d4eb241989c80408414ab41a806671be5R9-R12): Added an official poster with a caption and source.
* [`content/e/dfw/2017-09-30-dfw-anniversary.md`](diffhunk://#diff-1e516a830c08c2aa304549eff5eae3e89cddbc6e7de05398271e39a46521bfe6R9-R12): Added an official poster with a caption and source.
* [`content/e/dfw/2018-06-09-dfw-crosswords-city-2.md`](diffhunk://#diff-af9d5d7dba39da5b7817e9be7f0b2204c5e43ddc019a8e9c1d860f5699e11c47R8-R11): Added an official poster with a caption and source.

Updates to the organization page:

* [`content/o/dfw.md`](diffhunk://#diff-098c619dcadfade4df8de01f466aecd094bdd99ed0f413d55065fe317e3cbb0dR13-R23): Added a new image of the DFW Championship belt in good condition and a new image of DFW wrestlers reimagined as characters from Powerpuff Girls, with detailed captions and sources.