### PR TITLE
All the Brits

### DIFF
--- a/const/name-to-flag.yaml
+++ b/const/name-to-flag.yaml
@@ -95,7 +95,6 @@ Duende: PL # Duende == Sędzia Gocha == Sędzia Borys
 Eddie Rage: HU
 El Generico: CA
 Electra: IT
-Elliott Jordan: ENGLAND
 Emilian Lewis: DK
 Emma: AU
 '"The Enigma" Serg Sullivan': RU # "The Enigma" Serg Sullivan == Serg Sullivan
@@ -159,7 +158,6 @@ Jimmy Uso: US
 Jinder Mahal: CA
 Jody Fleisch: ENGLAND
 Joe Bravo: AT
-Joe Hendry: SCOTLAND
 Joey Ozbourne: ENGLAND
 Joey Riddic: PL
 John Cena: US
@@ -194,15 +192,12 @@ Král Slova Kuba: CZ
 Lanny Poffo: CA
 Laurance Roman: DE
 Layla: ENGLAND
-Lee Rogers: GB
 Leo Zayde: PL
 Leśny: PL
-Lewis Costello: ENGLAND
 Lexi Luxx: SE
 Lider: PL
 Lince Dorado: US
 Lord Tensai: US
-Louis Basham: ENGLAND
 Lucas Robinson: DE
 Ludy Lohan: DE
 Luca Bjorn: IT
@@ -218,11 +213,9 @@ Marcus Monere: DE
 Marek Łojek: PL
 Mario Rodriguez: PL
 Marius Al-Ani: DE
-Mark Andrews: WALES
 Mark Haskins: GB
 Mark Henry: US
 Martn Pain: AT
-Marty Scurll: ENGLAND
 Martyn Stallyon: SCOTLAND
 Mason Madden: US
 Matt Miric: HU
@@ -245,12 +238,10 @@ The Miz: US
 '"Modzel" Szymon Modzelewski': PL
 Mr Chairman: PL # Prezes Legacy
 "Ms. XXX": PL
-Myla Grace: GB # Northern Ireland
 # N
 Natalia Dinges: PL
 Natalya: US
 Newt Nova: ES
-Nick Aldis: GB
 Nick Schreier: DE
 Nickolas von Rijk: DE
 Nightshade: ENGLAND
@@ -267,7 +258,6 @@ Pastor William Eaver: GB
 Paweł Borkowski: PL
 Paweł "Boryss" Borkowski: PL
 Pedrolo: ES
-Pete Dunne: GB
 Peter Tihanyi: HU
 PG Hooker: HU
 Piotr Opolski: PL
@@ -275,7 +265,6 @@ Piotr Małecki: PL # Piotr Małecki == Piotr "ShowOff" Małecki
 Piotr "ShowOff" Małecki: PL # Piotr "ShowOff" Małecki == Piotr Małecki
 PJ Black: ZA
 Polish Giant: PL
-Primate: GB
 Primo: US # Primo == Diego
 # R
 Rambo: DO # Rambo == Salsakid Rambo
@@ -295,7 +284,6 @@ R-Truth: US
 Rubix: DE
 Rusałka: PL
 Rust: IT
-Ryan Smile: ENGLAND
 Ryback: US
 # S
 Sakal: CZ
@@ -305,7 +293,6 @@ Sam Gradwell: GB
 Samuray Del Sol: US
 Scarecrow: PL # Alias of Mister Z
 Scott Rider: FR
-Scotty Rawk: ENGLAND
 Sebastien: CZ
 Senza Volto: FR
 Sędzia Borys: PL # Sędzia Borys == Sędzia Gocha == Duende
@@ -323,7 +310,6 @@ Serg Sullivan: RU # "The Enigma" Serg Sullivan == Serg Sullivan
 Session Moth Martina: IE
 Seth Donner: BY
 Shane Baker: HU
-Sheamus: SCOTLAND
 Shigehiro Irie: JP
 Siostra Kimono: PL # Siostra Kimono == Istotna Martynka
 Sixt: SE
@@ -363,7 +349,6 @@ Violet Nyte: GB
 '"The Veteran" Jack Vaughn': US
 # W
 Wade Barrett: ENGLAND
-Wild Boar: WALES
 Wojciech "Vice" Baranowski: PL
 # X
 Xia Brookside: ENGLAND

--- a/content/a/ptw-awards-2022.md
+++ b/content/a/ptw-awards-2022.md
@@ -53,7 +53,7 @@ Later it turned out that the entire thing was orchestrated as a prank by Szymon 
 
 1. [Puncher](@/w/puncher.md) - 441 votes
 2. [Justin Joy](@/w/justin-joy.md) - 365 votes
-3. Joe Hendry - 65 votes
+3. [Joe Hendry](@/w/joe-hendry.md) - 65 votes
 4. Matt Sydal - 54 votes
 5. [Krampus](@/w/krampus.md) - 27 votes
 
@@ -101,12 +101,12 @@ Later it turned out that the entire thing was orchestrated as a prank by Szymon 
 2. Łukasz Baliński - 75
 3. Piotr Małecki - 56
 4. [Santino](@/w/santino.md) - 35
-5. Lewis Costello - 12
+5. [Lewis Costello](@/w/lewis-costello.md) - 12
 
 #### Female Wrestler of the Year
 
 1. [Diana Strong](@/w/diana-strong.md) - 135
-2. Myla Grace - 86
+2. [Myla Grace](@/w/myla-grace.md) - 86
 3. Xia Brookside - 11
 4. Helena Sixt - 3
 5. Gaya Glass - 0

--- a/content/c/kpw-old-town-championship.md
+++ b/content/c/kpw-old-town-championship.md
@@ -64,7 +64,7 @@ The championship belt also contains two pairs of sideplates with the KPW logo on
     en: '[KPW Arena 9: Na Krawędzi](@/e/kpw/2018-03-10-kpw-arena-9-na-krawedzi.md)'
     ed: 2018-03-10
 - - 'Greg (c)'
-  - 'Lee Rogers'
+  - '[Lee Rogers](@/w/lee-rogers.md)'
   - s: Singles match
     en: '[KPW OldTown 3](@/e/kpw/2018-07-14-kpw-oldtown-3.md)'
     ed: 2018-07-14

