### PR TITLE
A nicer article index.

### DIFF
--- a/content/a/_index.md
+++ b/content/a/_index.md
@@ -1,5 +1,5 @@
 +++
 title = "Articles"
-template = "blog_index.html"
+template = "article_index.html"
 sort_by = "weight"
 +++

--- a/sass/custom.sass
+++ b/sass/custom.sass
@@ -308,8 +308,10 @@ a:hover
     flex-wrap: nowrap
     overflow-x: auto
     gap: 1rem
+    padding: 1rem 0
+
     &:not(:last-child)
-      padding: 1rem 0 2rem
+      padding-bottom: 2rem
       border-bottom: .3rem solid var(--dark-blue)
 
     .title
@@ -324,6 +326,17 @@ a:hover
 
       img
         min-width: 16rem
+
+  @media only screen and (max-width: 720px)
+    article
+      .title
+        font-size: 1.75rem
+
+      .cover-image
+        flex-basis: 8rem
+
+        img
+          min-width: 8rem
 
 @media only screen and (max-width: 720px)
   .pagination .links span

--- a/sass/custom.sass
+++ b/sass/custom.sass
@@ -322,6 +322,9 @@ a:hover
       flex-grow: 0
       flex-shrink: 0
 
+      img
+        min-width: 16rem
+
 @media only screen and (max-width: 720px)
   .pagination .links span
     display: inline-block

--- a/sass/custom.sass
+++ b/sass/custom.sass
@@ -300,6 +300,28 @@ a:hover
     color: transparent
     white-space: nowrap
 
+.article-list
+  margin-top: 1rem
+
+  article
+    display: flex
+    flex-wrap: nowrap
+    overflow-x: auto
+    gap: 1rem
+    &:not(:last-child)
+      padding: 1rem 0 2rem
+      border-bottom: .3rem solid var(--dark-blue)
+
+    .title
+      font-size: 2rem
+      font-weight: bold
+      color: var(--dark-blue)
+
+    .cover-image
+      flex-basis: 16rem
+      flex-grow: 0
+      flex-shrink: 0
+
 @media only screen and (max-width: 720px)
   .pagination .links span
     display: inline-block

--- a/templates/article_index.html
+++ b/templates/article_index.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% import "macros/articles.html" as articles %}
+
+{% block content %}
+  <h1>{{ section.title }}</h1>
+
+  <section class="article-list">
+    {% for page in section.pages %}
+      <article>
+        {{ articles::cover(article=page) | safe }}
+        <div class="blurb">
+          <a class="title" href="{{ page.permalink }}">{{ page.title }}</a>
+          {{ page.summary | safe }}
+          <a class="continue" href="{{ page.permalink }}">Continue reading</a>
+        </div>
+      </article>
+    {% endfor %}
+  </section>
+{% endblock %}

--- a/templates/macros/articles.html
+++ b/templates/macros/articles.html
@@ -1,0 +1,23 @@
+{% macro cover(article) %}
+  <div class="cover-image">
+    {% if article.extra.gallery %}
+      {% if article.extra.gallery.manifest %}
+        {% set gallery_items = load_data(path=article.extra.gallery.manifest) %}
+      {% else %}
+        {% set gallery_items = article.extra.gallery %}
+      {% endif %}
+      {% set root = config.extra.gallery_root ~ article.path ~ "tn/" %}
+      {% for key, item in gallery_items %}
+        {% set path = item.path -%}
+        <a href="{{ article.permalink }}">
+          <img src="{{ root ~ path }}" />
+        </a>
+        {% break %}
+      {% endfor %}
+    {% else %}
+      <a href="{{ article.permalink }}">
+        <img src="{{ get_url(path='og-default.png') }}"/>
+      </a>
+    {% endif %}
+  </div>
+{% endmacro %}

--- a/templates/macros/articles.html
+++ b/templates/macros/articles.html
@@ -16,7 +16,7 @@
       {% endfor %}
     {% else %}
       <a href="{{ article.permalink }}">
-        <img src="{{ get_url(path='og-default.png') }}"/>
+        <img src="{{ get_url(path='ring.png') }}" />
       </a>
     {% endif %}
   </div>


### PR DESCRIPTION
Fixes #521.

Works best if an article has some sort of illustration, as it extracts the first one to use as cover image.
Otherwise, uses the site logo (ring with TPW letters).
