### PR TITLE
Accept apostrophe in team name when building roster and other metadata

### DIFF
--- a/content/c/ptw-tag-team-championship.md
+++ b/content/c/ptw-tag-team-championship.md
@@ -101,7 +101,7 @@ While Boro never defended the title, he was also recognized as a champion.
     ed: 2024-08-25
     en: '[PTW Underground 22](@/e/ptw/2024-08-25-ptw-underground-22.md)'
 - - 'Budapest Bastards: [Nitro](@/w/nitro.md), [Renegade](@/w/renegade.md)(c)'
-  - "L'Orda: Luca Bjorn, [Rust](@/w/rust.md)"
+  - "L'Orda: [Luca Bjorn](@/w/luca-bjorn.md), [Rust](@/w/rust.md)"
   - s: Tag Team Match
     ed: 2024-12-07
     en: '[PTW Underground 25](@/e/ptw/2024-12-07-ptw-underground-25.md)'

--- a/content/e/ptw/2024-12-07-ptw-underground-25.md
+++ b/content/e/ptw/2024-12-07-ptw-underground-25.md
@@ -37,7 +37,7 @@ For this event, PTW invited Session Moth Martina, Irish wrestler from Dublin, wh
   - s: 'Career Threatening Match'
     nc: upcoming
 - - 'Budapest Bastards: [Nitro](@/w/nitro.md), [Renegade](@/w/renegade.md)(c)'
-  - "L'Orda: Luca Bjorn, [Rust](@/w/rust.md)"
+  - "L'Orda: [Luca Bjorn](@/w/luca-bjorn.md), [Rust](@/w/rust.md)"
   - c: '[PTW Championship](@/c/ptw-championship.md)'
     s: 'Hardcore Tornado Tag Team Match'
     nc: upcoming

--- a/src/card.py
+++ b/src/card.py
@@ -156,7 +156,7 @@ class Match:
     tag_team_re = re.compile(r'''
         ^
          (?:
-           (?P<team>[\w\s]+) # Team name followed by a colon
+           (?P<team>[-'\w\s]+) # Team name followed by a colon
            (?:\s*\(c\))? # Optional champion marker
            : # Followed by a colon
          )? # All optional


### PR DESCRIPTION
Fixes #847, replaces #848 