### PR TITLE
PTW Awards update

### DIFF
--- a/content/a/ptw-awards-2022.md
+++ b/content/a/ptw-awards-2022.md
@@ -1,20 +1,21 @@
 +++
-title = "PTW Awards"
+title = "PTW Awards 2022"
 weight = 6
 template = "article.html"
 authors = ["Seweryn Pielucha"]
 [extra.gallery]
-1 = { path = "hero-of-the-year.webp", caption = "Nominees for the Hero Of the Year category.", source = "Facebook PTW"}
+1 = { path = "hero-of-the-year.webp", caption = "Nominees for the Hero of the Year category.", source = "Facebook PTW"}
 2 = { path = "ptw-awards-statues.webp", caption = "Awards statues made of acrylic glass, set on the ring in [PTW Performance Center](@/v/ptw-targowa.md)", source = "Facebook PTW"}
 3 = { path = "ptw-awards-results.png", caption = "Facebook post announcing winners in each category.", source = "Facebook PTW"}
 +++
 
-The PTW Awards (Nagrody podsumowujące rok, loosely translated as _End-Of-Year Awards_) are a PTW initiative where awards, similar to the Academy Awards or WWE-estabilished Slammy Awards, are given to professional wrestlers and other individuals within PTW, such as commentators and referees, for notable achievements during the year.
+The PTW Awards ("Nagrody podsumowujące rok", loosely translated as _End-of-the-Year Awards_) are a [PTW](@/o/ptw.md) initiative where awards, similar to the Academy Awards or WWE-estabilished Slammy Awards, are given to professional wrestlers and other individuals within PTW, such as commentators and referees, for notable achievements during the year.
 
 <!-- more -->
 
-The awards were originally planned to be hosted annually, at the end of the year.
-However, so far only one edition has been held, in Dec 2022/Jan 2023, to summarize the first chapter of PTW's existence, from [PTW#1: Revolucja](@/e/ptw/2021-10-09-ptw-1-revolucja.md) until the end of 2022.
+The awards were originally planned to be hosted annually, at the end of each year. This plan didn't entirely pan out, however, as there was no 2023/24 edition of the Awards. Instead, this edition was followed [two years later](@/a/ptw-awards-2024.md).
+
+The first edition took place in Dec 2022/Jan 2023, to summarize the first chapter of PTW's existence, from [PTW#1: Revolucja](@/e/ptw/2021-10-09-ptw-1-revolucja.md) until the end of 2022.
 Fans nominated their candidates by voting with reactions on PTW's Facebook page, which posted selected nominees in multiple categories.
 
 This award ceremony was held during [PTW Underground 12](@/e/ptw/2023-02-26-ptw-underground-12.md).

--- a/content/a/ptw-awards-2024.md
+++ b/content/a/ptw-awards-2024.md
@@ -21,3 +21,4 @@ Like previously, the winners are decided by fans on the official PTW Facebook fa
 - Debiutant Roku (_Newcomer of the Year_)
 - Progres Roku (_Progress of the Year_)
 - Mówca Roku (_Speaker of the Year_)
+- Bohater Roku (_Hero of the Year_)

--- a/content/a/ptw-awards-2024.md
+++ b/content/a/ptw-awards-2024.md
@@ -1,0 +1,23 @@
++++
+title = "PTW Awards 2024"
+weight = 6
+template = "article.html"
+authors = ["M3n747"]
+[extra.gallery]
+1 = { path = "awards-2024-wrestler-roku.jpg", caption = "Nominees for the Wrestler of the Year category.", source = "Official PTW Facebook"}
++++
+
+This is the second edition of the PTW End-of-the-Year Awards.
+
+<!-- more -->
+
+PTW Awards 2024 is a follow-up to the [2022 edition](@/a/ptw-awards-2022.md), as the 2023 one didn't take place. 
+
+Like previously, the winners are decided by fans on the official PTW Facebook fanpage by voting with FB reactions for the nominees. The voting started in mid-December 2024 and is set to comprise ten categories.
+
+## Categories awarded
+
+- Wrestler Roku (_Wrestler of the Year_)
+- Debiutant Roku (_Newcomer of the Year_)
+- Progres Roku (_Progress of the Year_)
+- Mówca Roku (_Speaker of the Year_)

