### PR TITLE
Pasy - ujednolicenie nagłówków

### DIFF
--- a/content/c/ddw-international-championship.md
+++ b/content/c/ddw-international-championship.md
@@ -33,7 +33,9 @@ The plate also contains some simple black ornaments and three red banners: the t
 the middle one with the word "International", and the bottom one with "Champion" engraved.
 Both sides of the Championship also feature sideplates - one with a big Polish flag, and the other with the DDW logo on it. The plates are attached to a standard black belt.
 
-## Champion #1: Joe Legend
+## Title history
+
+### Champion #1: Joe Legend
 
 {% free_card() %}
 - - '[Joe Legend](@/w/joe-legend.md)'
@@ -67,7 +69,7 @@ Both sides of the Championship also feature sideplates - one with a big Polish f
 Following DDW #7 the title was vacated and the promotion had no champion for 890 days.
 
 
-## Champion #2: Kamil Aleksander
+### Champion #2: Kamil Aleksander
 
 {% free_card() %}
 - - '[Kamil Aleksander](@/w/kamil-aleksander.md)'

--- a/content/c/kpw-old-town-championship.md
+++ b/content/c/kpw-old-town-championship.md
@@ -37,7 +37,9 @@ The championship belt also contains two pairs of sideplates with the KPW logo on
 * Most reigns: N/A
 * Longest reign: [David Oliwa](@/w/david-oliwa.md) (1190 days)
 
-## Champion #1: Greg
+## Title history
+
+### Champion #1: Greg
 
 {% free_card() %}
 - - '[Greg](@/w/greg.md)'
@@ -79,7 +81,7 @@ The championship belt also contains two pairs of sideplates with the KPW logo on
 
 **TOTAL:** 692 days.
 
-## Champion #2: David Oliwa
+### Champion #2: David Oliwa
 
 {% free_card() %}
 - - 'David Oliwa'
@@ -129,7 +131,7 @@ The championship belt also contains two pairs of sideplates with the KPW logo on
 
 Over 500 days of Oliwa's title run fell on the COVID-19 pandemic.
 
-## Champion #3: Rosetti
+### Champion #3: Rosetti
 
 {% free_card() %}
 - - 'Rosetti'
@@ -170,7 +172,7 @@ Over 500 days of Oliwa's title run fell on the COVID-19 pandemic.
 
 At Arena 20, Darius won the match by count-out, thus Rosetti retained the title.
 
-## Champion #4: Chemik
+### Champion #4: Chemik
 
 {% free_card() %}
 - - Chemik

