### PR TITLE
Alternative for long galleries: manifest file.

### DIFF
--- a/content/w/justin-gallery.toml
+++ b/content/w/justin-gallery.toml
@@ -1,0 +1,21 @@
+1 = { path = 'jj1.png', caption = "Justin explains his quiet exit. Background: PTW's dismissal of [Jacob Crane](@/w/jacob-crane.md)" }
+2 = { path = 'jj2.png', caption = "[LEGENDS](@/e/ptw/2022-11-26-ptw-3-legends.md) was the breaking point. Background: Joy winning over Axel Fox at that event."}
+3 = { path = 'jj3.png', caption= "Justin is done fighting abroad, wants to follow the money. Background: Joy winning the NSW National title in Dresden."}
+4 = { path = 'jj4.png', caption = "Addressing [PpW](@/o/ppw.md)'s image issues. Background: Joy vs Axel Fox at LEGENDS."}
+6 = { path = 'jj6.png', caption = "Justin's most positive thing in PTW was his friend [Axel Fox](@/w/axel-fox.md). Background: Fox hugging Joy."}
+7 = { path = 'jj7.png', caption = "No kayfabe needed. Background: A PTW Underground show."}
+8 = { path = 'jj8.png', caption = "The drama that happened has acumulated over the years. Background: Joy vs [Nitro](@/w/nitro.md) at PTW Underground 3"}
+9 = { path = 'jj9.png', caption = "Too many promises were made. Background: Joy and Fox at a PTW Underground show."}
+10 = { path = 'jj10.png', caption = "Everything was public, but not all was sunshine and rainbows. Background: crowd at a PTW Underground show, holding a banner that reads 'I spit at Joy'"}
+11 = { path = 'jj11.png', caption = "Everything can be a storyline. Background: Fox receives a birthday cake, at ringside with fans present."}
+12 = { path = 'jj12.png', caption = "Pawłowski burning bridges with Joy. Background: social media apps showing now-missing friend and follower status between Joy and Pawłowski."}
+13 = { path = 'jj13.png', caption = "Joy is on a hiatus and focusing on Ninja (Ninja Warrior TV show). Background: Fox being rolled up at a PTW Underground show."}
+14 = { path = 'jj14.png', caption = "Joy will not return at [Gold Rush](@/e/ptw/2024-02-03-ptw-5-gold-rush.md), negotiations are over. Background: Joy stares down Fox at [Ryucon 2022](@/e/ptw/2022-07-31-ptw-x-ryucon.md)"}
+15 = { path = 'jj15.png', caption = "Joy quit DDW because MZW required less travel. Background: Joy vs [Shadow](@/w/shadow.md) at [MZW Champions War II](@/e/mzw/2016-01-10-mzw-champions-war-2.md)"}
+16 = { path = 'jj16.png', caption = "Quitting because PTW stagnated or maybe even regressed, and did not pay enough."}
+17 = { path = 'jj17.png', caption = "Will PTW stagnate even more? Background: Joy's entrance at Ryucon"}
+18 = { path = 'jj18.png', caption = "Pawłowski is responsible for the uninspired booking. Background: Joy and Pawłowski at a PTW Underground show."}
+19 = { path = 'jj19.png', caption = "When did 'break' become 'sayonara'? Background: Joy handing over his headband to Fox at a PTW underground show."}
+20 = { path = 'jj20.png', caption = "The wrestling scene in Poland may have already peaked. Background: Joy pinning Nitro at PTW Underground 3."}
+21 = { path = 'jj21.png', caption = "Is PTW declining, are the audience numbers dropping? Joy thinks PTW failed to use Kinguin's sponsorship well. Background: Joy's entrance at a PTW Underground show."}
+22 = { path = 'jj22.png', caption = "What about you and Fox? Return to PTW unlikely. Background: Fox and Joy enjoying pizza."}

--- a/content/w/justin-joy.md
+++ b/content/w/justin-joy.md
@@ -5,27 +5,7 @@ career_aliases = ["Justin"]
 [taxonomies]
 country = ["PL"]
 [extra.gallery]
