### PR TITLE
PpW Poznań - brakujące nc

### DIFF
--- a/content/e/ppw/2021-07-30-ppw-poznan-supershow.md
+++ b/content/e/ppw/2021-07-30-ppw-poznan-supershow.md
@@ -27,7 +27,7 @@ Some matches featured wrestlers thinly disguised with a mask, fighting as anothe
 - - '[Hirinus](@/w/hirinus.md)'
   - '2 Chamy: [Automatico](@/w/rob-scaffold.md), [Black Orion](@/w/johnny-blade.md)'
   - s: Handicap Match
-  - nc: '?'
+    nc: '?'
 - - '[Isnorr](@/w/isnorr.md)'
   - '[Adam Wong](@/w/adam-wong.md)'
   - nc: '?'

--- a/content/e/ppw/2021-07-30-ppw-poznan-supershow.md
+++ b/content/e/ppw/2021-07-30-ppw-poznan-supershow.md
@@ -20,20 +20,27 @@ Some matches featured wrestlers thinly disguised with a mask, fighting as anothe
 - d: Day 1
 - - Superior
   - '[Cade Bruce](@/w/mister-z.md)'
+  - nc: '?'
 - - '[Direk](@/w/direk.md)'
   - '[Tony Sk1n](@/w/tony-sk1n.md)'
+  - nc: '?'
 - - '[Hirinus](@/w/hirinus.md)'
   - '2 Chamy: [Automatico](@/w/rob-scaffold.md), [Black Orion](@/w/johnny-blade.md)'
   - s: Handicap Match
+  - nc: '?'
 - - '[Isnorr](@/w/isnorr.md)'
   - '[Adam Wong](@/w/adam-wong.md)'
+  - nc: '?'
 - - '[Esteban Lucha](@/w/biesiad.md)'
   - '[Czacha](@/w/johnny-blade.md)'
+  - nc: '?'
 - - '[Adam Wong](@/w/adam-wong.md)'
   - '[Esteban Lucha](@/w/biesiad.md)'
+  - nc: '?'
 - - '[Isnorr](@/w/isnorr.md)'
   - '[Hades](@/w/olgierd.md)'
   - s: Hardcore Match
+    nc: '?'
 - - '[Rob Scaffold](@/w/rob-scaffold.md)'
   - '[Tony Sk1n](@/w/tony-sk1n.md)'
   - '[Adam Wong](@/w/adam-wong.md)'
@@ -44,21 +51,28 @@ Some matches featured wrestlers thinly disguised with a mask, fighting as anothe
   - '[Direk](@/w/direk.md)'
   - '[Hades](@/w/olgierd.md)'
   - s: Royal Rumble
+    nc: '?'
 - d: Day 2
   date: 2021-07-31
 - - '[Isnorr](@/w/isnorr.md)'
   - '[Esteban Lucha](@/w/biesiad.md)'
+  - nc: '?'
 - - '[Aron Wake](@/w/aron-wake.md)'
   - '[Rob Scaffold](@/w/rob-scaffold.md)'
+  - nc: '?'
 - - '[Hades](@/w/olgierd.md)'
   - '[Tony Sk1n](@/w/tony-sk1n.md)'
+  - nc: '?'
 - - '[Cade Bruce](@/w/mister-z.md)'
   - '[Madman Charlie](@/w/madman-charlie.md)'
+  - nc: '?'
 - - '[Johnny Blade](@/w/johnny-blade.md)'
   - '[Adam Wong](@/w/adam-wong.md)'
   - s: Classic Wrestling Match
+    nc: '?'
 - - '[Isnorr](@/w/isnorr.md)'
   - '[Bonus CBD](@/w/gabriel-queen.md)'
+  - nc: '?'
 - credits:
     Host, Ring Announcer: '[Michael HT](@/w/michael-ht.md)'
     Referees: '[Sędzia Gocha](@/w/sedzia-borys.md)'

--- a/content/e/ppw/2023-11-24-ppw-piwo-przyjacielem-wrestlingu.md
+++ b/content/e/ppw/2023-11-24-ppw-piwo-przyjacielem-wrestlingu.md
@@ -18,20 +18,26 @@ Piwo Przyjacielem Wrestlingu (_"Beer Is Wrestling's Friend"_) was an event by Pp
 Because the event was an exhibition show held for a mostly non-wrestling audience, the performers focused on comedy and invented new, humorous gimmicks. The card listed here covers both days of the event.
 
 {% card() %}
