### PR TITLE
Speed up costly lists, handle unused aliases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 ROSTERS=data/roster_ptw.json \
+				data/roster_ddw.json \
         data/roster_kpw.json \
         data/roster_mzw.json \
         data/roster_ppw.json \
@@ -15,26 +16,31 @@ CAL=static/calendar.ics \
 		static/calendar-low.ics
 MINISEARCH_INDEX=static/minisearch_index.json
 
-all: rosters meta calendar index plot
+all: rosters meta aliases atr calendar index plot
 rosters: $(ROSTERS)
+aliases: data/aliases.json
+atr: data/all_time_roster.json
 meta: $(METADATA)
 calendar: $(CAL)
 plot: $(PLOTS)
 index: $(MINISEARCH_INDEX)
 
 clean:
-	rm -rf $(ROSTERS) $(METADATA) $(PLOTS) $(CAL) $(MINISEARCH_INDEX)
+	rm -rf $(ROSTERS) $(METADATA) $(PLOTS) $(CAL) $(MINISEARCH_INDEX) data/all_time_roster.json data/aliases.json
 
-data/all_matches.json data/appearances.json data/crew_appearances.json: content/e/**/*.md
+data/all_matches.json data/appearances.json data/crew_appearances.json &: content/e/**/*.md
 	bin/build-matches
 
 data/career.json: content/e/**/*.md
 	bin/build-metadata
 
-data/roster_ptw.json data/roster_kpw.json data/roster_ppw.json data/roster_dfw.json: content/e/**/*.md
-	bin/build-roster
+data/aliases.json: content/w/*.md
+	bin/build-aliases
 
-data/roster_mzw.json data/roster_wws.json data/roster_wwe.json: content/e/**/*.md
+data/all_time_roster.json: data/aliases.json data/career.json const/name-to-flag.yaml const/flags-by-code.json const/emojis.yaml
+	bin/build-atr
+
+$(ROSTERS) &: content/e/**/*.md
 	bin/build-roster
 
 clean-plot:

--- a/bin/build-aliases
+++ b/bin/build-aliases
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+import sys
+from pathlib import Path
+
+srcdir = Path(__file__).resolve().parent / '../src'
+sys.path.insert(0, str(srcdir))
+import bin.aliases as aliases
+
+aliases.main()

--- a/bin/build-atr
+++ b/bin/build-atr
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+import sys
+from pathlib import Path
+
+srcdir = Path(__file__).resolve().parent / '../src'
+sys.path.insert(0, str(srcdir))
+import bin.all_time_roster as atr
+
+atr.main()

--- a/content/e/ddw/2014-08-16-ddw-pokaz-adeptow.md
+++ b/content/e/ddw/2014-08-16-ddw-pokaz-adeptow.md
@@ -15,7 +15,7 @@ This event was a showcase of DDW's newest trainees, and accompanied the bigger [
 - ["Kamil Leśny, [Luxus](@/w/luxus.md); [Piękny Kawaler](@/w/piekny-kawaler.md)",
   "Double G: [GREG](@/w/greg.md), Wielki G", {s: Tag Team Match}]
 - ['[Mira](@/w/mira.md)', '[Bianca](@/w/bianca.md)', {r: DQ}]
-- ['[Robert Star](@/w/robert-star.md)', "[El Homo](@/w/ostrowski.md); Bogdan"]
+- ['[Robert Star](@/w/robert-star.md)', "[El Homo](@/w/ostrowski.md); [Bogdan](@/w/krzysztof-zasada.md)"]
 - ['[Mateusz Kowalski](@/w/mateusz-kakareko.md)', '[Kaszub](@/w/kaszub.md)']
 {% end %}
 

--- a/content/w/krzysztof-zasada.md
+++ b/content/w/krzysztof-zasada.md
@@ -1,6 +1,8 @@
 +++
 title = "Krzysztof Zasada"
 template = "talent_page.html"