--- a/content/w/alex-brave.md
+++ b/content/w/alex-brave.md
@@ -29,7 +29,7 @@ He joined Referees [Matek](@/w/sedzia-matek.md) and [Sewi](@/w/sedzia-seweryn.md
 
 #### Asian Scandal and becoming S.Rafał
 
-In late 2024 he was nominated for [PTW Awards](@/a/ptw-awards.md), in the "Referee of the Year" category.
+In late 2024 he was nominated for [PTW Awards 2022](@/a/ptw-awards-2022.md), in the "Referee of the Year" category.
 During the popular vote, he was outvoted by Matek and Sewi by over 100 votes each, when he unexpectedly gained a couple hundred votes.
 Upon closer examination, it appeared that all of his votes were in fact purchased from a bot website; all of them were coming from Vietnam.
 This was dubbed the "Asian Scandal", with Rafał being the main suspect.

--- a/content/w/axel-fox.md
+++ b/content/w/axel-fox.md
@@ -129,11 +129,11 @@ During the match he was initially named as the winner, but due to a minimal rope
 
 ## Championships and accomplishments
 
-[PTW Awards](@/a/ptw-awards.md) (4 times):
-- Hero of the Year (2022)
-- Match of the Year (2022) - vs Justin Joy at [PTW#3: Legends](@/e/ptw/2022-11-26-ptw-3-legends.md)
-- Moment of the Year (2022) - reuniting with Justin Joy
-- Feud of the Year (2022) - vs Justin Joy
+[PTW Awards 2022](@/a/ptw-awards-2022.md) (4 times):
+- Hero of the Year
+- Match of the Year - vs Justin Joy at [PTW#3: Legends](@/e/ptw/2022-11-26-ptw-3-legends.md)
+- Moment of the Year - reuniting with Justin Joy
+- Feud of the Year - vs Justin Joy
 
 ### References
 

--- a/content/w/gabriel-queen.md
+++ b/content/w/gabriel-queen.md
@@ -80,7 +80,7 @@ The reunited tag team issued an open challenge at [Ledwo Legalne IV](@/e/ppw/202
 ## Championships and accomplishments
 
 * [Prime Time Wrestling](@/o/ptw.md)
-  - [PTW Awards](@/a/ptw-awards.md) (1 time)
+  - [PTW Awards 2022](@/a/ptw-awards-2022.md) (1 time)
 * Tag Team of the Year (as Pure Gold)
 * [PpW Ewenement Wrestling](@/o/ppw.md)
   - Golden Goat Trophy (1 time)

--- a/content/w/sedzia-klaudiusz.md
+++ b/content/w/sedzia-klaudiusz.md
@@ -29,7 +29,7 @@ At [Underground 6](@/e/ptw/2022-06-26-ptw-underground-6.md) Klaudiusz made his d
 
 #### Referee Klaudiusz
 
-Klaudiusz returned to PTW's ring as a referee making his re-debut at [Underground 14](@/e/ptw/2023-04-23-ptw-underground-14.md), to fill in as a second referee working with Senior [Referee Seweryn](@/w/sedzia-seweryn.md), after the suspention of [Referee Rafał](@/w/alex-brave.md) after the ["Asian Controversy"](@/a/ptw-awards.md). He continued to make regular appearances in PTW from this point onward. After Sewi's [departure from PTW](@/a/ptw-exits.md) following [Total Blast From The Past](@/e/ptw/2024-05-11-ptw-6.md), in June 2024 he became Senior Referee of PTW, and has been joined by Referee Herno soon after.
+Klaudiusz returned to PTW's ring as a referee making his re-debut at [Underground 14](@/e/ptw/2023-04-23-ptw-underground-14.md), to fill in as a second referee working with Senior [Referee Seweryn](@/w/sedzia-seweryn.md), after the suspention of [Referee Rafał](@/w/alex-brave.md) after the ["Asian Scandal"](@/a/ptw-awards-2022.md). He continued to make regular appearances in PTW from this point onward. After Sewi's [departure from PTW](@/a/ptw-exits.md) following [Total Blast From The Past](@/e/ptw/2024-05-11-ptw-6.md), in June 2024 he became Senior Referee of PTW, and has been joined by Referee Herno soon after.
 
 ## In wrestling
 

--- a/content/w/sedzia-seweryn.md
+++ b/content/w/sedzia-seweryn.md
@@ -46,9 +46,9 @@ Many of them either suspended their wrestling career, or transferred to Prime Ti
 
 Sewi the Ref debuted at [PTW Underground 2](@/e/ptw/2022-01-23-ptw-underground-2.md), which marked the start of his 2-year tenure as referee in the federation.
 He worked along [Sędzia Matek](@/w/sedzia-matek.md), with [Sędzia Rafał](@/w/alex-brave.md) joining in the second half of 2022.
-After Rafał's suspension due to the ["Asian Scandal" controversy](@/a/ptw-awards.md), and Matek's quiet departure from the company, he became the _de facto_ Senior Referee, briefly working as the sole referee for [Underground 11](@/e/ptw/2023-01-29-ptw-underground-11.md) & [12](@/e/ptw/2023-02-26-ptw-underground-12.md), before being joined by [Klaudiusz](@/w/sedzia-klaudiusz.md).
+After Rafał's suspension due to the ["Asian Scandal" controversy](@/a/ptw-awards-2022.md), and Matek's quiet departure from the company, he became the _de facto_ Senior Referee, briefly working as the sole referee for [Underground 11](@/e/ptw/2023-01-29-ptw-underground-11.md) & [12](@/e/ptw/2023-02-26-ptw-underground-12.md), before being joined by [Klaudiusz](@/w/sedzia-klaudiusz.md).
 For most of 2023 and 2024 he maintained his position as the main referee, working many of the main events and matches with high-profile international wrestlers.
-He was also awarded the [PTW's "Referee of the Year" Award](@/a/ptw-awards.md) for 2022.
+He was also awarded the [PTW's "Referee of the Year" Award](@/a/ptw-awards-2022.md) for 2022.
 
 During his tenure in Prime Time Wrestling, Referee Seweryn also made history as the first Polish referee to work in a foreign promotion, making his international debut at an Austrian Rings of Europe show "WrestleClash 25" in August 2023.
 Later he made yet another appearance at a PTW/WWA show in January 2024.
@@ -82,8 +82,8 @@ During the build-up for the [first show](@/e/low/2024-12-01-low-1.md) it was uno
 ## Championships and achievments:
 
 * [Prime Time Wrestling](@/o/ptw.md)
-  - [PTW Awards](@/a/ptw-awards.md) (1 time):
-    * Referee of the Year (2022)
+  - [PTW Awards 2022](@/a/ptw-awards-2022.md) (1 time):
+    * Referee of the Year
 
 ## Internet presence
 

--- a/content/w/sinister.md
+++ b/content/w/sinister.md
@@ -63,8 +63,8 @@ Sinister made his return to wrestling at [Legacy of Wrestling's](@/o/low.md) [fi
 ## Championships and accomplishments
 
 * [Prime Time Wrestling](@/o/ptw.md)"
-  - [PTW Awards](@/a/ptw-awards.md) (1 time):
-    * Villain of the Year (2022)
+  - [PTW Awards 2022](@/a/ptw-awards-2022.md) (1 time):
+    * Villain of the Year
 
 ## Internet presence
 

--- a/content/w/vic-golden.md
+++ b/content/w/vic-golden.md
@@ -84,7 +84,7 @@ Along with a new ringname - Vic Golden - he also adopted a new gimmick of a flam
 At the [sixth Underground](@/e/ptw/2022-06-26-ptw-underground-6.md), Vic and [Gabriel Queen](@/w/gabriel-queen.md) formed a tag team called Pure Gold.
 They feuded with PAKA and other teams, and were strong candidates to win the Tag Team tournament, defeating such candidates as FoxJoy - [Justin Joy](@/w/justin-joy.md) and [Axel Fox](@/w/axel-fox.md). 
 
-During his time in PTW, Vic managed to win in two categories of fan-voted [PTW Awards](@/a/ptw-awards.md) in 2022 - for a Tag Team of the Year as part of Pure Gold, and for a Newcomer of the Year.
+During his time in PTW, Vic managed to win in two categories of fan-voted [PTW Awards 2022](@/a/ptw-awards-2022.md) - for a Tag Team of the Year as part of Pure Gold, and for a Newcomer of the Year.
 
 Their final match as a team for PTW was during [PTW #4: The Mystery](@/e/ptw/2023-06-25-ptw-4-mystery.md), in the tournament final Tables Match for the newly created [PTW Tag Team Championship](@/c/ptw-tag-team-championship.md), which they however lost to PAKA.
 Later, they briefly joined forces with Legia Łysych ([Olgierd](@/w/olgierd.md) and [Marco Hammers](@/w/marco-hammers.md)), feuding against PAKA. Their failure to get rid of PAKA and shifting the blame away from them later transitioned into a feud between Pure Gold and Legia themselves, with the pay-off only happening nearly a year later in [PpW](@/o/ppw.md).
@@ -139,9 +139,9 @@ After Legia Łysych joined [Zmowa](@/a/the-collusion.md), Pure Gold became their
   - BWN Championship (1 time)
 
 * [Prime Time Wrestling](@/o/ptw.md):
-  - [PTW Awards](@/a/ptw-awards.md) (2 times):
-    * Tag Team of the Year (2022) - with [Gabriel Queen](@/w/gabriel-queen.md)
-    * Newcomer of the Year (2022)
+  - [PTW Awards 2022](@/a/ptw-awards-2022.md) (2 times):
+    * Tag Team of the Year - with [Gabriel Queen](@/w/gabriel-queen.md)
+    * Newcomer of the Year
 
 ## Internet presence
 


### PR DESCRIPTION
Zmiana tytułu pierwszego artykułu z "PTW Awards" na "PTW Awards 2022", dodany wstępny szkic PTW Awards 2024, poprawki linków gdzie potrzeba.