-- - "[Karol M](@/w/goblin.md)"
-  - "[Miłosz Z](@/w/mister-z.md)"
+- - '[Karol M](@/w/goblin.md)'
+  - '[Miłosz Z](@/w/mister-z.md)'
   - s: Young Lions Match
+    nc: '?'
 - - '[Isnorr](@/w/isnorr.md)'
   - '[Striker](@/w/royal-striker.md)'
-  - Mamet
+  - 'Mamet'
+  - nc: '?'
 - - '[Gustav Gryffin](@/w/gustav-gryffin.md)'
-  - "[Steven Kimono](@/w/biesiad.md)"
-- - "[Czacha](@/w/johnny-blade.md)"
-  - "[El Senior Cerveza](@/w/goblin.md)"
+  - '[Steven Kimono](@/w/biesiad.md)'
+  - nc: '?'
+- - '[Czacha](@/w/johnny-blade.md)'
+  - '[El Senior Cerveza](@/w/goblin.md)'
+  - nc: '?'
 - - '[Feager](@/w/feager.md)'
   - '[Adam Wong](@/w/adam-wong.md)'
+  - nc: '?'
 - - '[Isnorr](@/w/isnorr.md)'
   - '[Bonus CBD](@/w/gabriel-queen.md)'
+  - nc: '?'
 - - >
     Team Biesiad:
     [Biesiad Strong](@/w/biesiad.md),
@@ -44,25 +50,31 @@ Because the event was an exhibition show held for a mostly non-wrestling audienc
     [Isnorr](@/w/isnorr.md)
     [Gustav Gryffin](@/w/gustav-gryffin.md)
     [Kapitan Bazooka](@/w/kapitan-bazooka.md)
-  - nc: "?"
-    s: "4 vs 4 Elimination Match"
+  - s: "4 vs 4 Elimination Match"
+    nc: '?'
 - - '[Mister Z](@/w/mister-z.md)'
   - '[Isnorr](@/w/isnorr.md)'
   - '[Feager](@/w/feager.md)'
+  - nc: '?'
 - - '[Czesław Pierdolec](@/w/kapitan-bazooka.md)'
   - "[Steven Kimono](@/w/biesiad.md)"
+  - nc: '?'
 - - "[Isnorr](@/w/isnorr.md)"
   - "[Mister Z](@/w/mister-z.md)"
   - "[Striker](@/w/royal-striker.md)"
-  - Mamet
+  - 'Mamet'
   - s: "New Jack Tribute Match"
+    nc: '?'
 - - 'Bracia Pierdolec: [Czesław Pierdolec](@/w/kapitan-bazooka.md), [Gustav Pierdolec](@/w/gustav-gryffin.md)'
   - "Bracia Kimono: [Steven Kimono](@/w/biesiad.md), Konnan Kimono"
   - s: Tag Team Match
-- - "[Hardcore Gustav](@/w/gustav-gryffin.md)"
-  - "[El Senior Cerveza](@/w/goblin.md)"
-- - "[Kapral Kornel](@/w/sedzia-kornel.md)"
+    nc: '?'
+- - '[Hardcore Gustav](@/w/gustav-gryffin.md)'
+  - '[El Senior Cerveza](@/w/goblin.md)'
+  - nc: '?'
+- - '[Kapral Kornel](@/w/sedzia-kornel.md)'
   - '[Kapitan Bazooka](@/w/kapitan-bazooka.md)'
+  - nc: '?'
 - - '[Biesiad Strong](@/w/biesiad.md)'
   - '[Mister Z](@/w/mister-z.md)'
   - '[Goblin](@/w/goblin.md)'
@@ -71,6 +83,7 @@ Because the event was an exhibition show held for a mostly non-wrestling audienc
   - '[Feager](@/w/feager.md)'
   - '[Kapitan Bazooka](@/w/kapitan-bazooka.md)'
   - s: 20 man Royal Rumble
+    nc: '?'
 - credits:
     Host, Ring Announcer: '[Michael HT](@/w/michael-ht.md)'
     Referees: '[Sędzia Kornel](@/w/sedzia-kornel.md)'


### PR DESCRIPTION
Jest hide_results=true bo nei znamy wyników, ale brakowało nc: ?, co zakłamywało listę walk na stronach zawodników.