+[extra]
+career_aliases = ["Krzysztof Foryst", "Bogdan"]
 [taxonomies]
 country = ["PL"]
 +++

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,17 @@
-pyyaml
-matplotlib
-python-dateutil
-icalendar
-mistletoe
+-i https://pypi.org/simple
+contourpy==1.3.1; python_version >= '3.10'
+cycler==0.12.1; python_version >= '3.8'
+fonttools==4.55.0; python_version >= '3.8'
+icalendar==6.1.0; python_version >= '3.8'
+kiwisolver==1.4.7; python_version >= '3.8'
+matplotlib==3.9.2; python_version >= '3.9'
+mistletoe==1.4.0; python_version ~= '3.5'
+numpy==2.1.3; python_version >= '3.10'
+packaging==24.2; python_version >= '3.8'
+pillow==11.0.0; python_version >= '3.9'
+pyparsing==3.2.0; python_version >= '3.9'
+python-dateutil==2.9.0.post0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+pyyaml==6.0.2; python_version >= '3.8'
+six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+tzdata==2024.2; python_version >= '2'
+unidecode==1.3.8; python_version >= '3.5'

--- a/src/bin/aliases.py
+++ b/src/bin/aliases.py
@@ -1,0 +1,34 @@
+
+#! /usr/bin/env python3
+
+from page import all_talent_pages
+from typing import cast, Any
+from pathlib import Path
+import json
+
+def main():
+    content_root = Path.cwd() / 'content'
+    aliases = {}
+
+    for page in all_talent_pages():
+        path = str(page.path.relative_to(content_root))
+        fm = page.front_matter
+        extra = cast(dict[str, Any], fm.get('extra', {}))
+
+        title = fm['title']
+        career_name = extra.get('career_name')
+        career_aliases = extra.get('career_aliases', [])
+
+        aliases[title] = path
+        if career_name:
+            aliases[career_name] = path
+        aliases |= {ca: path for ca in career_aliases}
+
+    save_as_json(aliases, Path('data/aliases.json'))
+
+def save_as_json(data: Any, path: Path):
+    with path.open('w') as fp:
+        json.dump(data, fp)
+
+if __name__ == "__main__":
+    main()

--- a/src/bin/all_time_roster.py
+++ b/src/bin/all_time_roster.py
@@ -1,0 +1,89 @@
+#! /usr/bin/env python3
+
+from collections import namedtuple
+from pathlib import Path
+from typing import Any, Callable, Iterable, cast
+from page import page, TalentPage
+import json, re, yaml
+
+ATRecord = namedtuple('ATRecord', ['sort_key', 'name', 'kind', 'path', 'country', 'flag_or_emoji'])
+
+LookupFlagFn = Callable[[str|TalentPage], tuple[str, str]]
+
+def main():
+    content_path = Path.cwd() / 'content'
+
+    careers = json.load(Path('data/career.json').open())
+    name_to_flag = yaml.safe_load(Path('const/name-to-flag.yaml').open())
+    flags = json.load(Path('const/flags-by-code.json').open())
+    emojis = yaml.safe_load(Path('const/emojis.yaml').open())
+    alias_map = json.load(Path('data/aliases.json').open())
+
+    lookup_flag = lambda name_or_page: lookup_flag_or_emoji(name_or_page, name_to_flag, flags, emojis)
+
+    all_names = []
+    for name in careers:
+        path = alias_map.get(name)
+
+        if path:
+            talent_page = TalentPage(content_path / path, verbose=False)
+            all_names.extend(load_talent(talent_page, path, lookup_flag))
+        else:
+            all_names.append(unlinked_entry(name, lookup_flag))
+
+    all_names.sort(key=lambda atr: atr.sort_key)
+    save_as_json(all_names, Path('data/all_time_roster.json'))
+
+def load_talent(talent_page: TalentPage, path: str, lookup_flag: LookupFlagFn) -> Iterable[ATRecord]:
+    fm = talent_page.front_matter
+    title = fm['title']
+    country, flag = lookup_flag(talent_page)
+
+    yield ATRecord(make_sort_key(title), title, 'P', path, country, flag)
+
+    extra = cast(dict[str, Any], fm.get('extra', {}))
+    career_name = extra.get('career_name')
+    if career_name:
+        yield ATRecord(make_sort_key(career_name), career_name, 'T', path, country, flag)
+
+    aliases = cast(list[str], extra.get('career_aliases', []))
+    for alias in aliases:
+        yield ATRecord(make_sort_key(alias), alias, 'A', path, country, flag)
+
+def unlinked_entry(name, lookup_flag: LookupFlagFn) -> ATRecord:
+    country, flag = lookup_flag(name)
+    return ATRecord(make_sort_key(name), name, 'U', None, country, flag)
+
+def lookup_flag_or_emoji(name_or_page, names_dict, flags_list, emojis) -> tuple[str, str]:
+    match name_or_page:
+        case str() as name:
+            code = names_dict.get(name)
+            if not code: return 'ZZ', ''
+            if code in flags_list:
+                return code, flags_list[code]
+            elif code in emojis:
+                return code, emojis[code]
+            return 'ZZ', ''
+        case TalentPage(front_matter=fm):
+            taxonomies = cast(dict[str, Any], fm.get('taxonomies', {}))
+            code = taxonomies.get('country', [])[0]
+            if not code: return code, ''
+            if code in flags_list:
+                return code, flags_list[code]
+            elif code in emojis:
+                return code, emojis[code]
+            return 'ZZ', ''
+        case _:
+            return 'ZZ', ''
+
+def make_sort_key(text):
+    text = re.sub(r'^The\s+', '', text)
+    text = re.sub(r'\W+', '-', text)
+    return text.strip('-').lower()
+
+def save_as_json(data: Any, path: Path):
+    with path.open('w') as fp:
+        json.dump(data, fp)
+
+if __name__ == "__main__":
+    main()