--- a/content/c/kpw-tag-team-championship.md
+++ b/content/c/kpw-tag-team-championship.md
@@ -40,7 +40,7 @@ The KPW Tag Team Championship is the Tag Team division championship of [Kombat P
   - s: Tag Team Match
     en: '[Godzina Zero 2019](@/e/kpw/2019-08-17-kpw-godzina-zero-2019.md)'
     ed: 2019-08-17
-- - "The Hunt: Primate, Wild Boar"
+- - "The Hunt: [Primate](@/w/primate.md), [Wild Boar](@/w/wild-boar.md)"
   - "Sawicki, Victor Rosetti (c)"
   - s: Tag Team Match
     en: '[Godzina Zero 2019](@/e/kpw/2019-08-17-kpw-godzina-zero-2019.md)'

--- a/content/e/ddw/2012-03-09-ddw-6.md
+++ b/content/e/ddw/2012-03-09-ddw-6.md
@@ -11,7 +11,7 @@ city = "Rzeszów"
 This event, along with [DDW#7](@/e/ddw/2012-03-10-ddw-7.md) was part of a two-day supershow in Rzeszów and Kolbuszowa.
 
 {% card() %}
-- [Mark Andrews, Ryan Smile]
+- ['[Mark Andrews](@/w/mark-andrews.md)', '[Ryan Smile](@/w/ryan-smile.md)']
 - [Martyn Stallyon, Kamil Leśny]
 - - "PG Hooker, [Renegade](@/w/renegade.md); Sexy Jessie"
   - "[Dover](@/w/dover.md), Koppany"

--- a/content/e/ddw/2012-03-09-ddw-6.md
+++ b/content/e/ddw/2012-03-09-ddw-6.md
@@ -16,7 +16,7 @@ This event, along with [DDW#7](@/e/ddw/2012-03-10-ddw-7.md) was part of a two-da
 - - "PG Hooker, [Renegade](@/w/renegade.md); Sexy Jessie"
   - "[Dover](@/w/dover.md), Koppany"
   - s: "Tag Team Match"
-- ['[Klarys](@/w/klarys.md)', Pete Dunne]
+- ['[Klarys](@/w/klarys.md)', '[Pete Dunne](@/w/pete-dunne.md)']
 - - '[Jędruś Bułecka](@/w/jedrus-bulecka.md)'
   - "[Kevin Williams](@/w/kevin-williams.md); [Pan Pawłowski](@/w/pan-pawlowski.md)"
   - s: Flag Match

--- a/content/e/ddw/2012-03-10-ddw-7.md
+++ b/content/e/ddw/2012-03-10-ddw-7.md
@@ -11,8 +11,15 @@ city = "Kolbuszowa"
 This event, along with [DDW #6](@/e/ddw/2012-03-09-ddw-6.md) was part of a two-day supershow in Rzeszów and Kolbuszowa.
 
 {% card() %}
-- ["[Jędruś Bułecka](@/w/jedrus-bulecka.md), [Klarys](@/w/klarys.md) + Mark Andrews",
-  "[Dover](@/w/dover.md), Pete Dunne + Ryan Smile"]
+- - >
+    [Jędruś Bułecka](@/w/jedrus-bulecka.md),
+    [Klarys](@/w/klarys.md),
+    [Mark Andrews](@/w/mark-andrews.md)
+  - >
+    [Dover](@/w/dover.md),
+    [Pete Dunne](@/w/pete-dunne.md),
+    [Ryan Smile](@/w/ryan-smile.md)
+  - s: Six Man Tag Team Match
 - [Omen, '[Don Roid](@/w/don-roid.md)', {s: "DDW International Championship #1 Contender
       Match"}]
 - [Koppany, Martyn Stallyon, PG Hooker, {s: "Three Way Match"}]

--- a/content/e/kpw/2016-08-13-kpw-godzina-zero-2016.md
+++ b/content/e/kpw/2016-08-13-kpw-godzina-zero-2016.md
@@ -27,7 +27,7 @@ The venue for this event was the Hall of Sports in Gdynia, which would become th
 - [Mika The Polish Punisher, '[Victor Rosetti](@/w/rosetti.md)']
 - ['[Kaszub](@/w/kaszub.md)', '[Damian Lambert](@/w/damien-rothschild.md)', '[Peter
     Pannache](@/w/peter-pannache.md)', {s: Three Way Match}]
-- ['[Sawicki](@/w/sawicki.md)', Elliott Jordan]
+- ['[Sawicki](@/w/sawicki.md)', '[Elliott Jordan](@/w/elliott-jordan.md)']
 - ['[Ron Corvus](@/w/ron-corvus.md)', "[Gracjan Korpo](@/w/gracjan-korpo.md); [Krzysztof
     Zasada](@/w/krzysztof-zasada.md)"]
 - ["Kawaleria: [Greg](@/w/greg.md), [Luxus](@/w/luxus.md)", "[Boski Ostrowski](@/w/ostrowski.md),

--- a/content/e/kpw/2016-11-26-kpw-arena-4-nowy-rozdzial.md
+++ b/content/e/kpw/2016-11-26-kpw-arena-4-nowy-rozdzial.md
@@ -12,7 +12,7 @@ city = "Gdańsk"
 3 = { path = "wrzeszcz-dolny-panorama.jpg", caption = "Panoramic view of the Dolny Wrzeszcz district of Gdańsk. Visible in the bottom-right is the gym hall where the event took place.", source = "Artur Andrzej / Wikipedia.pl" }
 +++
 
-Nowy Rozdział (_The New Chapter_) was held in Gdańsk, in the gymnastics hall of CKZiU 1, a complex of various educational institutions at the high school or vocational school level. Much smaller in scope than the previous event, it had only one foreign guest, British wrestler Elliott Jordan.
+Nowy Rozdział (_The New Chapter_) was held in Gdańsk, in the gymnastics hall of CKZiU 1, a complex of various educational institutions at the high school or vocational school level. Much smaller in scope than the previous event, it had only one foreign guest, British wrestler [Elliott Jordan](@/w/elliott-jordan.md).
 
 {% card() %}
 - ['[Kaszub](@/w/kaszub.md)', '[Peter Pannache](@/w/peter-pannache.md)', {r: DQ}]
@@ -21,7 +21,7 @@ Nowy Rozdział (_The New Chapter_) was held in Gdańsk, in the gymnastics hall o
   - s: Tag Team Match
 - ['[Kamil Aleksander](@/w/kamil-aleksander.md)', '[Greg](@/w/greg.md)']
 - ['[Robert Star](@/w/robert-star.md)', '[Damian Lambert](@/w/damien-rothschild.md)']
-- ['[Piękny Kawaler](@/w/piekny-kawaler.md)(c)', Elliott Jordan, {c: '[KPW Championship](@/c/kpw-championship.md)'}]
+- ['[Piękny Kawaler](@/w/piekny-kawaler.md)(c)', '[Elliott Jordan](@/w/elliott-jordan.md)', {c: '[KPW Championship](@/c/kpw-championship.md)'}]
 - credits:
     Ring announcer: '[Arkadiusz Pawłowski](@/w/pan-pawlowski.md)'
     Referee: '[Krystian Malinowski](@/w/krystian-malinowski.md)'

--- a/content/e/kpw/2017-08-12-kpw-godzina-zero-2017.md
+++ b/content/e/kpw/2017-08-12-kpw-godzina-zero-2017.md
@@ -35,7 +35,9 @@ The other challenger was Welsh wrestler Wild Boar, by then already a veteran of 
   - '[Victor Rosetti](@/w/rosetti.md)'
   - s: "Magnificent Seven No Disqualification Elimination Ladder Match for a [KPW Championship](@/c/kpw-championship.md) Title Match"
 - [Kat Von Kaige, '[Bianca](@/w/bianca.md)']
-- ['[Piękny Kawaler](@/w/piekny-kawaler.md)(c)', Wild Boar, {c: "[KPW Championship](@/c/kpw-championship.md)"}]
+- - '[Piękny Kawaler](@/w/piekny-kawaler.md)(c)'
+  - '[Wild Boar](@/w/wild-boar.md)'
+  - c: "[KPW Championship](@/c/kpw-championship.md)"
 - credits:
     Ring announcer: '[Arkadiusz Pawłowski](@/w/pan-pawlowski.md)'
     Referee: '[Krystian Malinowski](@/w/krystian-malinowski.md)'

--- a/content/e/kpw/2018-07-14-kpw-oldtown-3.md
+++ b/content/e/kpw/2018-07-14-kpw-oldtown-3.md
@@ -20,7 +20,7 @@ In 2018 the event lasted an entire week, between July 13 and 19. KPW held a wres
 #### Build-up
 
 * [Robert Star](@/w/robert-star.md) is forced to join Kawaleria after previously losing to [Piękny Kawaler](@/w/piekny-kawaler.md)
-* British wrestlers [Dom Taylor](@/w/dom-taylor.md) and Lee Rogers debut for KPW. Taylor would later appear several more times for the organization in singles competition as well.
+* British wrestlers [Dom Taylor](@/w/dom-taylor.md) and [Lee Rogers](@/w/lee-rogers.md) debut for KPW. Taylor would later appear several more times for the organization in singles competition as well.
 
 {% card() %}
 - - "Kawaleria: [Piękny Kawaler](@/w/piekny-kawaler.md), [Robert Star](@/w/robert-star.md),
@@ -31,7 +31,7 @@ In 2018 the event lasted an entire week, between July 13 and 19. KPW held a wres
 - - '[Gracjan Korpo](@/w/gracjan-korpo.md)'
   - '[Adam Bravo](@/w/adam-bravo.md)'
 - - '[Greg](@/w/greg.md)(c)'
-  - Lee Rogers
+  - '[Lee Rogers](@/w/lee-rogers.md)'
   - c: '[KPW OldTown Championship](@/c/kpw-old-town-championship.md)'
 - - '[Bianca](@/w/bianca.md)'
   - '[Alisa](@/w/alisa.md)'

--- a/content/e/kpw/2018-11-03-kpw-arena-11-podwojne-zagrozenie.md
+++ b/content/e/kpw/2018-11-03-kpw-arena-11-podwojne-zagrozenie.md
@@ -22,17 +22,23 @@ Podwójne Zagrożenie (_Double Threat_) was an event by [KPW](@/o/kpw.md), held 
 - ["[Kamil Aleksander](@/w/kamil-aleksander.md), [Peter Pannache](@/w/peter-pannache.md)",
   "[Rosetti](@/w/rosetti.md), [Sawicki](@/w/sawicki.md)", {s: "Tournament First Round
       Tag Team Match"}]
-- ["Boska Oliwa: [Boski Ostrowski](@/w/ostrowski.md), [David Oliwa](@/w/david-oliwa.md);
-    [Mira](@/w/mira.md)", "[Chemik](@/w/chemik.md), [Greg](@/w/greg.md)", {s: "Tournament
-      First Round Tag Team Match"}]
+- - >
+    Boska Oliwa: [Boski Ostrowski](@/w/ostrowski.md)
+    [David Oliwa](@/w/david-oliwa.md);
+    [Mira](@/w/mira.md)
+  - "[Chemik](@/w/chemik.md), [Greg](@/w/greg.md)"
+  - s: Tournament First Round Tag Team Match
 - ["[Piękny Kawaler](@/w/piekny-kawaler.md), [Robert Star](@/w/robert-star.md)", '[Moloch](@/w/moloch.md)',
   {s: "Tournament First Round Two On One Handicap Match"}]
-- ["British Bouncer Club: [Dom Taylor](@/w/dom-taylor.md), Lee Rogers", "[Adam Bravo](@/w/adam-bravo.md),
+- ["British Bouncer Club: [Dom Taylor](@/w/dom-taylor.md), [Lee Rogers](@/w/lee-rogers.md)", "[Adam Bravo](@/w/adam-bravo.md),
     [Mateusz Kakareko](@/w/mateusz-kakareko.md)", {s: "Tournament First Round Tag
       Team Match"}]
-- ["Boska Oliwa: [Boski Ostrowski](@/w/ostrowski.md), [David Oliwa](@/w/david-oliwa.md);
-    [Mira](@/w/mira.md)", "British Bouncer Club: [Dom Taylor](@/w/dom-taylor.md),
-    Lee Rogers", {s: "Tournament Semi Final Tag Team Match"}]
+- - >
+    Boska Oliwa: [Boski Ostrowski](@/w/ostrowski.md), 
+    [David Oliwa](@/w/david-oliwa.md); 
+    [Mira](@/w/mira.md)
+  - "British Bouncer Club: [Dom Taylor](@/w/dom-taylor.md), [Lee Rogers](@/w/lee-rogers.md)"
+  - s: Tournament Semi Final Tag Team Match
 - ["[Rosetti](@/w/rosetti.md), [Sawicki](@/w/sawicki.md)", "[Piękny Kawaler](@/w/piekny-kawaler.md),
     [Robert Star](@/w/robert-star.md)", {r: "DQ", s: "Tournament Semi Final Tag Team
       Match"}]

--- a/content/e/kpw/2020-02-01-kpw-arena-16-polowanie.md
+++ b/content/e/kpw/2020-02-01-kpw-arena-16-polowanie.md
@@ -37,7 +37,7 @@ We saw one debuting wrestler: Piotr "Opol" Opolski. Another foreign guest this t
   - c: '[KPW OldTown Championship](@/c/kpw-old-town-championship.md)'
 - - '[Greg](@/w/greg.md)'
   - 'Piotr Opolski'
-- - 'The Hunt: [Primate](@/w/primate.md), Wild Boar'
+- - 'The Hunt: [Primate](@/w/primate.md), [Wild Boar](@/w/wild-boar.md)'
   - '[Sawicki](@/w/sawicki.md), [Victor Rosetti](@/w/rosetti.md)'
   - c: '[KPW Tag Team Championship](@/c/kpw-tag-team-championship.md)'
 - credits:

--- a/content/e/kpw/2023-02-24-kpw-arena-21.md
+++ b/content/e/kpw/2023-02-24-kpw-arena-21.md
@@ -49,7 +49,7 @@ The event had one new foreign guest: Japanese wrestler Shigehiro Irie, by that t
 he scored one singles win against Piotr Opolski at [Arena 18](@/e/kpw/2022-03-18-kpw-arena-18-powrot-do-przyszlosci.md),
 and one as a team with Lesak at the [Tattoo Konwent](@/e/kpw/2022-07-30-kpw-tattoo-konwent-2022.md).
 * Rosetti managed to keep his belt in a double countout when the fight spilled outside the ring, a decision that left many fans puzzled. As a champion, he hasn't scored a single win defending the belt.
-* The German tag team managed to hold on to their championship. Post-match, they kept punishing their opponents, who were saved by Michał Fux. Then Chemik arrived and sided with the Germans. Then we saw a surprise return of the British Bouncer Club (Dom Taylor and Lee Rogers), who initially confronted the heels, but it didn't take them long to join the trio and attack Michał, Leon and Zefir. A brutal beatdown ensued, which included each of the faces being painfully thrown into thumbtacks.
+* The German tag team managed to hold on to their championship. Post-match, they kept punishing their opponents, who were saved by Michał Fux. Then Chemik arrived and sided with the Germans. Then we saw a surprise return of the British Bouncer Club ([Dom Taylor](@/w/dom-taylor.md) and [Lee Rogers](@/w/lee-rogers.md)), who initially confronted the heels, but it didn't take them long to join the trio and attack Michał, Leon and Zefir. A brutal beatdown ensued, which included each of the faces being painfully thrown into thumbtacks.
 * David Oliwa was dead set on pruning the Gregorian Branch after dispatching Chemik on the previous event. Lesak also had no chances against his more experienced rival.
 
 ### References

--- a/content/e/kpw/2023-05-19-kpw-arena-22.md
+++ b/content/e/kpw/2023-05-19-kpw-arena-22.md
@@ -23,7 +23,7 @@ The event had one returning foreign guest: Lee Rogers, one half of the British B
 
 {% card() %}
 - - '[Filip Fux](@/w/filip-fux.md)'
-  - 'Lee Rogers'
+  - '[Lee Rogers](@/w/lee-rogers.md)'
 - - "[Chemik](@/w/chemik.md), [Eryk Lesak](@/w/eryk-lesak.md)"
   - "[Leon Lato](@/w/leon-lato.md), [Zefir](@/w/zefir.md)"
   - s: '[KPW Tag Team Championship](@/c/kpw-tag-team-championship.md) Contendership Match'

--- a/content/e/kpw/2024-05-17-kpw-arena-25.md
+++ b/content/e/kpw/2024-05-17-kpw-arena-25.md
@@ -18,7 +18,7 @@ The poster for this event strongly referenced the Hitman game series. On a red b
 Foreign wrestlers performing at this event were:
 
 * Austrian wrestler Martn Pain, in his second appearance for KPW. He has another connection to the Polish wrestling scene: two matches in PTW's Austrian [sister promotion](@/o/ptw.md#expansion-into-austria), one of them against [Puncher](@/w/puncher.md).
-* English wrestler Louis Basham, competing for Coventry-based UKPW and other British organizations.
+* English wrestler [Louis Basham](@/w/louis-basham.md), competing for Coventry-based UKPW and other British organizations.
 * Hungarian heavyweight Gulyás Öcsi. While this is his first match in Poland, he already faced against some Polish wrestlers on the German and Hungarian scenes, though none from KPW.
 
 ### Build-up and stories leading to the event
@@ -30,7 +30,7 @@ Foreign wrestlers performing at this event were:
 
 {% card() %}
 - - '[David Oliwa](@/w/david-oliwa.md)'
-  - 'Louis Basham'
+  - '[Louis Basham](@/w/louis-basham.md)'
 - - '[Filip Fux](@/w/filip-fux.md)'
   - '[Greg](@/w/greg.md)'
 - - 'Martn Pain'

--- a/content/e/kpw/2024-06-15-kpw-pyrkon-2024.md
+++ b/content/e/kpw/2024-06-15-kpw-pyrkon-2024.md
@@ -20,7 +20,7 @@ In [his video][malinowski-video], Chairman Malinowski announced that Greg would 
 
 
 {% card() %}
-- ['Louis Basham', '[Rosetti](@/w/rosetti.md)']
+- ['[Louis Basham](@/w/louis-basham.md)', '[Rosetti](@/w/rosetti.md)']
 - ['[Eryk Lesak](@/w/eryk-lesak.md)', '[Leon Lato](@/w/leon-lato.md)', 'Pahlevan Nima',
   {s: Three Way Match}]
 - ['[Chemik](@/w/chemik.md)', '[Zefir](@/w/zefir.md)']

--- a/content/e/ptw/2021-10-09-ptw-1-revolucja.md
+++ b/content/e/ptw/2021-10-09-ptw-1-revolucja.md
@@ -7,7 +7,7 @@ venue=["moris-chorzow"]
 [extra]
 city = "Chorzów"
 [extra.gallery]
-1 = { path = "2021-10-09-ptw-1-revolucja-plakat.jpg", caption = "Official poster. Left to right, top row: Marius Al-Ani, [Joe E. Legend](@/w/joe-legend.md), Marcin Rzeźniczek, [Arkadiusz Pawłowski](@/w/pan-pawlowski.md), Nick Aldis, [Santino](@/w/santino.md). Bottom row: Axel Tischer, Chris Masters, [Robert Star](@/w/robert-star.md).", source = "Official PTW Facebook" }
+1 = { path = "2021-10-09-ptw-1-revolucja-plakat.jpg", caption = "Official poster. Left to right, top row: Marius Al-Ani, [Joe E. Legend](@/w/joe-legend.md), Marcin Rzeźniczek, [Arkadiusz Pawłowski](@/w/pan-pawlowski.md), [Nick Aldis](@/w/nick-aldis.md), [Santino](@/w/santino.md). Bottom row: Axel Tischer, Chris Masters, [Robert Star](@/w/robert-star.md).", source = "Official PTW Facebook" }
 2 = { path = "2021-10-09-ptw-1-revolucja-plakat-alt.jpg", caption = "Alternative poster. Top-left: Marcin Rzeźniczek; bottom-left: Marius Al-Ani; middle: Axel Tischer, Chris Masters; top-right: Nick Aldis, bottom-right: [Arkadiusz Pawłowski](@/w/pan-pawlowski.md).", source = "Official PTW Facebook" }
 +++
 
@@ -33,7 +33,9 @@ city = "Chorzów"
   -  "[Disco Pablo](@/w/disco-pablo.md), [Santino](@/w/santino.md)"
   - s: Tag Team Match
 - [Chris Masters, '[Robert Star](@/w/robert-star.md)']
-- ['[Gracjan Korpo](@/w/gracjan-korpo.md)', Nick Aldis, {r: DQ}]
+- - '[Gracjan Korpo](@/w/gracjan-korpo.md)'
+  - '[Nick Aldis](@/w/nick-aldis.md)'
+  - r: DQ
 - credits:
     Host, Ring Announcer, General Manager: '[Arkadiusz Pawłowski](@/w/pan-pawlowski.md)'
     Interviewer: Krzysztof Skwarczyński

--- a/content/e/ptw/2022-02-19-ptw-2-blackout.md
+++ b/content/e/ptw/2022-02-19-ptw-2-blackout.md
@@ -19,9 +19,9 @@ For this event, PTW invited several guests from the independent European and Ame
 * French wrestler Tristan Archer.
 * German wrestlers Axel Tischer and "Bad Bones" John Klinger.
 * British wrestlers Jonny Storm and Jody Fleisch.
-* British wrestler Nick Aldis, two-time NWA World Heavyweight Champion.
-* British wrestler Marty Scurll, best known for his time at Ring of Honor and NJPW.
-* Scottish wrestler Joe Hendry, at that time best known from Ring of Honor.
+* British wrestler [Nick Aldis](@/w/nick-aldis.md), two-time NWA World Heavyweight Champion.
+* British wrestler [Marty Scurll](@/w/marty-scurll.md), best known for his time at Ring of Honor and NJPW.
+* Scottish wrestler [Joe Hendry](@/w/joe-hendry.md), at that time best known from Ring of Honor.
 
 ### Build-up
 
@@ -44,9 +44,11 @@ For this event, PTW invited several guests from the independent European and Ame
 - - 'PAKA: [Boro](@/w/boro.md), [Disco Pablo](@/w/disco-pablo.md), [Taras](@/w/taras.md)'
   - '[Puncher](@/w/puncher.md), [Sinister](@/w/sinister.md), [Syriusz Dziedzic](@/w/dziedzic.md)'
   - s: Six Man Tag Team Match
-- ['[Krampus](@/w/krampus.md)', Marty Scurll]
-- [Joe Hendry, "[Gabriel Queen](@/w/gabriel-queen.md); [TAXI Złotówa](@/w/taxi-zlotowa.md)"]
-- [Nick Aldis, Chris Masters]
+- ['[Krampus](@/w/krampus.md)', '[Marty Scurll](@/w/marty-scurll.md)']
+- - '[Joe Hendry](@/w/joe-hendry.md)'
+  - "[Gabriel Queen](@/w/gabriel-queen.md); [TAXI Złotówa](@/w/taxi-zlotowa.md)"
+- - '[Nick Aldis](@/w/nick-aldis.md)'
+  - Chris Masters
 - credits:
     Host, Ring Announcer, General Manager: '[Arkadiusz Pawłowski](@/w/pan-pawlowski.md)'
     Commentary: >

--- a/content/e/ptw/2022-09-25-ptw-underground-8.md
+++ b/content/e/ptw/2022-09-25-ptw-underground-8.md
@@ -17,7 +17,7 @@ For this event, PTW invited Northern Irish wrestler Myla Grace, who was briefly 
 - - '[Axel Fox](@/w/axel-fox.md)'
   - '[Renegade](@/w/renegade.md)'
 - - '[Diana Strong](@/w/diana-strong.md)'
-  - Myla Grace
+  - '[Myla Grace](@/w/myla-grace.md)'
 - - '[Wiktor Longman](@/w/wiktor-longman.md)'
   - '[Disco Pablo](@/w/disco-pablo.md)'
   - '["Top Gun" Samson](@/w/samson.md)'

--- a/content/e/ptw/2022-11-26-ptw-3-legends.md
+++ b/content/e/ptw/2022-11-26-ptw-3-legends.md
@@ -23,16 +23,20 @@ By far the most were from the United Kingdom: "The Villain" Marty Scurll, Primat
 - - "Pure Gold: [Vic Golden](@/w/vic-golden.md), [Gabriel Queen](@/w/gabriel-queen.md)"
   - "PAKA: [Taras](@/w/taras.md), [Disco Pablo](@/w/disco-pablo.md); [Boro](@/w/boro.md)"
   - s: Tag Team Match
-- [Marty Scurll, '[Primate](@/w/primate.md)']
-- [Myla Grace, Xia Brookside, '[Diana Strong](@/w/diana-strong.md)', {s: Triple Threat
-      Match}]
+- ['[Marty Scurll](@/w/marty-scurll.md)', '[Primate](@/w/primate.md)']
+- - '[Myla Grace](@/w/myla-grace.md)'
+  - Xia Brookside
+  - '[Diana Strong](@/w/diana-strong.md)'
+  - s: Triple Threat Match
 - ['[Justin Joy](@/w/justin-joy.md)', '[Axel Fox](@/w/axel-fox.md)', {s: No Disqualification
       Match}]
 - ['[Santino](@/w/santino.md)', {g: true, s: Santino named new co-owner of PTW}]
 - ['[Dawid "Puncher" Seńko](@/w/puncher.md)', '[Robert Star](@/w/robert-star.md)']
-- [Joe Hendry(c), Trent Seven, {c: IMPACT Digital Media Championship}]
+- - '[Joe Hendry](@/w/joe-hendry.md)(c)'
+  - Trent Seven
+  - c: IMPACT Digital Media Championship
 - - '[TAXI Złotówa](@/w/taxi-zlotowa.md)'
-  - Joe Hendry
+  - '[Joe Hendry](@/w/joe-hendry.md)'
   - '[Arkadiusz Pawłowski](@/w/pan-pawlowski.md)'
   - g: true
     s: Misbehaving Kinguin mascot
@@ -54,7 +58,7 @@ By far the most were from the United Kingdom: "The Villain" Marty Scurll, Primat
       [Piotr "ShowOff" Małecki](@/w/piotr-malecki.md)
     Special guest commentary for the tag team match: '[Boro](@/w/boro.md)'
     Special guest commentary for the main event: 'Andrzej Supron, [Paweł "Boryss" Borkowski](@/w/pawel-borkowski.md)'
-    English commentary: '[Santino](@/w/santino.md), Lewis Costello'
+    English commentary: '[Santino](@/w/santino.md), [Lewis Costello](@/w/lewis-costello.md)'
 {% end %}
 
 

--- a/content/e/ptw/2024-02-03-ptw-5-gold-rush.md
+++ b/content/e/ptw/2024-02-03-ptw-5-gold-rush.md
@@ -25,7 +25,9 @@ Polish celebrity and former boxer Marcin Najman was also expected to appear in s
 * The surprise, was however spoiled by Lince Dorado, who posted about a last-minute trip to Poland on his Instagram profile.
 
 {% card() %}
-- [Scotty Rawk(c), Speedball Mike Bailey, {c: "British Wrestling Revolution Championship"}]
+- - '[Scotty Rawk](@/w/scotty-rawk.md)(c)'
+  - Speedball Mike Bailey
+  - c: British Wrestling Revolution Championship
 - ['[Diana Strong](@/w/diana-strong.md)', Nina Samuels]
 - ['[Krampus](@/w/krampus.md)', '["Starboy" Nano Lopez](@/w/nano-lopez.md)', {s: No
       DQ Match}]
@@ -74,7 +76,7 @@ Polish celebrity and former boxer Marcin Najman was also expected to appear in s
     Host, Ring Announcer, General Manager: '[Arkadiusz Pawłowski](@/w/pan-pawlowski.md)'
     Commentary: '[Arek Paterek](@/w/arek-paterek.md), [Piotr "ShowOff" Małecki](@/w/piotr-malecki.md), [Łukasz "Balik" Baliński](@/w/lukasz-balinski.md)'
     Special Guest Commentary: 'Andrzej Supron, [Paweł "Boryss" Borkowski](@/w/pawel-borkowski.md)'
-    English Commentary: 'Lewis Costello, [Santino](@/w/santino.md)'
+    English Commentary: '[Lewis Costello](@/w/lewis-costello.md), [Santino](@/w/santino.md)'
     Referees: '[Sędzia Klaudiusz](@/w/sedzia-klaudiusz.md), [Sędzia Seweryn](@/w/sedzia-seweryn.md)'
 {% end %}
 

--- a/content/e/ptw/2024-05-11-ptw-6.md
+++ b/content/e/ptw/2024-05-11-ptw-6.md
@@ -22,7 +22,7 @@ The event's name openly refers to [Total Blast Wrestling](@/o/tbw.md), a short-l
 
 Also announced were numerous foreign guests:
 
-* English wrestler Scotty Rawk, once more defending his British Wrestling Revolution championship. This is his second appearance, after debuting at [PTW#5 Gold Rush](@/e/ptw/2024-02-03-ptw-5-gold-rush.md) in February 2024.
+* English wrestler [Scotty Rawk](@/w/scotty-rawk.md), once more defending his British Wrestling Revolution championship. This is his second appearance, after debuting at [PTW#5 Gold Rush](@/e/ptw/2024-02-03-ptw-5-gold-rush.md) in February 2024.
 * Welsh wrestler Flash Morgan Webster, known for competing on the British scene and several  Tag Team Championships across different promotions worldwide, mostly with Mark Andrews. Flash also had a run in NXT UK between 2018 and 2021.
 * American wrestler Dirty Dango, best known from his years at WWE as Johnny Curtis and later Fandango. Since his release in 2021, Dango has been touring the American independent scene.
 * American wrestler Matt Sydal, most recently competing in All Elite Wrestling. This is his third appearance for PTW: the first was at [PTW#2 Blackout](@/e/ptw/2022-02-19-ptw-2-blackout.md), then Sydal main evented [PTW#3 Legends](@/e/ptw/2022-11-26-ptw-3-legends.md). Originally he was also in the card for Gold Rush, but had to cancel at the last minute.
@@ -43,7 +43,7 @@ Out of nowhere, Zbigniew Stonoga appeared and started giving away tickets (see [
 Little to no information was available on whether the show would be streamed. Finally, right before the show, it was revealed that the event would stream for free on YouTube, as well as on FITE/TrillerTV for paid users.
 
 {% card() %}
-- - Scotty Rawk
+- - '[Scotty Rawk](@/w/scotty-rawk.md)'
   - '[Axel Fox](@/w/axel-fox.md)'
   - '[Marcelito](@/w/marcelito.md)'
   - c: British Wrestling Revolution Championship

--- a/content/e/wwe/2011-11-11-wwe-smackdown-house-show.md
+++ b/content/e/wwe/2011-11-11-wwe-smackdown-house-show.md
@@ -18,7 +18,7 @@ city = ["Gdańsk", "Sopot"]
 - [Brodus Clay, Ted DiBiase]
 - [Ezekiel Jackson, Jinder Mahal]
 - [Hunico, Yoshi Tatsu]
-- [Sheamus, Wade Barrett]
+- ['[Sheamus](@/w/sheamus.md)', Wade Barrett]
 - [Alicia Fox, Natalya]
 - - Randy Orton
   - Cody Rhodes

--- a/content/e/wwe/2015-04-15-wwe-live.md
+++ b/content/e/wwe/2015-04-15-wwe-live.md
@@ -24,7 +24,7 @@ The final [WWE](@/o/wwe.md) show in Poland to date, it was held in the capital c
   - 'The New Day: Big E. Langston, Kofi Kingston'
   - s: Triple Threat Tag Match
     c: WWE Tag Team Championship
-- [Sheamus, Dolph Ziggler]
+- ['[Sheamus](@/w/sheamus.md)', Dolph Ziggler]
 - - 'Emma, Layla, Natalya'
   - 'Cameron, Rosa Mendes, Tamina Snuka'
   - s: Six Man Tag Team Match

--- a/content/o/ptw-academy.md
+++ b/content/o/ptw-academy.md
@@ -34,7 +34,7 @@ PTW Academy is the wrestling school associated with [Prime Time Wrestling](@/o/p
   * Seminary hosts:
     - [Santino Marella](@/w/santino.md) (2021 - 2022)
     - Chris Masters (Feb 2022)
-    - Nick Aldis (Feb 2022)
+    - '[Nick Aldis](@/w/nick-aldis.md)' (Feb 2022)
     - Axel Tischer (Feb 2022)
     - Tucker (2023)
     - Dirty Dango (2023)

--- a/content/o/ptw.md
+++ b/content/o/ptw.md
@@ -39,7 +39,7 @@ The venue had limited capacity, which was cleverly used to make these events fee
 
 Continuing their strong entry into the scene, PTW started the year with the [second Underground show](@/e/ptw/2022-01-23-ptw-underground-2.md)
 and quickly followed with [PTW#2 Blackout](@/e/ptw/2022-02-19-ptw-2-blackout.md), which was also well received.
-This show had even more starpower than Revolucja, featuring debuts of well-known names like Joe Hendry, Marty Scurll, Matt Sydal and John "Bad Bones" Klinger.
+This show had even more starpower than Revolucja, featuring debuts of well-known names like [Joe Hendry](@/w/joe-hendry.md), [Marty Scurll](@/w/marty-scurll.md), Matt Sydal and [John "Bad Bones" Klinger](@/w/bad-bones.md).
 
 Over the course of the year, PTW continued its steady pace, presenting the monthly Underground shows, and debuting at [Ryucon](@/e/ptw/2022-07-31-ptw-x-ryucon.md), a manga-themed fan convention in Kraków.
 The third major show, [Legends](@/e/ptw/2022-11-26-ptw-3-legends.md), was the first one to be held outside Chorzów, in Warsaw.
@@ -206,7 +206,7 @@ It was quickly renamed to _PTW: WWA_ and became a de facto "sister federation" r
 This cooperation allowed PTW talent to be booked at the PTW: WWA show on 2024-01-05.
 See the [Expansion into Austria](#expansion-into-austria) section above.
 
-PTW also entered a deal with British Revolution Wrestling (BWR), which allowed BWR Champion Scotty Rawk to defend his championship in PTW. In return, [Diana Strong](@/w/diana-strong.md) and [Puncher](@/w/puncher.md) were booked at one of BWR's shows in the UK. These appearances never came to fruition, however Puncher confirmed, on a [livestream][live-istota-puncher] by Istota Wrestlingu, that the deal is still on.
+PTW also entered a deal with British Revolution Wrestling (BWR), which allowed BWR Champion [Scotty Rawk](@/w/scotty-rawk.md) to defend his championship in PTW. In return, [Diana Strong](@/w/diana-strong.md) and [Puncher](@/w/puncher.md) were booked at one of BWR's shows in the UK. These appearances never came to fruition, however Puncher confirmed, on a [livestream][live-istota-puncher] by Istota Wrestlingu, that the deal is still on.
 
 In the early September 2024, PTW announced they'd be sending a team of wrestlers to _Botte da Bestya 2_, an event by the Italian organization ICW happening on September 15, 2024. This team consisted of foreign wrestlers Iva Kolasky and Luca Bjorn, plus Polish PTW talent: [Pawłowski](@/w/pan-pawlowski.md) and [Puncher](@/w/puncher.md), who defended his championship.
 

--- a/content/w/elliott-jordan.md
+++ b/content/w/elliott-jordan.md
@@ -6,7 +6,7 @@ authors = ["Krzysztof Zych"]
 country = ["ENGLAND"]
 +++
 
-Elliott Jordan is a retired English Pro wrestler, who did two appearances for [KPW](@/o/kpw.md) back in 2016. In his home country, Jordan wrestled primarily for Birmingham-based Kamikaze Pro, plus several smaller promotions in the West Midlands.
+Elliott Jordan is a retired English Pro wrestler, who did two appearances for [KPW](@/o/kpw.md) in 2016. In his home country, Jordan wrestled primarily for Birmingham-based Kamikaze Pro, plus several smaller promotions in the West Midlands.
 
 ## Internet presence
 

--- a/content/w/elliott-jordan.md
+++ b/content/w/elliott-jordan.md
@@ -1,0 +1,17 @@
++++
+title = "Elliott Jordan"
+template = "talent_page.html"
+authors = ["Krzysztof Zych"]
+[taxonomies]
+country = ["ENGLAND"]
++++
+
+Elliott Jordan is a retired English Pro wrestler, who did two appearances for [KPW](@/o/kpw.md) back in 2016. In his home country, Jordan wrestled primarily for Birmingham-based Kamikaze Pro, plus several smaller promotions in the West Midlands.
+
+## Internet presence
+
+* [The Elliot Jordan Experience @ Facebook](https://www.facebook.com/Theelliottjordanexperience)
+
+## References
+
+* [Cagematch profile page](https://www.cagematch.net/?id=2&nr=21619)

--- a/content/w/filip-fux.md
+++ b/content/w/filip-fux.md
@@ -5,7 +5,7 @@ authors = ["M3n747"]
 [taxonomies]
 country = ["PL"]
 [extra.gallery]
-1 = { path = "kpw-arena-22-filip-fux.jpg", caption = "Filip carries Lee Rogers, KPW Arena 22.", source = "M3n747" }
+1 = { path = "kpw-arena-22-filip-fux.jpg", caption = "Filip carries [Lee Rogers](@/w/lee-rogers.md), KPW Arena 22.", source = "M3n747" }
 +++
 
 Filip Fux is one half of the Fux Brothers tag team, along with his kayfabe sibling [Michał](@/w/michal-fux.md). Debuting at [KPW Arena 17](@/e/kpw/2021-08-21-kpw-arena-17-odrodzenie.md), he's best known for his tag team work alongside Michał, but he's also had a number of solo matches.

--- a/content/w/joe-hendry.md
+++ b/content/w/joe-hendry.md
@@ -1,0 +1,18 @@
++++
+title = "Joe Hendry"
+template = "talent_page.html"
+authors = ["Krzysztof Zych"]
+[taxonomies]
+country = ["SCOTLAND"]
++++
+
+Joe Hendry is a Scottish wrestler and musician, best known for his runs in Ring of Honor and TNA/Impact. He made two appearances in Poland in 2022 for [Prime Time Wrestling](@/o/ptw.md), even defending his Impact Digital Media Championship in the second one.
+
+## Internet presence
+
+* [Joe Hendry on Facebook](https://www.facebook.com/JoeHendryOfficial)
+* [joehendry on Instagram](https://www.instagram.com/joehendry)
+
+## References
+
+* [Cagematch profile page](https://www.cagematch.net/?id=2&nr=14930)

--- a/content/w/lee-rogers.md
+++ b/content/w/lee-rogers.md
@@ -1,0 +1,12 @@
++++
+title = "Lee Rogers"
+template = "talent_page.html"
+[taxonomies]
+country = ["ENGLAND"]
++++
+
+Lee Rogers is an English professional wrestler, who made several appearances for [Kombat Pro Wrestling](@/o/kpw.md).
+
+## References
+
+* [Cagematch profile page](https://www.cagematch.net/?id=2&nr=29957)

--- a/content/w/lewis-costello.md
+++ b/content/w/lewis-costello.md
@@ -1,0 +1,14 @@
++++
+title = "Lewis Costello"
+template = "talent_page.html"
+authors = ["Krzysztof Zych"]
+[taxonomies]
+country = ["ENGLAND"]
++++
+
+Lewis Costello is an English standup comedian, announcer and pro wrestling commentator. In 2022 and 2024, he was providing English live commentary on PTW shows, first solo and later with [Santino](@/w/santino.md).
+
+## Internet presence
+
+* [Lewis' official site](https://www.lewiscostello.co.uk/)
+* [lewisblaizecostello on Instagram](https://www.instagram.com/lewisblaizecostello/)

--- a/content/w/lewis-costello.md
+++ b/content/w/lewis-costello.md
@@ -6,9 +6,9 @@ authors = ["Krzysztof Zych"]
 country = ["ENGLAND"]
 +++
 
-Lewis Costello is an English standup comedian, announcer and pro wrestling commentator. In 2022 and 2024, he was providing English live commentary on PTW shows, first solo and later with [Santino](@/w/santino.md).
+Lewis Costello is an English standup comedian, announcer and pro wrestling commentator. In 2022 and 2024 he provided English live commentary on PTW shows, first solo and later with [Santino](@/w/santino.md).
 
 ## Internet presence
 
-* [Lewis' official site](https://www.lewiscostello.co.uk/)
+* [Lewis's official site](https://www.lewiscostello.co.uk/)
 * [lewisblaizecostello on Instagram](https://www.instagram.com/lewisblaizecostello/)

--- a/content/w/louis-basham.md
+++ b/content/w/louis-basham.md
@@ -1,0 +1,13 @@
++++
+title = "Louis Basham"
+template = "talent_page.html"
+authors = ["Krzysztof Zych"]
+[taxonomies]
+country = ["ENGLAND"]
++++
+
+Louis Basham is an English profession wrestler, known from his appearances in [KPW](@/o/kpw.md) in 2024. Outside of Poland, he wrestles mainly for Kent-based UKPW.
+
+## Internet presence
+
+* [louisbasham on Instagram](https://www.instagram.com/louisbasham/)

--- a/content/w/mark-andrews.md
+++ b/content/w/mark-andrews.md
@@ -1,0 +1,13 @@
++++
+title = "Mark Andrews"
+template = "talent_page.html"
+authors = ["Krzysztof Zych"]
+[taxonomies]
+country = ["WALES"]
++++
+
+Mark Andrews is a Welsh wrestler from Cardiff, best known for his run in NXT UK and a long career all over the British Isles. In 2012, Andrews, along with several other British wrestlers, performed for [DDW](@/o/ddw.md) at their double header weekend in Rzeszów and Kolbuszowa.
+
+## References
+
+* [Cagematch profile page](https://www.cagematch.net/?id=2&nr=6092)

--- a/content/w/mark-andrews.md
+++ b/content/w/mark-andrews.md
@@ -6,7 +6,7 @@ authors = ["Krzysztof Zych"]
 country = ["WALES"]
 +++
 
-Mark Andrews is a Welsh wrestler from Cardiff, best known for his run in NXT UK and a long career all over the British Isles. In 2012, Andrews, along with several other British wrestlers, performed for [DDW](@/o/ddw.md) at their double header weekend in Rzeszów and Kolbuszowa.
+Mark Andrews is a Welsh wrestler from Cardiff, best known for his run in NXT UK and a long career all over the British Isles. In 2012, Andrews, along with several other British wrestlers, he performed for [DDW](@/o/ddw.md) at their double header weekend in Rzeszów and Kolbuszowa.
 
 ## References
 

--- a/content/w/marty-scurll.md
+++ b/content/w/marty-scurll.md
@@ -1,0 +1,17 @@
++++
+title = "Marty Scurll"
+template = "talent_page.html"
+authors = ["Krzysztof Zych"]
+[taxonomies]
+country = ["ENGLAND"]
++++
+
+Marty 'The Villain' Scurll is an English professional wrestler, best known from his time in Ring of Honor, New Japan Pro Wrestling, as well as multiple other promotions worldwide, both solo and as part of the Bullet Club stable. In Poland, he appeared twice for [Prime Time Wrestling](@/o/ptw.md) in 2022.
+
+## Internet presence
+
+* [martyscurll on Instagram](https://www.instagram.com/martyscurll)
+
+## References
+
+* [Cagematch profile page](https://www.cagematch.net/?id=2&nr=4255)

--- a/content/w/marty-scurll.md
+++ b/content/w/marty-scurll.md
@@ -6,7 +6,7 @@ authors = ["Krzysztof Zych"]
 country = ["ENGLAND"]
 +++
 
-Marty 'The Villain' Scurll is an English professional wrestler, best known from his time in Ring of Honor, New Japan Pro Wrestling, as well as multiple other promotions worldwide, both solo and as part of the Bullet Club stable. In Poland, he appeared twice for [Prime Time Wrestling](@/o/ptw.md) in 2022.
+Marty "The Villain" Scurll is an English professional wrestler, best known from his time in Ring of Honor, New Japan Pro Wrestling, as well as multiple other promotions worldwide, both solo and as part of the Bullet Club stable. In Poland he made two appearances for [Prime Time Wrestling](@/o/ptw.md) in 2022.
 
 ## Internet presence
 

--- a/content/w/myla-grace.md
+++ b/content/w/myla-grace.md
@@ -1,0 +1,17 @@
++++
+title = "Myla Grace"
+template = "talent_page.html"
+[taxonomies]
+country = ["GB"] # Northern Ireland
++++
+
+Myla Grace is a Northern Irish wrestler from Belfast, best known for her brief stint in NXT UK, and various Irish and British promotions. In Poland, Myla appeared for [Prime Time Wrestling](@/o/ptw.md) to face [Diana Strong](@/w/diana-strong.md) twice in 2022.
+
+## Internet presence
+
+* [Myla Grace - Pro Wrestler on Facebook](https://www.facebook.com/MylaGraceProWrestler)
+* [mylagrace_x on Instagram](https://www.instagram.com/mylagrace_x)
+
+## References
+
+* [Cagematch profile page](https://www.cagematch.net/?id=2&nr=25051)

--- a/content/w/nick-aldis.md
+++ b/content/w/nick-aldis.md
@@ -1,0 +1,16 @@
++++
+title = "Nick Aldis"
+template = "talent_page.html"
+[taxonomies]
+country = ["GB"]
++++
+
+Nick Aldis is a wrestler from Norfolk, England, best known for his runs in TNA and Ring of Honor, a long reign as the NWA Heavyweight Champion, and many appearances in other promotions all around the world. Nick appeared for [Prime Time Wrestling](@/o/ptw.md) at their first two major shows, and to date is likely the highest profile international wrestler to perform for them.
+
+## Internet presence
+
+* [nickaldis on Instagram](https://www.instagram.com/nickaldis/)
+
+## References
+
+* [Cagematch profile page](https://www.cagematch.net/?id=2&nr=5123)

--- a/content/w/pete-dunne.md
+++ b/content/w/pete-dunne.md
@@ -1,0 +1,12 @@
++++
+title = "Pete Dunne"
+template = "talent_page.html"
+[taxonomies]
+country = ["GB"]
++++
+
+Pete Dunne is an English wrestler from Birmingham, best known for his runs in NXT and its UK sister promotion, plus multiple British and Irish organizations. Dunne was one of the British wrestlers to perform for [Do Or Die Wrestling](@/o/ddw.md) back in 2012 at their double header show in Rzeszów and Kolbuszowa.
+
+## References
+
+* [Cagematch profile page](https://www.cagematch.net/?id=2&nr=10529)

--- a/content/w/pete-dunne.md
+++ b/content/w/pete-dunne.md
@@ -5,7 +5,7 @@ template = "talent_page.html"
 country = ["GB"]
 +++
 
-Pete Dunne is an English wrestler from Birmingham, best known for his runs in NXT and its UK sister promotion, plus multiple British and Irish organizations. Dunne was one of the British wrestlers to perform for [Do Or Die Wrestling](@/o/ddw.md) back in 2012 at their double header show in Rzeszów and Kolbuszowa.
+Pete Dunne is an English wrestler from Birmingham, best known for his runs in NXT and its UK sister promotion, plus multiple British and Irish organizations. Dunne was one of the British wrestlers to perform for [Do Or Die Wrestling](@/o/ddw.md) at their 2012 double header show in Rzeszów and Kolbuszowa.
 
 ## References
 

--- a/content/w/primate.md
+++ b/content/w/primate.md
@@ -5,6 +5,12 @@ template = "talent_page.html"
 country = ["ENGLAND"]
 +++
 
+Primate is an English pro wrestler from Newcastle, best known for his run in NXT UK with tag team partner [Wild Boar](@/w/wild-boar.md). In Poland, their team won the [KPW Tag Team Championship](@/c/kpw-tag-team-championship.md) in 2019, but was unable to defend it due to the COVID-19 pandemic. With it finally over, the team could not defend the title due to Wild Boar's injury, and they had to vacate it.
+
+## Internet presence
+
+* [the_primate_](https://www.instagram.com/the_primate_/) on Instagram
+
 ## References
 
 * [Cagematch profile page](https://www.cagematch.net/?id=2&nr=17236)

--- a/content/w/primate.md
+++ b/content/w/primate.md
@@ -5,7 +5,7 @@ template = "talent_page.html"
 country = ["ENGLAND"]
 +++
 
-Primate is an English pro wrestler from Newcastle, best known for his run in NXT UK with tag team partner [Wild Boar](@/w/wild-boar.md). In Poland, their team won the [KPW Tag Team Championship](@/c/kpw-tag-team-championship.md) in 2019, but was unable to defend it due to the COVID-19 pandemic. With it finally over, the team could not defend the title due to Wild Boar's injury, and they had to vacate it.
+Primate is an English pro wrestler from Newcastle, best known for his run in NXT UK with tag team partner [Wild Boar](@/w/wild-boar.md). In Poland, their team won the [KPW Tag Team Championship](@/c/kpw-tag-team-championship.md) in 2019, but was unable to defend it due to the COVID-19 pandemic. With the pandemic finally over, the team could not defend the title due to Wild Boar's injury, and they had to vacate it.
 
 ## Internet presence
 

--- a/content/w/ryan-smile.md
+++ b/content/w/ryan-smile.md
@@ -1,0 +1,13 @@
++++
+title = "Ryan Smile"
+template = "talent_page.html"
+authors = ["Krzysztof Zych"]
+[taxonomies]
+country = ["ENGLAND"]
++++
+
+Ryan Smile was an English pro wrestler and promoter from Birmingham. In 2012, he appeared twice for [Do Or Die Wrestling](@/o/ddw.md) on their double header weekend in Rzeszów and Kolbuszowa.
+
+## References
+
+* [Cagematch profile page](https://www.cagematch.net/?id=2&nr=14039)

--- a/content/w/scotty-rawk.md
+++ b/content/w/scotty-rawk.md
@@ -1,0 +1,9 @@
++++
+title = "Scotty Rawk"
+template = "talent_page.html"
+authors = ["Krzysztof Zych"]
+[taxonomies]
+country = ["ENGLAND"]
++++
+
+Scotty Rawk is an English wrestler from Grimsby, who mainly performs for his local British Wrestling Revolution. In 2024, Scotty defended his BWR championship title twice in Poland, on events held by [PTW](@/o/ptw.md).

--- a/content/w/scotty-rawk.md
+++ b/content/w/scotty-rawk.md
@@ -6,4 +6,4 @@ authors = ["Krzysztof Zych"]
 country = ["ENGLAND"]
 +++
 
-Scotty Rawk is an English wrestler from Grimsby, who mainly performs for his local British Wrestling Revolution. In 2024, Scotty defended his BWR championship title twice in Poland, on events held by [PTW](@/o/ptw.md).
+Scotty Rawk is an English wrestler from Grimsby, who mainly performs for his local British Wrestling Revolution. In 2024, Scotty defended his BWR championship title twice in Poland, at events held by [PTW](@/o/ptw.md).

--- a/content/w/sheamus.md
+++ b/content/w/sheamus.md
@@ -1,0 +1,13 @@
++++
+title = "Sheamus"
+template = "talent_page.html"
+authors = ["Krzysztof Zych"]
+[taxonomies]
+country = ["SCOTLAND"]
++++
+
+Sheamus is a Scottish professional wrestler, best known for his long tenure in WWE. He performed in Poland twice, back when the federation was touring Europe with its Smackdown house shows and later under the WWE Live brand.
+
+## References
+
+* [Cagematch profile page](https://www.cagematch.net/?id=2&nr=2641)

--- a/content/w/wild-boar.md
+++ b/content/w/wild-boar.md
@@ -5,7 +5,7 @@ template = "talent_page.html"
 country = ["ENGLAND"]
 +++
 
-Wild Boar is a Welsh pro wrestler, best known for his run in NXT UK with tag team partner [Primate](@/w/primate.md), and a long career performing mostly in Wales and south-west England. In Poland, their team won the [KPW Tag Team Championship](@/c/kpw-tag-team-championship.md) in 2019, but was unable to defend it due to the COVID-19 pandemic. With it finally over, Wild Boar could not defend the title due to an injury, and they had to vacate it.
+Wild Boar is a Welsh pro wrestler, best known for his run in NXT UK with tag team partner [Primate](@/w/primate.md), and a long career performing mostly in Wales and south-west England. In Poland, their team won the [KPW Tag Team Championship](@/c/kpw-tag-team-championship.md) in 2019, but was unable to defend it due to the COVID-19 pandemic. With the pandemic finally over, Wild Boar could not defend the title due to an injury, and they had to vacate it.
 
 ## Internet presence
 

--- a/content/w/wild-boar.md
+++ b/content/w/wild-boar.md
@@ -1,0 +1,16 @@
++++
+title = "Wild Boar"
+template = "talent_page.html"
+[taxonomies]
+country = ["ENGLAND"]
++++
+
+Wild Boar is a Welsh pro wrestler, best known for his run in NXT UK with tag team partner [Primate](@/w/primate.md), and a long career performing mostly in Wales and south-west England. In Poland, their team won the [KPW Tag Team Championship](@/c/kpw-tag-team-championship.md) in 2019, but was unable to defend it due to the COVID-19 pandemic. With it finally over, Wild Boar could not defend the title due to an injury, and they had to vacate it.
+
+## Internet presence
+
+* [wild_boar_hitchman](https://www.instagram.com/wild_boar_hitchman/) on Instagram
+
+## References
+
+* [Cagematch profile page](https://www.cagematch.net/?id=2&nr=9762)


### PR DESCRIPTION
Create brief profiles for all British (England, Scotland, Wales and UK if not specified otherwise) wrestlers with two or more appearances, who didn't have them already.