### PR TITLE
Puncher vs Shida na Ryuconie 3

### DIFF
--- a/content/c/ptw-championship.md
+++ b/content/c/ptw-championship.md
@@ -75,11 +75,6 @@ The central plate shows a large globe, with a black rim and "Prime Time Wrestlin
     en: '[PTW#6: Total Blast From The Past](@/e/ptw/2024-05-11-ptw-6.md)'
     ed: 2024-05-11
 - - 'Puncher(c)'
-  - Miyagi Shida
-  - s: Puncher's Open Challenge
-    en: '[PTW x RyuCon 3](@/e/ptw/2024-07-07-ptw-x-ryucon.md)'
-    ed: 2024-07-07
-- - 'Puncher(c)'
   - '["Starboy" Nano Lopez](@/w/nano-lopez.md)'
   - s: Singles Match
     en: '[PTW Walczymy Dla Fundacji](@/e/ptw/2024-09-29-ptw-walczymy-dla-fundacji.md)'

--- a/content/e/ptw/2024-07-07-ptw-x-ryucon.md
+++ b/content/e/ptw/2024-07-07-ptw-x-ryucon.md
@@ -81,7 +81,6 @@ In a typical fashion for these ceremonies, wrestlers came out to random songs, n
 - - '[Puncher](@/w/puncher.md)'
   - '[Miyagi Shida](@/w/miyagi-shida.md)'
   - s: Puncher's open challenge
-    c: PTW Championship and WWA Championship
 - - '[Nano Lopez](@/w/nano-lopez.md)'
   - '[Erik Šlotíř](@/w/erik-slotir.md)'
 - - '[Vincent Caravaggio](@/w/vincent-caravaggio.md), Svedberg'


### PR DESCRIPTION
Jak napisałem na czacie, to był debiut Shidy, więc za szybko na title shota (jeszcze podwójnego), a poza tym na fancamie widać, że Puncher ze złotem tylko wchodził i tyle.