-1 = { path = 'jj1.png', caption = "Justin explains his quiet exit. Background: PTW's dismissal of [Jacob Crane](@/w/jacob-crane.md)" }
-2 = { path = 'jj2.png', caption = "[LEGENDS](@/e/ptw/2022-11-26-ptw-3-legends.md) was the breaking point. Background: Joy winning over Axel Fox at that event."}
-3 = { path = 'jj3.png', caption= "Justin is done fighting abroad, wants to follow the money. Background: Joy winning the NSW National title in Dresden."}
-4 = { path = 'jj4.png', caption = "Addressing [PpW](@/o/ppw.md)'s image issues. Background: Joy vs Axel Fox at LEGENDS."}
-6 = { path = 'jj6.png', caption = "Justin's most positive thing in PTW was his friend [Axel Fox](@/w/axel-fox.md). Background: Fox hugging Joy."}
-7 = { path = 'jj7.png', caption = "No kayfabe needed. Background: A PTW Underground show."}
-8 = { path = 'jj8.png', caption = "The drama that happened has acumulated over the years. Background: Joy vs [Nitro](@/w/nitro.md) at PTW Underground 3"}
-9 = { path = 'jj9.png', caption = "Too many promises were made. Background: Joy and Fox at a PTW Underground show."}
-10 = { path = 'jj10.png', caption = "Everything was public, but not all was sunshine and rainbows. Background: crowd at a PTW Underground show, holding a banner that reads 'I spit at Joy'"}
-11 = { path = 'jj11.png', caption = "Everything can be a storyline. Background: Fox receives a birthday cake, at ringside with fans present."}
-12 = { path = 'jj12.png', caption = "Pawłowski burning bridges with Joy. Background: social media apps showing now-missing friend and follower status between Joy and Pawłowski."}
-13 = { path = 'jj13.png', caption = "Joy is on a hiatus and focusing on Ninja (Ninja Warrior TV show). Background: Fox being rolled up at a PTW Underground show."}
-14 = { path = 'jj14.png', caption = "Joy will not return at [Gold Rush](@/e/ptw/2024-02-03-ptw-5-gold-rush.md), negotiations are over. Background: Joy stares down Fox at [Ryucon 2022](@/e/ptw/2022-07-31-ptw-x-ryucon.md)"}
-15 = { path = 'jj15.png', caption = "Joy quit DDW because MZW required less travel. Background: Joy vs [Shadow](@/w/shadow.md) at [MZW Champions War II](@/e/mzw/2016-01-10-mzw-champions-war-2.md)"}
-16 = { path = 'jj16.png', caption = "Quitting because PTW stagnated or maybe even regressed, and did not pay enough."}
-17 = { path = 'jj17.png', caption = "Will PTW stagnate even more? Background: Joy's entrance at Ryucon"}
-18 = { path = 'jj18.png', caption = "Pawłowski is responsible for the uninspired booking. Background: Joy and Pawłowski at a PTW Underground show."}
-19 = { path = 'jj19.png', caption = "When did 'break' become 'sayonara'? Background: Joy handing over his headband to Fox at a PTW underground show."}
-20 = { path = 'jj20.png', caption = "The wrestling scene in Poland may have already peaked. Background: Joy pinning Nitro at PTW Underground 3."}
-21 = { path = 'jj21.png', caption = "Is PTW declining, are the audience numbers dropping? Joy thinks PTW failed to use Kinguin's sponsorship well. Background: Joy's entrance at a PTW Underground show."}
-22 = { path = 'jj22.png', caption = "What about you and Fox? Return to PTW unlikely. Background: Fox and Joy enjoying pizza."}
+manifest = "@/w/justin-gallery.toml"
 +++
 
 #### 2021-2023: Ninja Warrior Poland

--- a/templates/auto_lightbox.html
+++ b/templates/auto_lightbox.html
@@ -2,7 +2,12 @@
 <h2 id="gallery">Gallery</h2>
 <section>
   <ul class="gallery">
-    {% for key, item in page.extra.gallery %}
+    {% if page.extra.gallery.manifest %}
+      {% set gallery_items = load_data(path=page.extra.gallery.manifest) %}
+    {% else %}
+      {% set gallery_items = page.extra.gallery %}
+    {% endif %}
+    {% for key, item in gallery_items %}
       {% set path = item.path -%}
       {% set caption = item | get(key="caption", default="") -%} 
       <li>


### PR DESCRIPTION
Instead of listing the gallery items in the frontmatter, it can have a single key `manifest`, with its value a Zola-path pointing to a data file. This file can be in any supported textual format.

Zola-paths are resolved from content directory. So if a gallery manifest is in the `w/` folder next to a wrestler's article, the path is `"@/w/some-file.toml"`.

As a testbed, converted Justin Joy's gallery.