### PR TITLE
Fix zooming long photos

### DIFF
--- a/static/gallery.js
+++ b/static/gallery.js
@@ -59,8 +59,10 @@ class LightboxController {
             this.zoom_buttons({ maximize: true, minimize: false})
         } else {
             // this.imgTarget.style.objectFit = 'none'
-            this.imgTarget.style.removeProperty("max-height")
+            this.imgTarget.style.removeProperty('max-height')
+            this.imgTarget.style.removeProperty('height')
             this.imgTarget.style.setProperty('max-width', 'unset', 'important')
+            this.imgTarget.style.setProperty('height', 'unset', 'important')
             this.zoom_buttons({ maximize: false, minimize: true})
             this.containerTarget.classList.add('maximised')
             this.captionTarget.style.visibility = 'collapse'
@@ -70,7 +72,7 @@ class LightboxController {
 
     reset_zoom() {
         const img = this.imgTarget
-        img.style.maxHeight = '100%'
+        img.style.height = '100%'
         img.style.removeProperty('zoom')
         img.style.removeProperty('max-width')
         this.maximised = false


### PR DESCRIPTION
Broken in #956, fixed by controlling height (which is what 956 added to make the small pictures scale).

To test: go to PTW, find Kawaler's long post.