### PR TITLE
PpW Co za noc - update karty

### DIFF
--- a/content/e/ppw/2024-10-26-ppw-co-za-noc.md
+++ b/content/e/ppw/2024-10-26-ppw-co-za-noc.md
@@ -32,8 +32,10 @@ city = "Warszawa"
 - - '[Alex Arthur](@/w/alex-arthur.md)'
   - '[Bill Feager](@/w/feager.md)'
   - nc: upcoming
-- - '[Shadow](@/w/shadow.md)'
+- - '[Marcelito](@/w/marcelito.md)'
   - '_rookie_ Oskar'
+  - '[Sambor](@/w/sambor.md)'
+  - '[Aron Wake](@/w/aron-wake.md)'
   - nc: upcoming
 {% end %}
 


### PR DESCRIPTION
https://www.facebook.com/OficjalnePPW/posts/pfbid0RRa4bMRncbRp5nqqSw9WFs45UGmyFnnLppEX71fvbTia3f2krinZQU5ze36iDWsal

(Tymczasem post zapowiadający walkę Shadow vs adept Oskar po cichutku zniknął.)