### PR TITLE
Highlight a person's position in the card on their results page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ index: $(MINISEARCH_INDEX)
 clean:
 	rm -rf $(ROSTERS) $(METADATA) $(PLOTS) $(CAL) $(MINISEARCH_INDEX) data/all_time_roster.json data/aliases.json
 
-data/all_matches.json data/appearances.json data/crew_appearances.json &: content/e/**/*.md
+data/all_matches.json data/appearances.json data/crew_appearances.json data/appearances_v2.json &: content/e/**/*.md
 	bin/build-matches
 
 data/career.json: content/e/**/*.md

--- a/src/bin/matches.py
+++ b/src/bin/matches.py
@@ -30,7 +30,7 @@ def main():
     events_dir = content_dir / "e"
     event_pages = events_dir.glob("**/????-??-??-*.md")
     # 2. For each event page, determine it's organization (can be more than one) from page name or frontmatter
-    i = 0
+    global_match_num = 0
     for path in event_pages:
         try:
             page = EventPage(path, verbose=False)
@@ -52,6 +52,7 @@ def main():
                 n=page.title,
                 m=bout,
                 p=relative_path,
+                i=global_match_num
             )
             if predicted:
                 info['tt'] = 'predicted'
@@ -62,11 +63,11 @@ def main():
 
             all_bouts.append(info)
 
-            for person in bout.all_names():
+            for index, person in bout.all_names_indexed():
                 if not accepted_name(person.name): continue
                 bouts = appearances.setdefault(person.name, [])
-                bouts.append(i)
-            i += 1
+                bouts.append((global_match_num, index))
+            global_match_num += 1
 
         if not card.crew: continue
 
@@ -92,6 +93,11 @@ def main():
 
     with (data_dir / 'appearances.json').open('w') as f:
         print("Saving appearance map to %s" % f.name)
+        app_simple = {name: [apr[0] for apr in bouts] for name, bouts in appearances.items()}
+        json.dump(app_simple, f)
+
+    with (data_dir / 'appearances_v2.json').open('w') as f:
+        print("Saving appearance map v2 to %s" % f.name)
         json.dump(appearances, f)
 
     with (data_dir / 'crew_appearances.json').open('w') as f:

--- a/src/card.py
+++ b/src/card.py
@@ -192,6 +192,13 @@ class Match:
                 for name in members.all_names()
                 )
 
+    def all_names_indexed(self):
+        return ((i, name)
+                for i, person_or_team in enumerate(self.opponents)
+                for members in person_or_team
+                for name in members.all_names()
+                )
+
     def winner(self) -> Iterable[Participant]:
         return self.opponents[0]
 

--- a/templates/career/matchlist.html
+++ b/templates/career/matchlist.html
@@ -21,9 +21,6 @@
 {% set appearances = [] %}
 {% set matches_by_date = my_matches | sort(attribute='d') %}
 {% set my_match_pos = my_appearances | group_by(attribute='0') %}
-<pre>
-  {{ my_match_pos | json_encode(pretty=true) }}
-</pre>
 
 {% if my_matches %}
 <h3>Matches and segments</h3>
@@ -40,7 +37,6 @@
             {% for org in match.o %}
               {{ macros::promolink_color(code=org, styles=org_styles) }}
             {% endfor %}
