### PR TITLE
Dates in event list can no longer shrink

### DIFF
--- a/sass/_tables.sass
+++ b/sass/_tables.sass
@@ -10,6 +10,9 @@ ul.event-list
     gap: 0.5rem
     break-inside: avoid
 
+    time
+      flex-shrink: 0
+
 
 ul.talentlist-section
   list-style-type: none

--- a/templates/year_list_section.html
+++ b/templates/year_list_section.html
@@ -32,11 +32,12 @@ Add these events to your calendar by subscribing to <a href="{{ get_url(path="ca
 {% endblock content %}
 {% block extra_head %}
 <script defer type="module">
-import { extractUpcoming, createSection } from '/events.js'
+import { extractUpcoming, createSection, cleanEmptyYears } from '/events.js'
 document.addEventListener('DOMContentLoaded', () => {
   const events = extractUpcoming()
   const list = document.querySelector('ul.event-list')
   createSection(events, list, 'h2')
+  cleanEmptyYears('h2')
 })
 </script>
 {% endblock %}


### PR DESCRIPTION
Fixes #593.

This did not happen on Firefox, but on Chromium browsers the date could be flex-shrunk if the event name was extra long. This is now fixed. Also as noticed, an empty year section wasn't properly removed on the main event list, and now it is.

BTW: the year 9999 event from #594 did not show on the org page event list. That is by design: the `events_from_org_taxonomy` template has a year list start and end values, set from the front matter OR with some reasonable defaults. The reasonable end year is 2099 and this event was way past it. Since this can be easily set on the org page frontmatter, there's no need to fix it.