### PR TITLE
Add a small animation to indicate that search index is still loading.

### DIFF
--- a/sass/_search.sass
+++ b/sass/_search.sass
@@ -34,6 +34,16 @@
       height: 1.5rem
       width: 1.5rem
 
+      &.spin
+        animation: spin 3s linear infinite
+
+@keyframes spin
+  0%
+    transform: rotate(0deg)
+  100%
+    transform: rotate(360deg)
+
+
 .search-results
   display: none
   position: absolute

--- a/static/search.js
+++ b/static/search.js
@@ -117,11 +117,29 @@ class SearchController {
         return text.replace(/\p{L}/gu, m => chars[m] || m).toLowerCase();
     }
 
+    spin(enabled) {
+        const svg = this.searchboxTarget.querySelector('button > svg')
+        const icon = svg.querySelector('use')
+        const url = new URL(icon.href.baseVal)
+        if (enabled) {
+            url.hash = '#loader'
+            svg.classList.add('spin')
+        } else {
+            url.hash = '#search'
+            svg.classList.remove('spin')
+        }
+
+        icon.href.baseVal = url.toString()
+
+
+    }
+
     async search() {
         // Load index on first use
         if (this.index === undefined) {
             await this.load_minisearch()
             await this.load_index()
+            this.spin(false)
         }
 
         let term = this.queryTarget.value.trim()
@@ -138,6 +156,7 @@ class SearchController {
 
     async load_index() {
         let response = await fetch("/minisearch_index.json")
+        this.spin(true)
 
         this.index = MiniSearch.loadJSON(await response.text(), {
             fields: ['title', 'text'],


### PR DESCRIPTION
To test: set network throttling in devtools to e.g. 3G. Notice that search is not functional after focusing and typing, and that two requests were fired to fetch the minisearch code and the site index (this part is not new). While the two are pending, the magnifying glass icon in the search field is replaced with a loader, which slowly spins.