-            {{ match.i }}
         </span>
         {% set row = match.m %}
         {# It may happen that the same match.i happens more than once #}

--- a/templates/career/matchlist.html
+++ b/templates/career/matchlist.html
@@ -19,7 +19,7 @@
 {% set careers = [] %}
 {% set all_matches = [] %}
 {% set appearances = [] %}
-{% set matches_by_date = my_matches | sort(attribute='d') %}
+{% set matches_by_date = my_matches | sort(attribute='d') | unique(attribute='i') %}
 {% set my_match_pos = my_appearances | group_by(attribute='0') %}
 
 {% if my_matches %}
@@ -41,8 +41,8 @@
         {% set row = match.m %}
         {# It may happen that the same match.i happens more than once #}
         {# This means more than one appearance in that match (think rumbles, entering under different names) #}
-        {# In that case, each pos should be used, order does not matter #}
-        {% set pos = my_match_pos[match.i] | last | last %}
+        {# These matches were filtered out by unique above, so we have only one. #}
+        {% set positions = my_match_pos[match.i] | map(attribute='1') %}
         <span class="r">
             {% include "career/result_row.html" %}
             {% set event_path = "@/" ~ match.p %}

--- a/templates/career/matchlist.html
+++ b/templates/career/matchlist.html
@@ -1,7 +1,7 @@
 {%- import "macros/career.html" as macros %}
 {% set org_styles = config.extra.org_styles %}
 {% set all_matches = load_data(path="data/all_matches.json") %}
-{% set appearances = load_data(path="data/appearances.json") %}
+{% set appearances = load_data(path="data/appearances_v2.json") %}
 {% if page.extra.career_name %}
     {% set my_appearances = appearances | get(key=page.extra.career_name) %}
 {% else %}
@@ -12,13 +12,18 @@
     {% set_global my_appearances = my_appearances | concat(with=alias_appearances) %}
 {% endfor %}
 {% set_global my_matches = [] -%}
-{% for index in my_appearances %}
-{% set_global my_matches = my_matches | concat(with=all_matches[index]) %}
+{% for entry in my_appearances %}
+  {% set index = entry[0] %}
+  {% set_global my_matches = my_matches | concat(with=all_matches[index]) %}
 {% endfor %}
 {% set careers = [] %}
 {% set all_matches = [] %}
 {% set appearances = [] %}
 {% set matches_by_date = my_matches | sort(attribute='d') %}
+{% set my_match_pos = my_appearances | group_by(attribute='0') %}
+<pre>
+  {{ my_match_pos | json_encode(pretty=true) }}
+</pre>
 
 {% if my_matches %}
 <h3>Matches and segments</h3>
@@ -35,8 +40,13 @@
             {% for org in match.o %}
               {{ macros::promolink_color(code=org, styles=org_styles) }}
             {% endfor %}
+            {{ match.i }}
         </span>
         {% set row = match.m %}
+        {# It may happen that the same match.i happens more than once #}
+        {# This means more than one appearance in that match (think rumbles, entering under different names) #}
+        {# In that case, each pos should be used, order does not matter #}
+        {% set pos = my_match_pos[match.i] | last | last %}
         <span class="r">
             {% include "career/result_row.html" %}
             {% set event_path = "@/" ~ match.p %}

--- a/templates/career/result_row.html
+++ b/templates/career/result_row.html
@@ -22,12 +22,13 @@
     {% set sep = "defeated" %}
 {% endif %}
 {% if not stip %}{% set stip = default_stip %}{% endif %}
+{% set positions = positions | default(value=[]) %}
 
 {% if segment %}
   <strong>Segment:</strong> {{ winner | markdown(inline=true) | safe }}{% if others %}, {{ others | join(sep=", ") | markdown(inline=true) | safe }}{% endif %}
 {% else %}
   {% if bodies == 0 and not final.nc %} Winner: {% endif %}
-  {% if pos == 0 %}
+  {% if 0 in positions %}
     <strong>{{ winner | markdown(inline=true) | safe }}</strong>
   {% else %}
     {{ winner | markdown(inline=true) | safe }}
@@ -35,7 +36,7 @@
   {% if bodies > 0 %}
     {{ sep }}
     {% for opponent in others %}
-      {% if loop.index == pos %}
+      {% if loop.index in positions %}
         <strong>{{ opponent | markdown(inline=true) | safe }}</strong>
       {% else %}
         {{ opponent | markdown(inline=true) | safe }}

--- a/templates/career/result_row.html
+++ b/templates/career/result_row.html
@@ -26,7 +26,6 @@
 {% if segment %}
   <strong>Segment:</strong> {{ winner | markdown(inline=true) | safe }}{% if others %}, {{ others | join(sep=", ") | markdown(inline=true) | safe }}{% endif %}
 {% else %}
-  {{ pos }}
   {% if bodies == 0 and not final.nc %} Winner: {% endif %}
   {% if pos == 0 %}
     <strong>{{ winner | markdown(inline=true) | safe }}</strong>

--- a/templates/career/result_row.html
+++ b/templates/career/result_row.html
@@ -26,10 +26,26 @@
 {% if segment %}
   <strong>Segment:</strong> {{ winner | markdown(inline=true) | safe }}{% if others %}, {{ others | join(sep=", ") | markdown(inline=true) | safe }}{% endif %}
 {% else %}
+  {{ pos }}
   {% if bodies == 0 and not final.nc %} Winner: {% endif %}
-  {{ winner | markdown(inline=true) | safe }}
+  {% if pos == 0 %}
+    <strong>{{ winner | markdown(inline=true) | safe }}</strong>
+  {% else %}
+    {{ winner | markdown(inline=true) | safe }}
+  {% endif %}
   {% if bodies > 0 %}
-    {{ sep }} {{ others | join(sep=" and ") | markdown(inline=true) | safe }}
+    {{ sep }}
+    {% for opponent in others %}
+      {% if loop.index == pos %}
+        <strong>{{ opponent | markdown(inline=true) | safe }}</strong>
+      {% else %}
+        {{ opponent | markdown(inline=true) | safe }}
+      {% endif %}
+      {% if not loop.last %}
+        and
+      {% endif %}
+    {% endfor %}
+    {# {{ others | join(sep=" and ") | markdown(inline=true) | safe }} #}
   {% endif %}
   {% if final.r %}
       via {{ final.r }}


### PR DESCRIPTION
When viewing career matchlist on a talent page, highlight (in bold) their name in the match results. 

### Before

![image](https://github.com/user-attachments/assets/15ae4668-9198-4b6a-b5c0-009f599f1007)

### After

![image](https://github.com/user-attachments/assets/696a3310-3ba0-4238-b5f7-034483850b64)

Collapsed what was two entries into one: Goblin and Larwa in the same match, both highlighted.

 and for tag teams, the only solution is to highlight the whole team

![image](https://github.com/user-attachments/assets/82bc9afc-02ff-4b65-b800-f6aead7ef327)

Also: only matches, not segments.