--- a/content/c/kpw-tag-team-championship.md
+++ b/content/c/kpw-tag-team-championship.md
@@ -19,7 +19,9 @@ The KPW Tag Team Championship is the Tag Team division championship of [Kombat P
 * Most reigns: N/A
 * Longest reign: The Hunt: Primate & Wild Boar (959 days)
 
-## Champions #1: Sawicki & Victor Rosetti
+## Title history
+
+### Champions #1: Sawicki & Victor Rosetti
 
 {% free_card() %}
 - - "[Sawicki](@/w/sawicki.md), [Victor Rosetti](@/w/rosetti.md)"
@@ -46,7 +48,7 @@ The KPW Tag Team Championship is the Tag Team division championship of [Kombat P
 
 **TOTAL:** 455 days.
 
-## Champions #2: The Hunt: Primate & Wild Boar
+### Champions #2: The Hunt: Primate & Wild Boar
 
 {% free_card() %}
 - - "The Hunt: Primate, Wild Boar"
@@ -69,7 +71,7 @@ Over 500 days of The Hunt's title run fell on the COVID-19 pandemic.
 
 Wild Boar was injured a couple of days before the event and was replaced by Tommy Freeman. The Tag Team belts were therefore vacated during the show.
 
-## Champions #3: Die Ordnung: Hans Schulte & Veit Müller
+### Champions #3: Die Ordnung: Hans Schulte & Veit Müller
 
 {% free_card() %}
 - - "Die Ordnung: [Hans Schulte](@/w/hans-schulte.md), [Veit Müller](@/w/veit-mueller.md)"
@@ -98,7 +100,7 @@ Wild Boar was injured a couple of days before the event and was replaced by Tomm
 
 **TOTAL:** 335 days.
 
-## Champions #4: The Fux Brothers: Filip Fux & Michał Fux
+### Champions #4: The Fux Brothers: Filip Fux & Michał Fux
 
 {% free_card() %}
 - - "The Fux Brothers: Filip Fux, Michał Fux"

--- a/content/c/mcw-championship.md
+++ b/content/c/mcw-championship.md
@@ -11,7 +11,9 @@ toclevel=2
 
 MCW Championship is [Mine City Wrestling's](@/o/mcw.md) only title. Despite MCW starting years earlier, the belt was only introduced in late 2019 due lack of funds and personal difficulties, as well as the promotion's wish to have the best-looking title possible.
 
-## Champion #1: Johny Vegas
+## Title history
+
+### Champion #1: Johny Vegas
 
 {% free_card() %}
 - - '[Johny Vegas](@/w/johny-vegas.md)'
@@ -30,7 +32,7 @@ MCW Championship is [Mine City Wrestling's](@/o/mcw.md) only title. Despite MCW 
 
 **TOTAL:** 1127 days.
 
-## Champion #2: RAV
+### Champion #2: RAV
 
 {% free_card() %}
 - - 'RAV'

--- a/content/c/ppw-championship.md
+++ b/content/c/ppw-championship.md
@@ -41,7 +41,9 @@ In February 2021 Mister Z introduced a new version of the Championship, this tim
 
 At [Hardcore Friday 2](@/e/ppw/2024-09-20-ppw-hardcore-friday-2.md) [Gustav Gryffin](@/w/gustav-gryffin.md) introduced a new, personalized variation of the PpW Championship. It was rather similar in design to the previous version, with the main differences being the added colourful details (such as a blue and red PpW logo), white belt instead of a black one, and golden tips with PpW logo at the ends of the belt itself.
 
-## Champion #1: Mister Z
+## Title history
+
+### Champion #1: Mister Z
 
 {% free_card() %}
 - - '[Mister Z](@/w/mister-z.md)(c)'
@@ -60,7 +62,7 @@ At [Hardcore Friday 2](@/e/ppw/2024-09-20-ppw-hardcore-friday-2.md) [Gustav Gryf
 
 Mister Z had been the PpW Champion since the backyard era, however the available sources are inconsistent: the PpW Wiki's [championship entry](https://ppw-fandom.tpwres.pl/ppw-championship) states that Mister Z won the title at the Neomania V Kick Off on 9.09.2017, but the [Neomania V entry](https://ppw-fandom.tpwres.pl/ppw-neomania-v) gives a different date: 25.09.2016. Thus, the above title run only counts the days since the promotion went pro.
 
-## Champion #2: Osamu
+### Champion #2: Osamu
 
 {% free_card() %}
 - - '[Osamu](@/w/osamu.md)'
@@ -74,7 +76,7 @@ Mister Z had been the PpW Champion since the backyard era, however the available
 
 Following Ledwo Legalne, the Championship was vacated for 182 days.
 
-## Champion #3: Biesiad Strong (1st run)
+### Champion #3: Biesiad Strong (1st run)
 
 {% free_card() %}
 - - 'Biesiad Strong'
@@ -119,7 +121,7 @@ Following Ledwo Legalne, the Championship was vacated for 182 days.
 
 **TOTAL:** 462 days.
 
-## Champion #4: Steve Kuningas
+### Champion #4: Steve Kuningas
 
 {% free_card() %}
 - - 'Steve Kuningas'
@@ -138,7 +140,7 @@ Following Ledwo Legalne, the Championship was vacated for 182 days.
 
 Steve Kuningas made at least one appearance with the PpW Championship outside of Poland (see the gallery), but no international defences of the title are known to have taken place.
 
-## Champion #5: Bill Feager
+### Champion #5: Bill Feager
 
 {% free_card() %}
 - - '[Bill Feager](@/w/feager.md)'
@@ -161,7 +163,7 @@ Steve Kuningas made at least one appearance with the PpW Championship outside of
 
 **TOTAL:** 119 days.
 
-## Champion #6: Biesiad Strong (2nd run)
+### Champion #6: Biesiad Strong (2nd run)
 
 {% free_card() %}
 - - 'Biesiad Strong'
@@ -181,7 +183,7 @@ Steve Kuningas made at least one appearance with the PpW Championship outside of
 
 Immediately after Biesiad won the title match at Ledwo Legalne IV, Mister Z granted the #1 Contender Gustav Gryffin his title shot.
 
-## Champion #7: Gustav Gryffin
+### Champion #7: Gustav Gryffin
 
 {% free_card() %}
 - - '[Gustav Gryffin](@/w/gustav-gryffin.md)'

--- a/content/c/ppw-european-ultraviolent-championship.md
+++ b/content/c/ppw-european-ultraviolent-championship.md
@@ -26,7 +26,9 @@ Sideplates are simply two small circular sawblades, and instead of a classic pin
 * Most reigns: Johnny Blade (2)
 * Longest reign: [Stanisław Van Dobroniak](@/w/stanislaw-van-dobroniak.md) (637 days)
 
-## Champion #1: Johnny Blade (1st run)
+## Title history
+
+### Champion #1: Johnny Blade (1st run)
 
 {% free_card() %}
 - - '[Johnny Blade](@/w/johnny-blade.md)'
@@ -44,8 +46,7 @@ Sideplates are simply two small circular sawblades, and instead of a classic pin
 
 **TOTAL:** 112 days.
 
-
-## Champion #2: Stanisław Van Dobroniak
+### Champion #2: Stanisław Van Dobroniak
 
 {% free_card() %}
 - - 'Stanisław Van Dobroniak'
@@ -83,7 +84,7 @@ Sideplates are simply two small circular sawblades, and instead of a classic pin
 In addition to the above, Dobroniak also defended the title abroad: twice in STHLM Wrestling, in [November 2022](https://www.cagematch.net/?id=1&nr=355802) against Jack Jones and [December 2023](https://www.cagematch.net/?id=1&nr=381560) against Lexi Luxx, and once in Freedom Pro Wrestling against Mange Mörbult, in [January 2024](https://www.cagematch.net/?id=1&nr=389324).
 
 
-## Champion #3: Johnny Blade (2nd run)
+### Champion #3: Johnny Blade (2nd run)
 
 {% free_card() %}
 - - 'Johnny Blade'


### PR DESCRIPTION
Różne artykuły miały nagłówki różnych poziomów, ujednoliciłem, żeby zachować jakąś konsekwencję.