### PR TITLE
Nowe gale PTW

### DIFF
--- a/content/e/ptw/2025-01-11-ptw-nowe-porzadki.md
+++ b/content/e/ptw/2025-01-11-ptw-nowe-porzadki.md
@@ -1,0 +1,15 @@
++++
+title = "PTW: Nowe Porządki"
+template = "event_page.html"
+authors = ["M3n747"]
+[taxonomies]
+chronology = ["ptw", "underground"]
+venue = ["dworek-kozlow"]
+[extra]
+hide_results = true
+city = "Kozłów"
++++
+
+"Nowe Porządki" (_A New Order_) is an upcoming show by [Prime Time Wrestling](@/o/ptw.md) and the first to drop the "Underground" name. The show was announced around eight hours after [KPW Arena 27: Nowe Porządki](@/e/kpw/2025-01-24-kpw-arena-27.md); whether or not the identical names are a coincidence, currently remains unknown.
+
+{{ skip_card() }}

--- a/content/e/ptw/2025-02-15-ptw-wrestlingowe-walentynki.md
+++ b/content/e/ptw/2025-02-15-ptw-wrestlingowe-walentynki.md
@@ -1,0 +1,15 @@
++++
+title = "PTW: Wrestlingowe Walentynki"
+template = "event_page.html"
+authors = ["M3n747"]
+[taxonomies]
+chronology = ["ptw", "underground"]
+venue = ["dworek-kozlow"]
+[extra]
+hide_results = true
+city = "Kozłów"
++++
+
+"Wrestlingowe Walentynki" (_Wrestling St. Vallentine's Day_) is an upcoming show by [Prime Time Wrestling](@/o/ptw.md), set to take place the day after St. Vallentine's Day. It is the third PTW show, after [Halloweenowy Łomot](@/e/ptw/2024-10-19-ptw-underground-23.md) and [Wrestlingowe Mikołajki](@/e/ptw/2024-12-07-ptw-underground-25.md), to be named after a holiday.
+
+{{ skip_card() }}

--- a/content/e/ptw/2025-03-15-ptw-wiosenna-bijatyka.md
+++ b/content/e/ptw/2025-03-15-ptw-wiosenna-bijatyka.md
@@ -1,0 +1,15 @@
++++
+title = "PTW: Wiosenna Bijatyka"
+template = "event_page.html"
+authors = ["M3n747"]
+[taxonomies]
+chronology = ["ptw", "underground"]
+venue = ["dworek-kozlow"]
+[extra]
+hide_results = true
+city = "Kozłów"
++++
+
+"Wiosenna Bijatyka" (_Spring Brawl_) is an upcoming show by [Prime Time Wrestling](@/o/ptw.md).
+
+{{ skip_card() }}


### PR DESCRIPTION
Na razie w chronologii zostawiam "underground", dopóki nie wymyślimy na co to podmienić.