### PR TITLE
Replace underscores with dashes in page paths to better match Zola's …

### DIFF
--- a/src/bin/talent_gallery.py
+++ b/src/bin/talent_gallery.py
@@ -64,7 +64,7 @@ def combine_path(event_page: EventPage, subdir, photo_path: str) -> str:
     content_root = Path.cwd() / 'content'
     relative = event_page.path.relative_to(content_root)
     path = relative / subdir / photo_path
-    return str(path).replace('.md', '')
+    return str(path).replace('.md', '').replace('_', '-')
 
 def generate_key(event_page: EventPage, index: int):
     """Given an event page and photo index, generate an identifier unique within that page."""

--- a/src/bin/talent_gallery.py
+++ b/src/bin/talent_gallery.py
@@ -63,8 +63,9 @@ def combine_path(event_page: EventPage, subdir, photo_path: str) -> str:
     """Given an event page and a photo path that should be located in its directory, generate a path from content root."""
     content_root = Path.cwd() / 'content'
     relative = event_page.path.relative_to(content_root)
-    path = relative / subdir / photo_path
-    return str(path).replace('.md', '').replace('_', '-')
+    slugified = Path(str(relative).replace('_', '-'))
+    path = slugified / subdir / photo_path
+    return str(path).replace('.md', '')
 
 def generate_key(event_page: EventPage, index: int):
     """Given an event page and photo index, generate an identifier unique within that page."""


### PR DESCRIPTION
Should help with missing photos from co-branded events (MZW/PPW Żadnych Granic) in talent pages, e.g. Shadow's.