### PR TITLE
MZW Beatdown 2 - grafiki, zewnętrzna galeria

### DIFF
--- a/content/e/mzw/2017-02-18-mzw-beatdown-2-gallery.toml
+++ b/content/e/mzw/2017-02-18-mzw-beatdown-2-gallery.toml
@@ -1,0 +1,8 @@
+01 = { path = "plakat.webp", caption = "Official poster.", source = "Facebook @ManiacZoneWrestling" }
+02 = { path = "mzw-beatdown-2-foto-01", caption = "Marcus Monere", source = "doba.pl" }
+03 = { path = "mzw-beatdown-2-foto-02", caption = "Lider vs Prince Victor", source = "doba.pl" }
+04 = { path = "mzw-beatdown-2-foto-03", caption = "Asmund vs Stanisław Van Dobroniak", source = "doba.pl" }
+05 = { path = "mzw-beatdown-2-foto-04", caption = "Skullevil vs Jędryś Bułecka", source = "doba.pl" }
+06 = { path = "mzw-beatdown-2-foto-05", caption = "Posse in Effect", source = "doba.pl" }
+07 = { path = "mzw-beatdown-2-foto-06", caption = "Hexia", source = "doba.pl" }
+08 = { path = "mzw-beatdown-2-foto-07", caption = "Franz Engel vs Shadow", source = "doba.pl" }

--- a/content/e/mzw/2017-02-18-mzw-beatdown-2.md
+++ b/content/e/mzw/2017-02-18-mzw-beatdown-2.md
@@ -7,7 +7,7 @@ venue = ["bakara"]
 [extra]
 city = "Wrocław"
 [extra.gallery]
-1 = { path = "plakat.webp", caption = "Official poster.", source = "Facebook @ManiacZoneWrestling" }
+manifest = "@/e/mzw/2017-02-18-mzw-beatdown-2-gallery.toml"
 +++
 
 {% card() %}


### PR DESCRIPTION
https://doba.pl/wroclaw/galeria/15975/45719/cat/13?fbclid=IwZXh0bgNhZW0CMTAAAR3Wol9ipdXtUUovY507gOmasaTElN3o9fjMtK3vU4tXr9GZivwAxQNrLvM_aem_ck7TLrdHRouZAEUo3O9_FA