### PR TITLE
Non-authoritative matches

### DIFF
--- a/sass/_tables.sass
+++ b/sass/_tables.sass
@@ -181,6 +181,10 @@ details[open] + .card
     grid-template-rows: auto
     grid-column: span 3
 
+  .entry.unofficial, .entry.incomplete, .entry.predicted
+    .r
+      font-style: italic
+
   .entry:nth-child(odd)
     background: var(--accent-bg)
 

--- a/src/bin/matches.py
+++ b/src/bin/matches.py
@@ -41,17 +41,27 @@ def main():
             continue
 
         relative_path = path.relative_to(content_dir).as_posix()
+        predicted = card.params.get('predicted', False)
+        incomplete = card.params.get('incomplete', False)
+        unofficial = card.params.get('unofficial', False)
 
         for bout in card.matches:
-            all_bouts.append(
-                dict(
-                    d=bout.date or page.event_date,
-                    o=page.orgs,
-                    n=page.title,
-                    m=bout,
-                    p=relative_path
-                )
+            info = dict(
+                d=bout.date or page.event_date,
+                o=page.orgs,
+                n=page.title,
+                m=bout,
+                p=relative_path,
             )
+            if predicted:
+                info['tt'] = 'predicted'
+            elif incomplete:
+                info['tt'] = 'incomplete'
+            elif unofficial:
+                info['tt'] = 'unofficial'
+
+            all_bouts.append(info)
+
             for person in bout.all_names():
                 if not accepted_name(person.name): continue
                 bouts = appearances.setdefault(person.name, [])

--- a/templates/career_result_row.html
+++ b/templates/career_result_row.html
@@ -2,50 +2,43 @@
 {% set winner = row | first %}
 {% if final is object %}
   {% set others = row | slice(start=1, end=-1) %}
-  {% set title = final | get(key="c", default="") %}
-  {% set stip = final | get(key="s", default="") %}
+  {% set title = final.c | default(value="") %}
+  {% set stip = final.s | default(value="") %}
   {% set segment = final | get(key="g", default=false) %}
 {% else %}
   {% set others = row | slice(start=1) %}
-  {% set title = "" %}
-  {% set stip = "" %}
   {% set segment = false %}
+  {% set final = [] | group_by(key=0) %}
 {% endif %}
 {% set bodies = others | length %}
-{% if not stip %}
-  {% if title %}
-    {% set stip = "Match" %}
-  {% else %}
-    {% set stip = "Singles Match" %}
-  {% endif %}
+{% if title %}
+  {% set default_stip = "Match" %}
+{% else %}
+  {% set default_stip = "Singles Match" %}
 {% endif %}
-{% if final is object and final.nc %}
+{% if final.nc %}
     {% set sep = "vs" %}
 {% else %}
     {% set sep = "defeated" %}
 {% endif %}
+{% if not stip %}{% set stip = default_stip %}{% endif %}
 
 {% if segment %}
   <strong>Segment:</strong> {{ winner | markdown(inline=true) | safe }}{% if others %}, {{ others | join(sep=", ") | markdown(inline=true) | safe }}{% endif %}
 {% else %}
-  {% if bodies == 0 and not final.nc %}
-  Winner:
-  {% endif %}
+  {% if bodies == 0 and not final.nc %} Winner: {% endif %}
   {{ winner | markdown(inline=true) | safe }}
   {% if bodies > 0 %}
-  {{ sep }}
-  {{ others | join(sep=" and ") | markdown(inline=true) | safe }}
+    {{ sep }} {{ others | join(sep=" and ") | markdown(inline=true) | safe }}
   {% endif %}
-  {% if final is object %}
-      {% if final.r %}
-          via {{ final.r }}
-      {% elif final.nc %}
-          - {{ final.nc }}
-      {% endif %}
+  {% if final.r %}
+      via {{ final.r }}
+  {% elif final.nc %}
+      - {{ final.nc }}
   {% endif %}
   <strong>
 {% endif %}
 <br/>
-{{ title | markdown(inline=true) | safe }}
-{{ stip | markdown(inline=true) | safe }}
+{{ title | default(value="") | markdown(inline=true) | safe }}
+{{ stip | default(value=default_stip) | markdown(inline=true) | safe }}
 </strong>

--- a/templates/talent_matchlist.html
+++ b/templates/talent_matchlist.html
@@ -29,7 +29,7 @@
         <span class="r">Details</span>
     </li>
     {% for match in matches_by_date | reverse %}
-    <li class="entry">
+    <li class="entry {{ match.tt | default(value="") }}">
         <time class="d" style="white-space: nowrap" datetime="{{ match.d }}">{{ match.d }}</time>
         <span class="o">
             {% for org in match.o %}
@@ -41,6 +41,9 @@
             {% include "career_result_row.html" %}
             {% set event_path = "@/" ~ match.p %}
             <small>at <a href="{{ get_url(path=event_path) }}">{{ match.n }}</a></small>
+            {% if match.tt %}
+              ({{ match.tt }})
+            {% endif %}
         </span>
     </li>
     {% endfor %}


### PR DESCRIPTION
Non-authoritative cards are ones marked with unofficial, predicted or incomplete. All matches in such a card inherit the status.

Such matches are then displayed, only on the talent pages, in italics, and a (predicted) or other mark is added after the second line (that lists the match type and event name).