### PR TITLE
Stop using career.json for talent lists

### DIFF
--- a/templates/alphabetical_talent_list.html
+++ b/templates/alphabetical_talent_list.html
@@ -7,7 +7,6 @@
 {{ section.content | safe }}
 
 {% set org_styles = config.extra.org_styles %}
-{% set career_dict = load_data(path="data/career.json") %}
 {% set all_matches = load_data(path="data/all_matches.json") %}
 {% set appearances = load_data(path="data/appearances.json") %}
 {% set crew_appearances = load_data(path="data/crew_appearances.json") %}
@@ -44,7 +43,6 @@
           {% set_global person_name = name %}
           {% set_global appearances_entry = appearances|get(key=name, default=[]) %}
           {% set_global crew_appearances_entry = crew_appearances|get(key=name, default=[]) %}
-          {% set_global career_entry = career_dict|get(key=name, default=empty_obj) %}
           {% set_global display_match_links = false %}
           {% set page_path = "@/" ~ page_path %}
           <li class="pwf">
@@ -56,7 +54,6 @@
           {% set_global person_name = name %}
           {% set_global appearances_entry = appearances|get(key=career_name, default=[]) %}
           {% set_global crew_appearances_entry = crew_appearances|get(key=career_name, default=[]) %}
-          {% set_global career_entry = career_dict|get(key=career_name, default=empty_obj) %}
           {% set_global display_match_links = false %}
           {% set page_path = "@/" ~ page_path %}
           <li class="pwf">
@@ -68,8 +65,6 @@
           {% set career_key = page.extra|get(key='career_name', default=page.title) %}
           {% set_global appearances_entry = appearances|get(key=name, default=[]) %}
           {% set_global crew_appearances_entry = crew_appearances|get(key=name, default=[]) %}
-          {# TODO: Do not use career, just appearances #}
-          {% set_global career_entry = career_dict|get(key=career_key, default=empty_obj) %}
           {% set_global person_name = '<em>' ~ name ~ '</em>' %}
           {% set_global display_match_links = false %}
           {% set page_path = "@/" ~ page_path %}
@@ -81,7 +76,6 @@
           {% set_global person_name = name %}
           {% set_global appearances_entry = appearances|get(key=name, default=[]) %}
           {% set_global crew_appearances_entry = crew_appearances|get(key=name, default=[]) %}
-          {% set_global career_entry = career_dict|get(key=name, default=empty_obj) %}
           {% set_global display_match_links = true %}
           <li class="pwf">
             {% include "roster/unlinked_person.html" %}

--- a/templates/country_talent_list.html
+++ b/templates/country_talent_list.html
@@ -41,7 +41,6 @@
           {% set_global person_name = name %}
           {% set_global appearances_entry = appearances|get(key=name, default=[]) %}
           {% set_global crew_appearances_entry = crew_appearances|get(key=name, default=[]) %}
-          {% set_global career_entry = career_dict|get(key=name, default=empty_obj) %}
           {% set_global display_match_links = false %}
           {% set page_path = "@/" ~ page_path %}{# Overwrite so that pwf can produce correct link #}
           <li class="pwf">
@@ -53,7 +52,6 @@
           {% set_global person_name = name %}
           {% set_global appearances_entry = appearances|get(key=career_name, default=[]) %}
           {% set_global crew_appearances_entry = crew_appearances|get(key=career_name, default=[]) %}
-          {% set_global career_entry = career_dict|get(key=career_name, default=empty_obj) %}
           {% set_global display_match_links = false %}
           {% set page_path = "@/" ~ page_path %}
           <li class="pwf">
@@ -64,8 +62,6 @@
           {% set career_key = page.extra|get(key='career_name', default=page.title) %}
           {% set_global appearances_entry = appearances|get(key=name, default=[]) %}
           {% set_global crew_appearances_entry = crew_appearances|get(key=name, default=[]) %}
-          {# TODO: Do not use career, just appearances #}
-          {% set_global career_entry = career_dict|get(key=career_key, default=empty_obj) %}
           {% set_global person_name = '<em>' ~ name ~ '</em>' %}
           {% set_global display_match_links = false %}
           {% set page_path = "@/" ~ page_path %}
@@ -77,7 +73,6 @@
           {% set_global person_name = name %}
           {% set_global appearances_entry = appearances|get(key=name, default=[]) %}
           {% set_global crew_appearances_entry = crew_appearances|get(key=name, default=[]) %}
-          {% set_global career_entry = career_dict|get(key=name, default=empty_obj) %}
           {% set_global display_match_links = true %}
           <li class="pwf">
             <span class="name">{{ person_name }}</span>

--- a/templates/orgs/all_time_roster.html
+++ b/templates/orgs/all_time_roster.html
@@ -1,5 +1,4 @@
 {% set org_styles = config.extra.org_styles -%}
-{% set career_dict = load_data(path="data/career.json") -%}
 {% set appearances = load_data(path="data/appearances.json") -%}
 {% set all_matches = load_data(path="data/all_matches.json") -%}
 {% set name_to_flag = load_data(path="const/name-to-flag.yaml") -%}
@@ -51,7 +50,6 @@
       {%- else -%}
         {%- set_global person_name = pname -%}
         {%- set_global appearances_entry = appearances|get(key=pname) -%}
-        {%- set_global career_entry = career_dict|get(key=pname) -%}
         {%- set_global org = page.slug -%}
         {%- include "roster/unlinked_person.html" -%}
         {%- include "roster/person_alltime_entry.html" -%}

--- a/templates/roster/person_alltime_entry.html
+++ b/templates/roster/person_alltime_entry.html
@@ -1,4 +1,4 @@
-{%- if appearances_entry and career_entry -%}
+{%- if appearances_entry -%}
   {% set_global all_my_matches = [] -%}
   {% for app in appearances_entry -%}
     {% set match = all_matches[app] -%}
@@ -9,7 +9,7 @@
   {% for match in all_my_matches|sort(attribute='d') -%}
     {% if not match.o is containing(org) -%} {% continue %} {%- endif -%}
     {% if used_events is containing(match.p) -%} {% continue %} {%- endif -%}
-    <a class="nu" href="{{ get_url(path="@/" ~ match.p) }}">[{{ i }}]</a>
+    <a class="nu" href="{{ get_url(path="@/" ~ match.p) }}"><small>[{{ i }}]</small></a>
     {% set_global used_events = used_events|concat(with=match.p) -%}
     {% set_global i = i + 1 -%}
   {% endfor -%}

--- a/templates/roster/person_orgs_matches.html
+++ b/templates/roster/person_orgs_matches.html
@@ -9,13 +9,11 @@
   {% set_global all_appearances = all_appearances | concat(with=app) %}
 {% endfor %}
 
-{# Calculate orgs from career_entry #}
+{# Calculate orgs from appearances #}
 {% set_global orgs = [] %}
-{% for _year, org_count in career_entry %}
-  {% for org, _count in org_count %}
-    {% if orgs is not containing(org) %}
-      {% set_global orgs = orgs|concat(with=org) %}
-    {% endif %}
+{% for match in all_appearances %}
+  {% for org in match.o %}
+    {% if orgs is not containing(org) %}{% set_global orgs=orgs | concat(with=org) %}{% endif %}
   {% endfor %}
 {% endfor %}
 


### PR DESCRIPTION
It's only useful for the yearly bars section.

This fixes a longstanding, specific niggle: In the country talent list, a name which is an alias (and has a page), did not display an org badge.

Now it does, and the orgs displayed are only ones where that alias was used.