### PR TITLE
KPW Arena 26 - info o turnieju

### DIFF
--- a/content/e/kpw/2024-11-15-kpw-arena-26.md
+++ b/content/e/kpw/2024-11-15-kpw-arena-26.md
@@ -11,4 +11,13 @@ city = "Gdynia"
 
 KPW Arena 26 is the upcoming show by [Kombat Pro Wrestling](@/o/kpw.md), set to return to [Nowy Harem](@/v/atlantic-nh-gdynia.md) after a brief change of venue for [Godzina Zero 2024](@/e/kpw/2024-09-07-kpw-godzina-zero-2024.md).
 
-{{ skip_card() }}
+Chairman [Krystian Malinowski](@/w/krystian-malinowski.md) [announced][yt-wyscig] an eight-man tournament for the [KPW Championship](@/c/kpw-championship.md) contendership, with the first four quarter final matches to take place at this event.
+
+{% card(predicted=true) %}
+- - '[Hans Schulte](@/w/hans-schulte.md)'
+  - '???'
+  - c: [KPW Championship](@/c/kpw-championship.md)
+    nc: upcoming
+{% end %}
+
+[yt-wyscig]: https://www.youtube.com/watch?v=SV6nnBFO3Iw

--- a/content/e/kpw/2024-11-15-kpw-arena-26.md
+++ b/content/e/kpw/2024-11-15-kpw-arena-26.md
@@ -16,7 +16,7 @@ Chairman [Krystian Malinowski](@/w/krystian-malinowski.md) [announced][yt-wyscig
 {% card(predicted=true) %}
 - - '[Hans Schulte](@/w/hans-schulte.md)'
   - '???'
-  - c: [KPW Championship](@/c/kpw-championship.md)
+  - c: '[KPW Championship](@/c/kpw-championship.md)'
     nc: upcoming
 {% end %}
 


### PR DESCRIPTION
Plus Hans Schulte, zapowiedziany przez Malinowskiego w filmiku.