### PR TITLE
Replace plain tables in org articles with a shortcode

### DIFF
--- a/content/o/ddw.md
+++ b/content/o/ddw.md
@@ -27,6 +27,15 @@ Finally, Roid decided to close down DDW and let that team run things under a new
 One character in that history, although a non-wrestler, was Arkadiusz Pawłowski. Active on the internet at the time, he had grand ambitions to bring WWE to host a show in Poland, although he had no experience or contacts to pull that off. That didn't stop him from claiming that DDW was going to host a match at Night of Champions II, an MMA event in Włocławek, and he was to book the show and gather sponsors and media coverage. That did not happen, and the actual showrunners denied any knowledge of his actions, calling Pawłowski a fraud. That did not stop him from gaining a role in DDW as a ring announcer and manager. He was also a member of the aforementioned team
 that took over from DDW in Gdańsk. A couple years later Pawłowski would go on to create [PTW](@/o/ptw.md), this time with more experience under his belt, with similar ambitions to what DDW originally wanted to achieve.
 
+## Championships
+
+{% championship() %}
+- - '[DDW International Championship](@/c/ddw-international-championship.md)'
+  - 'Final champion: [Kamil Aleksander](@/w/kamil-aleksander.md)'
+  - >
+    Defeated [Joe Legend](@/w/joe-legend.md) at [DDW #7](@/e/ddw/2012-03-10-ddw-7.md)
+{% end %}
+
 ### References
 
 * [Polish Wrestling History Part 2 on mywrestling](https://mywrestling.com.pl/historia-polskiego-wrestlingu-2-proby-ponownego-wprowadzenia-wrestlingu-do-polski-poczatki-ddw-wielka-gala-w-stodole/) (in Polish)

--- a/content/o/dfw.md
+++ b/content/o/dfw.md
@@ -71,7 +71,14 @@ After the organization dissolved in 2018, some unspecified wrestlers were announ
 
 ### Championships
 
-DFW had one singles championship, introduced and awarded at the first (and only) [Tournament of Dreams](@/e/dfw/2016-08-20-dfw-tournament-of-dreams-2.md). The inaugural champion was Chris Hunter, and the final person to hold the belt was Norris.
+DFW had one singles championship, introduced and awarded at the first (and only) [Tournament of Dreams](@/e/dfw/2016-08-20-dfw-tournament-of-dreams-2.md). The inaugural champion was Chris Hunter.
+
+{% championship() %}
+- - '[DFW Championship](@/c/dfw-championship.md)'
+  - 'Final champion: [Norris](@/w/isnorr.md)'
+  - >
+    Won a gauntlet match for the vacated belt at [DFW Charity Gauntlet Match](@/e/dfw/2018-03-08-dfw-charity-gauntlet-match.md)
+{% end %}
 
 Norris brought the belt to PpW, although it was never defended there. At some point the belt's faceplate was damaged, showing a large fracture line down the middle. The plate was also removed from the leather strap, which was reused for another belt.
 

--- a/content/o/kpw.md
+++ b/content/o/kpw.md
@@ -78,11 +78,21 @@ As of 2024, KPW has one tag team championship and two singles championships. The
 
 The [Tag Team Championship](@/c/kpw-tag-team-championship.md) was created in 2018 and the first champions crowned in 2018, at [Arena 11](@/e/kpw/2018-11-03-kpw-arena-11-podwojne-zagrozenie.md).
 
-| Championship | Current champion(s) | Notes |
-|---|---|---|
-| [KPW Championship](@/c/kpw-championship.md) | Hans Schulte | Defeated [Red Scorpion](@/w/red-scorpion.md) at [Godzina Zero 2024](@/e/kpw/2024-09-07-kpw-godzina-zero-2024.md) |
-| [KPW OldTown Championship](@/c/kpw-old-town-championship.md) | [Chemik](@/w/chemik.md) | Defeated [Rosetti](@/w/rosetti.md) at [Arena 25: Odkupienie](@/e/kpw/2024-05-17-kpw-arena-25.md) |
-| [KPW Tag Team Championship](@/c/kpw-tag-team-championship.md) | The Fux Brothers: [Michał Fux](@/w/michal-fux.md), [Filip Fux](@/w/filip-fux.md) | Defeated Die Ordnung (Veit Müller, Hans Schulte) at [Godzina Zero 2023](@/e/kpw/2023-08-18-kpw-godzina-zero-2023.md) |
+
+{% championship() %}
+- - '[KPW Championship](@/c/kpw-championship.md)'
+  - '[Hans Schulte](@/w/hans-schulte.md)'
+  - >
+    Defeated [Red Scorpion](@/w/red-scorpion.md) at [Godzina Zero 2024](@/e/kpw/2024-09-07-kpw-godzina-zero-2024.md)
+- - '[KPW OldTown Championship](@/c/kpw-old-town-championship.md)'
+  - '[Chemik](@/w/chemik.md)'
+  - >
+    Defeated [Rosetti](@/w/rosetti.md) at [Arena 25: Odkupienie](@/e/kpw/2024-05-17-kpw-arena-25.md)
+- - '[KPW Tag Team Championship](@/c/kpw-tag-team-championship.md)'
+  - 'The Fux Brothers: [Michał Fux](@/w/michal-fux.md), [Filip Fux](@/w/filip-fux.md)'
+  - >
+    Defeated Die Ordnung ([Veit Müller](@/w/veit-mueller.md), [Hans Schulte](@/w/hans-schulte.md)) at [Godzina Zero 2023](@/e/kpw/2023-08-18-kpw-godzina-zero-2023.md)
+{% end %}
 
 ### References
 

--- a/content/o/mcw.md
+++ b/content/o/mcw.md
@@ -40,9 +40,11 @@ In addition to the events listed below, MCW also held two undated demonstrations
 
 MCW has one singles championship, which was introduced in late 2019.
 
-| Championship | Current champion | Notes |
-|---|---|---|
-| [MCW Championship](@/c/mcw-championship.md) | Jack Kalom | Defeated [RAV](@/w/rav.md) at [MCW Charytatywnie](@/e/mcw/2024-11-16-mcw-charytatywnie.md) |
+{% championship() %}
+- - '[MCW Championship](@/c/mcw-championship.md)'
+  - Jack Kalom
+  - Defeated [RAV](@/w/rav.md) at [MCW Charytatywnie](@/e/mcw/2024-11-16-mcw-charytatywnie.md)
+{% end %}
 
 ### References
 

--- a/content/o/mcw.md
+++ b/content/o/mcw.md
@@ -36,7 +36,7 @@ Notable names to come out of MCW were [Syriusz Dziedzic](@/w/dziedzic.md), [Disc
 
 In addition to the events listed below, MCW also held two undated demonstrations of wrestling techniques, without the ring, in Siemianowice Śląskie.
 
-### Championships
+## Championships
 
 MCW has one singles championship, which was introduced in late 2019.
 
@@ -46,7 +46,7 @@ MCW has one singles championship, which was introduced in late 2019.
   - Defeated [RAV](@/w/rav.md) at [MCW Charytatywnie](@/e/mcw/2024-11-16-mcw-charytatywnie.md)
 {% end %}
 
-### References
+## References
 
 - [Czas na Polski WRESTLING!](https://web.archive.org/web/20160527112136/http://natlok.pl/czas-na-polski-wrestling/), archived article from natlok.pl
 - [Facebook post announcing a new beginning, new plan and new attitude](https://www.facebook.com/minecitywrestling/posts/pfbid02zVfpG1gojMXq5jBkAVcqPMjnAmPLyhrNwqB78upeCzGchKRKKLJHd8zP6w7o1BQpl)

--- a/content/o/mzw.md
+++ b/content/o/mzw.md
@@ -62,10 +62,16 @@ In 2020, local branch of the national broadcaster TVP3 Wrocław published a [sho
 
 MZW has one singles championship, with Shadow having the longest combined reigns as of 2024. Between 2016 and 2019 they also used to have a Tag Team championship, currently inactive.
 
-| Championship | Current champion | Notes |
-|---|---|---|
-| [MZW Championship][mzw-c] | [Matt Buckna](@/w/matt-buckna.md) | Defeated [Aron Wake](@/w/aron-wake.md) at [No Time to Die](@/e/mzw/2024-10-12-mzw-no-time-to-die.md) |
-| [MZW Tag Team Championship][mzw-ttc] | **INACTIVE** since 2019-03-23 | Final Champions: Wataha (Apollo Anderson & [Justin Joy](@/w/justin-joy.md)) |
+{% championship() %}
+- - '[MZW Championship](@/c/mzw-championship.md)' 
+  - '[Matt Buckna](@/w/matt-buckna.md)' 
+  - >
+    Defeated [Aron Wake](@/w/aron-wake.md) at [No Time to Die](@/e/mzw/2024-10-12-mzw-no-time-to-die.md)
+- - '[MZW Tag Team Championship](@/c/mzw-tag-team-championship.md)'
+  - |
+    **INACTIVE** since 2019-03-23
+    Final Champions: Wataha (Apollo Anderson & [Justin Joy](@/w/justin-joy.md))
+{% end %}
 
 ## References
 

--- a/content/o/mzw.md
+++ b/content/o/mzw.md
@@ -68,9 +68,8 @@ MZW has one singles championship, with Shadow having the longest combined reigns
   - >
     Defeated [Aron Wake](@/w/aron-wake.md) at [No Time to Die](@/e/mzw/2024-10-12-mzw-no-time-to-die.md)
 - - '[MZW Tag Team Championship](@/c/mzw-tag-team-championship.md)'
-  - |
-    **INACTIVE** since 2019-03-23
-    Final Champions: Wataha (Apollo Anderson & [Justin Joy](@/w/justin-joy.md))
+  - 'Final Champions: Wataha (Apollo Anderson & [Justin Joy](@/w/justin-joy.md))'
+  - '**INACTIVE** since 2019-03-23'
 {% end %}
 
 ## References

--- a/content/o/ppw.md
+++ b/content/o/ppw.md
@@ -108,10 +108,16 @@ Finally, Biesiad managed to German suplex Gryffin on the studio floor, while the
 
 ## Championships
 
-| Championship | Current champion(s) | Notes |
-|--|--|--|
-| [PpW Championship][ppw-c] | [Gustav Gryffin](@/w/gustav-gryffin.md) | Won an additional title match immediately after [Biesiad](@/w/biesiad.md) defeated champion [Feager](@/w/feager.md) at [Ledwo Legalne IV](@/e/ppw/2024-06-08-ppw-ledwo-legalne-4.md). |
-| [PpW European Ultraviolent Championship][ppw-uvc] | [Johnny Blade](@/w/johnny-blade.md) | Eliminated champion [Stanislaw Van Dobroniak](@/w/stanislaw-van-dobroniak.md) at [Ledwo Legalne IV](@/e/ppw/2024-06-08-ppw-ledwo-legalne-4.md), then defeated [Isnorr](@/w/isnorr.md) to reclaim the belt. |
+{% championship() %}
+- - '[PpW Championship](@/c/ppw-championship.md)'
+  - '[Gustav Gryffin](@/w/gustav-gryffin.md)'
+  - >
+    Won an additional title match immediately after [Biesiad](@/w/biesiad.md) defeated champion [Feager](@/w/feager.md) at [Ledwo Legalne IV](@/e/ppw/2024-06-08-ppw-ledwo-legalne-4.md).
+- - '[PpW European Ultraviolent Championship](@/c/ppw-european-ultraviolent-championship.md)'
+  - '[Johnny Blade](@/w/johnny-blade.md)'
+  - >
+    Eliminated champion [Stanislaw Van Dobroniak](@/w/stanislaw-van-dobroniak.md) at [Ledwo Legalne IV](@/e/ppw/2024-06-08-ppw-ledwo-legalne-4.md), then defeated [Isnorr](@/w/isnorr.md) to reclaim the belt.
+{% end %}
 
 ## Internet presence
 

--- a/content/o/ptw.md
+++ b/content/o/ptw.md
@@ -205,10 +205,15 @@ One remarkable deal between PTW and a bigger promotion was an agreement with Imp
 
 ## Championships
 
-| Championship | Current champion(s) | Notes |
-|--|--|--|
-| [PTW Championship](@/c/ptw-championship.md) | [Puncher](@/w/puncher.md) | Inaugural champion, won the championship rumble match at [Gold Rush](@/e/ptw/2024-02-03-ptw-5-gold-rush.md). |
-| [PTW Tag Team Championship](@/c/ptw-tag-team-championship.md) | Budapest Bastards: [Renegade](@/w/renegade.md) and [Nitro](@/w/nitro.md) | Defeated PAKA: [Disco Pablo](@/w/disco-pablo.md), [Boro](@/w/boro.md) and [Taras](@/w/taras.md) at [Gold Rush](@/e/ptw/2024-02-03-ptw-5-gold-rush.md). |
+{% championship() %}
+- - '[PTW Championship](@/c/ptw-championship.md)'
+  - '[Puncher](@/w/puncher.md)'
+  - Inaugural champion, won the championship rumble match at [Gold Rush](@/e/ptw/2024-02-03-ptw-5-gold-rush.md).
+- - '[PTW Tag Team Championship](@/c/ptw-tag-team-championship.md)'
+  - 'Budapest Bastards: [Renegade](@/w/renegade.md) and [Nitro](@/w/nitro.md)'
+  - >
+    Defeated PAKA: [Disco Pablo](@/w/disco-pablo.md), [Boro](@/w/boro.md) and [Taras](@/w/taras.md) at [Gold Rush](@/e/ptw/2024-02-03-ptw-5-gold-rush.md).
+{% end %}
 
 ## Other media
 

--- a/sass/_tables.sass
+++ b/sass/_tables.sass
@@ -161,6 +161,56 @@ ul.column-rule
 details[open] + .card
     display: none
 
+.championship
+  display: grid
+  padding-left: 0
+  grid-template-rows: auto
+  grid-template-columns: 1fr 1fr 2fr
+  gap: 0.3em
+
+  .n, .c, .r
+    padding: 0.1em 0.3rem
+    white-space: pre-line
+
+  .header
+    font-weight: bold
+    background: var(--accent-bg)
+
+  .champ, .header
+    display: grid
+    grid-template-columns: subgrid
+    grid-template-rows: auto
+    grid-column: span 3
+
+  .champ:nth-child(odd)
+    background: var(--accent-bg)
+
+
+  @media only screen and (max-width: 720px)
+    grid-template-columns: 3fr 6fr
+
+    .champ, .header
+      grid-template-rows: auto auto
+      grid-column: span 2
+
+      .c
+        grid-column: 1
+        grid-row: 1 / span 2
+
+      .r
+        grid-column: 2
+        grid-row: 1
+
+      .n
+        grid-column: 2
+        grid-row: 2
+        font-size: 1rem
+
+    .header .n
+      display: none
+
+
+
 .career
   padding-left: 0
   display: grid

--- a/sass/_tables.sass
+++ b/sass/_tables.sass
@@ -165,7 +165,7 @@ details[open] + .card
   display: grid
   padding-left: 0
   grid-template-rows: auto
-  grid-template-columns: 1fr 1fr 2fr
+  grid-template-columns: minmax(2fr, auto) auto auto
   gap: 0.3em
 
   .n, .c, .r

--- a/templates/orgs/championship_row.html
+++ b/templates/orgs/championship_row.html
@@ -1,0 +1,8 @@
+{% set title = row[0] %}
+{% set champ = row[1] %}
+{% set notes = row[2] | default(value='') %}
+<li class="champ">
+  <span class="c">{{ title | markdown(inline=true) | safe }}</span>
+  <span class="r">{{ champ | markdown(inline=true) | safe }}</span>
+  <span class="n">{{ notes | markdown(inline=true) | safe }}</span>
+</li>

--- a/templates/shortcodes/championship.html
+++ b/templates/shortcodes/championship.html
@@ -1,0 +1,11 @@
+{% set data = load_data(literal=body,format="yaml") %}
+<ul class="championship">
+  <li class="header">
+    <span class="c">Championship</span>
+    <span class="r">Current champion(s)</span>
+    <span class="n">Notes</span>
+  </li>
+  {% for row in data %}
+    {% include "orgs/championship_row.html" %}
+  {% endfor %}
+</ul>


### PR DESCRIPTION
This is a bit of yak-shaving, because the table can be too wide in mobile views, forcing horizontal scrolling, which then causes the lightbox gallery dialog to be in the wrong position.