### PR TITLE
KPW Arena 26 - walka wieczoru

### DIFF
--- a/content/e/kpw/2024-11-15-kpw-arena-26.md
+++ b/content/e/kpw/2024-11-15-kpw-arena-26.md
@@ -12,7 +12,7 @@ hide_results = true
 1 = { path = "2024-11-15-kpw-arena-26-plakat.jpg", caption = "Official poster. Pictured left to right, top to bottom: [Hans Schulte](@/w/hans-schulte.md) & [Filip Fux](@/w/filip-fux.md); [Michał Fux](@/w/michal-fux.md); [Chemik](@/w/chemik.md) & [Rosetti](@/w/rosetti.md); [Eryk Lesak](@/w/eryk-lesak.md); [Red Scorpion](@/w/red-scorpion.md).", source = "kpwrestling.pl / Official KPW Facebook" }
 +++
 
-"Wyścig" (_The Race_) is the upcoming show by [Kombat Pro Wrestling](@/o/kpw.md), set to return to [Nowy Harem](@/v/atlantic-nh-gdynia.md) after a brief change of venue for [Godzina Zero 2024](@/e/kpw/2024-09-07-kpw-godzina-zero-2024.md).
+"Wyścig" (_The Race_) is the upcoming show by [Kombat Pro Wrestling](@/o/kpw.md), set to return to [Nowy Harem](@/v/atlantic-nh-gdynia.md) after a brief change of venue for [Godzina Zero 2024](@/e/kpw/2024-09-07-kpw-godzina-zero-2024.md). This is the first KPW event not to feature [Zefir](@/w/zefir.md) on the card since his debut at [Arena 17](@/e/kpw/2021-08-21-kpw-arena-17-odrodzenie.md).
 
 {% card(predicted=true) %}
 - - '[Filip Fux](@/w/filip-fux.md)'
@@ -28,7 +28,7 @@ hide_results = true
   - s: '[KPW Championship](@/c/kpw-championship.md) Contendership Qualifying Match'
     nc: upcoming
 - - '[Hans Schulte](@/w/hans-schulte.md)'
-  - '???'
+  - '[Red Scorpion](@/w/red-scorpion.md)'
   - c: '[KPW Championship](@/c/kpw-championship.md)'
     nc: upcoming
 {% end %}


### PR DESCRIPTION
Na razie nie aktualizuję teczki Zefira pod kątem obecności na wszystkich galach lub też jej braku, ponieważ na samym wydarzeniu może się jeszcze coś niespodziewanego wydarzyć.