### PR TITLE
Autoscaling photos

### DIFF
--- a/sass/_lightbox.sass
+++ b/sass/_lightbox.sass
@@ -73,6 +73,7 @@ dialog#lb
 
   img
     object-fit: contain
+    height: 100%
 
   figcaption
     align-self: flex-end


### PR DESCRIPTION
Add height:100% to lightbox image container, which should help auto zoom low-resolution images (e.g. TBW2)