--- a/src/page.py
+++ b/src/page.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from card import Card
 import tomllib
 from sys import exit, stderr
-from typing import Tuple
+from typing import Tuple, Iterable, Optional
 from io import TextIOBase
 
 
@@ -45,6 +45,9 @@ class Page:
     @property
     def title(self): return self.front_matter['title']
 
+    def __repr__(self):
+        return f"<{self.__class__.__name__}({self.path})>"
+
 class EventPage(Page):
     event_date: date
     orgs: list[str]
@@ -63,6 +66,9 @@ class EventPage(Page):
 
         self.card = Card(self.body, path, self.front_offset)
 
+    def __repr__(self):
+        return f"<EventPage({self.path}) date={self.event_date} orgs={self.orgs}>"
+
 
 class OrgPage(Page):
     pass
@@ -71,7 +77,9 @@ class VenuePage(Page):
     pass
 
 class TalentPage(Page):
-    pass
+    def __repr__(self):
+        title = self.front_matter.get('title', None)
+        return f"<TalentPage({self.path}) name={title!r}>"
 
 class Article(Page):
     pass
@@ -89,6 +97,15 @@ def page(path: Path, verbose: bool = False) -> Page:
         return VenuePage(path, verbose)
     else:
         return Article(path, verbose)
+
+def all_talent_pages(root: Optional[Path]=None) -> Iterable[TalentPage]:
+    """Walk the files and produce all talent pages"""
+    if root is None:
+        root = Path.cwd()
+
+    yield from (TalentPage(page_path)
+                for page_path in (root / 'content/w/').glob('*.md')
+                if page_path.stem != '_index.md')
 
 if __name__ == "__main__":
     import sys, code

--- a/templates/all_time_roster.html
+++ b/templates/all_time_roster.html
@@ -5,11 +5,12 @@
 {% set name_to_flag = load_data(path="const/name-to-flag.yaml") -%}
 {% set flag_dict = load_data(path="const/flags-by-code.json") -%}
 {% set all_emojis = load_data(path="const/emojis.yaml") %}
+{% set empty_obj = []|group_by(attribute=0) %}
 
 {% set path = "data/roster_" ~ page.slug ~ ".json" -%}
 {% set roster = load_data(path=path, required=false) -%}
 {% if not roster -%}
-{% set roster = [] | group_by(attribute="none") -%}
+  {% set roster = empty_obj -%}
 {% endif -%}
 
 {% set_global rx = [] -%}

--- a/templates/alphabetical_talent_list.html
+++ b/templates/alphabetical_talent_list.html
@@ -7,45 +7,12 @@
 {{ section.content | safe }}
 
 {% set org_styles = config.extra.org_styles %}
-{% set all_talent_pages = section.pages %}
-{% set atp_index = all_talent_pages | group_by(attribute='title') %}
-{% set atp_index_cname = all_talent_pages | group_by(attribute='extra.career_name') %}
-{% set name_to_flag = load_data(path="const/name-to-flag.yaml") %}
 {% set career_dict = load_data(path="data/career.json") %}
 {% set all_matches = load_data(path="data/all_matches.json") %}
 {% set appearances = load_data(path="data/appearances.json") %}
 {% set crew_appearances = load_data(path="data/crew_appearances.json") %}
-{% set_global all_names = [] %}
+{% set all_names = load_data(path="data/all_time_roster.json") %}
 
-{# The careers dict contains all names, with and without articles #}
-{% for name, _ in career_dict %}
-  {% set talent_page = atp_index | get(key=name, default=[])|first %}
-  {% if not talent_page %}
-    {% set talent_page = atp_index_cname | get(key=name, default=[]) | first%}
-  {% endif %}
-  {% if talent_page %}
-    {# This name has an actual talent page, record this as a P(age) record #}
-    {% set pair = [name|trim_start_matches(pat='The ')|slugify, name, 'P', talent_page] %}
-    {% set_global all_names = all_names | concat(with=[pair]) %}
-    {# Title may be different from career dict entry #}
-    {% if talent_page.title != name %}
-      {% set pair = [talent_page.title|trim_start_matches(pat='The ')|slugify, talent_page.title, 'T', talent_page, name] %}
-      {% set_global all_names = all_names | concat(with=[pair]) %}
-    {% endif %}
-    {% set xtra = talent_page.extra %}
-    {# And it may have some aliases. Record this as an A(lias) record, pointing to the main name #}
-    {% for alias in xtra|get(key='career_aliases', default=[]) %}
-      {% set alias_pair = [alias|trim_start_matches(pat='The ')|slugify, alias, 'A', talent_page] %}
-      {% set_global all_names = all_names | concat(with=[alias_pair]) %}
-    {% endfor %}
-  {% else %}
-    {# Otherwise, no talent page, record this as an U record #}
-    {% set pair = [name|trim_start_matches(pat='The ')|slugify, name, 'U', false] %}
-    {% set_global all_names = all_names | concat(with=[pair]) %}
-  {% endif %}
-{% endfor %}
-
-{% set all_names = all_names | sort(attribute='0') %}
 {% set alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' %}
 {% set alpha_variants = load_data(literal="{S: [S, Ś], L: [L, Ł], Z: [Z, Ź, Ż]}", format='yaml') %}
 {% set flag_dict = load_data(path="const/flags-by-code.json") %}
@@ -70,7 +37,8 @@
       {% for talent in talents %}
         {% set name = talent[1] %}
         {% set flavor = talent[2] %}
-        {% set page = talent[3] %}
+        {% set page_path = talent[3] %}
+        {% set flag = talent[5] %}{# country is at [4] but we don't use it here #}
         {% set_global career_entry = false %}
         {% if flavor == 'P' %}
           {% set_global person_name = name %}
@@ -78,6 +46,7 @@
           {% set_global crew_appearances_entry = crew_appearances|get(key=name, default=[]) %}
           {% set_global career_entry = career_dict|get(key=name, default=empty_obj) %}
           {% set_global display_match_links = false %}
+          {% set page_path = "@/" ~ page_path %}{# Overwrite so that pwf can produce correct link #}
           <li class="pwf">
             {% include "person_with_flag.html" %}
             {% include "person_orgs_matches.html" %}
@@ -94,6 +63,7 @@
             {% include "person_orgs_matches.html" %}
           </li>
         {% elif flavor == 'A' %}
+          {% set page = get_page(path=page_path) %}
           {% set career_key = page.extra|get(key='career_name', default=page.title) %}
           {% set_global appearances_entry = appearances|get(key=name, default=[]) %}
           {% set_global crew_appearances_entry = crew_appearances|get(key=name, default=[]) %}
@@ -101,6 +71,7 @@
           {% set_global career_entry = career_dict|get(key=career_key, default=empty_obj) %}
           {% set_global person_name = '<em>' ~ name ~ '</em>' %}
           {% set_global display_match_links = false %}
+          {% set page_path = "@/" ~ page_path %}{# Overwrite so that pwf can produce correct link #}
         <li class="pwf">
             {% include "person_with_flag.html" %}
             {% include "person_orgs_matches.html" %}

--- a/templates/country_talent_list.html
+++ b/templates/country_talent_list.html
@@ -7,48 +7,19 @@
 {{ page.content | safe }}
 
 {% set org_styles = config.extra.org_styles %}
-{% set talent_section = get_section(path='w/_index.md') %}
-{% set all_talent_pages = talent_section.pages %}
-{% set atp_index = all_talent_pages | group_by(attribute='title') %}
-{% set atp_index_cname = all_talent_pages | group_by(attribute='extra.career_name') %}
-{% set name_to_flag = load_data(path="const/name-to-flag.yaml") %}
 {% set country_names = load_data(path="const/country_names.yml") %}
-{% set flag_dict = load_data(path="const/flags-by-code.json") %}
 {% set career_dict = load_data(path="data/career.json") %}
+{% set flag_dict = load_data(path='const/flags-by-code.json') %}
 {% set all_matches = load_data(path="data/all_matches.json") %}
 {% set appearances = load_data(path="data/appearances.json") %}
 {% set crew_appearances = load_data(path="data/crew_appearances.json") %}
 {% set_global all_names = [] %}
 
-{% for name, _ in career_dict %}
-  {% set talent_page = atp_index | get(key=name, default=[]) | first %}
-  {% if not talent_page %}
-    {% set talent_page = atp_index_cname | get(key=name, default=[]) | first %}
-  {% endif %}
-  {% if talent_page %}
-    {% set country = talent_page.taxonomies.country | first %}
-    {% set rec = [country, name|trim_start_matches(pat='The ')|slugify, name, 'P', talent_page] %}
-    {% set_global all_names = all_names | concat(with=[rec]) %}
-    {% if talent_page.title != name %}
-      {% set rec = [country, talent_page.title|trim_start_matches(pat='The ')|slugify, talent_page.title, 'T', talent_page, name] %}
-      {% set_global all_names = all_names | concat(with=[rec]) %}
-    {% endif %}
-    {% set xtra = talent_page.extra %}
-    {# And it may have some aliases. Record this as an A(lias) record, pointing to the main name #}
-    {% for alias in xtra|get(key='career_aliases', default=[]) %}
-      {% set alias_rec = [country, alias|trim_start_matches(pat='The ')|slugify, alias, 'A', talent_page] %}
-      {% set_global all_names = all_names | concat(with=[alias_rec]) %}
-    {% endfor %}
-  {% else %}
-    {% set country = name_to_flag|get(key=name, default='ZZ') %}
-    {% set rec = [country, name|trim_start_matches(pat='The ')|slugify, name, 'U', false] %}
-    {% set_global all_names = all_names | concat(with=[rec]) %}
-  {% endif %}
-{% endfor %}
+{% set all_names = load_data(path="data/all_time_roster.json") %}
 
-{% set all_countries = all_names | map(attribute='0') | sort | unique %}
+{% set all_countries = all_names | map(attribute='4') | sort | unique %}
 {% set empty_obj = []|group_by(key=0) %}
-{% set rbc_grouped = all_names | group_by(attribute='0') %}
+{% set rbc_grouped = all_names | group_by(attribute='4') %}
 
 {% for country, country_name in country_names %}
   {% set recs_by_country = rbc_grouped[country] %}
@@ -61,9 +32,10 @@
   </h2>
   <ul class="talentlist-section">
     {% for talent in recs_by_country %}
-        {% set name = talent[2] %}
-        {% set flavor = talent[3] %}
-        {% set page = talent[4] %}
+        {% set name = talent[1] %}
+        {% set flavor = talent[2] %}
+        {% set page_path = talent[3] %}
+        {% set flag = talent[5] %}
         {% set_global career_entry = false %}
         {% if flavor == 'P' %}
           {% set_global person_name = name %}
@@ -71,8 +43,9 @@
           {% set_global crew_appearances_entry = crew_appearances|get(key=name, default=[]) %}
           {% set_global career_entry = career_dict|get(key=name, default=empty_obj) %}
           {% set_global display_match_links = false %}
+          {% set page_path = "@/" ~ page_path %}{# Overwrite so that pwf can produce correct link #}
           <li class="pwf">
-            <a class="nu name" href="{{ get_url(path=page.path) }}">{{ person_name | safe }}</a>
+            <a class="nu name" href="{{ get_url(path=page_path) }}">{{ person_name | safe }}</a>
             {% include "person_orgs_matches.html" %}
           </li>
         {% elif flavor == 'T' %}
@@ -83,7 +56,7 @@
           {% set_global career_entry = career_dict|get(key=career_name, default=empty_obj) %}
           {% set_global display_match_links = false %}
           <li class="pwf">
-            <a class="nu name" href="{{ get_url(path=page.path) }}">{{ person_name | safe }}</a>
+            <a class="nu name" href="{{ get_url(path=page_path) }}">{{ person_name | safe }}</a>
             {% include "person_orgs_matches.html" %}
           </li>
         {% elif flavor == 'A' %}

--- a/templates/person_with_flag.html
+++ b/templates/person_with_flag.html
@@ -1,8 +1,13 @@
+{% if flag is defined and page_path is defined %}
+  <span class="flag">{{ flag }} </span>
+  <a class="nu name" href="{{ get_url(path=page_path) }}">{{ person_name | safe }}</a>
+{% elif page is defined %}
 <span class="flag">
   {%- set flag = page.taxonomies | get(key='country', default=[]) | first -%}
   {%- set flag_symbol = flag_dict|get(key=flag|upper, default=False) -%}
   {%- set emoji = all_emojis|get(key=flag, default=False) -%}
   {% if flag_symbol %}{{ flag_symbol }}{% elif emoji %}{{ emoji }}{% endif %}
 </span>
-
 <a class="nu name" href="{{ get_url(path=page.path) }}">{{ person_name | safe }}</a>
+{% endif %}
+

--- a/templates/unlinked_person.html
+++ b/templates/unlinked_person.html
@@ -1,7 +1,12 @@
-<span class="flag">
-{% set flag = name_to_flag|get(key=person_name, default='') -%}
-{% if flag -%}
-  {{ flag_dict|get(key=flag|upper, default='') -}}
-{% endif -%}
-</span>
-<span class="name">{{ person_name }}</span>
+{% if flag is defined %}
+  <span class="flag">{{ flag }} </span>
+  <span class="name">{{ person_name }}</span>
+{% else %}
+  <span class="flag">
+  {% set flag = name_to_flag|get(key=person_name, default='') -%}
+  {% if flag -%}
+    {{ flag_dict|get(key=flag|upper, default='') -}}
+  {% endif -%}
+  </span>
+  <span class="name">{{ person_name }}</span>
+{% endif %}


### PR DESCRIPTION
Move most of that calculation upfront into the build, in a Python script.  Visually there should be no changes, but the build is now much faster, as we're not building these huge lists on each recompilation.

Specifically for Krzysztof Zasada however: his unused alias (Foryst) should now appear in the main people list, linking to him. It still won't appear in DDW's all-time-roster, and that's by design - it wasn't used there (or in any other org).

We also now can handle adding aliases that weren't used in any match or crew appearance, which previously could cause errors.
