### PR TITLE
Index talent aliases, display in search results just like event dates.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,5 +69,5 @@ static/calendar-%.ics: content/e/%/*.md
 		-t $(shell grep -Po 'title = \K(.*)' content/e/${ORG}/_index.md) \
 		content/e/${ORG} > $@
 
-$(MINISEARCH_INDEX): content/**/*.md
+$(MINISEARCH_INDEX): content/**/*.md data/aliases.json
 	bin/build-index > $@

--- a/sass/_search.sass
+++ b/sass/_search.sass
@@ -78,6 +78,7 @@
         gap: 0.25rem
 
         #info
+          font-size: 0.9rem
           margin-left: auto
 
 

--- a/sass/_search.sass
+++ b/sass/_search.sass
@@ -72,9 +72,12 @@
         padding: 0.25rem
 
       a.search-result
-        padding-left: 0.5rem
-        padding-right: 0.5rem
-        display: block
+        padding: 0 0.5rem
+        display: flex
         text-decoration: none
+        gap: 0.25rem
+
+        #info
+          margin-left: auto
 
 

--- a/sass/_search.sass
+++ b/sass/_search.sass
@@ -73,12 +73,9 @@
 
       a.search-result
         padding: 0 0.5rem
-        display: flex
         text-decoration: none
-        gap: 0.25rem
 
         #info
           font-size: 0.9rem
-          margin-left: auto
 
 

--- a/src/bin/indexer.mjs
+++ b/src/bin/indexer.mjs
@@ -45,7 +45,7 @@ const build_document = async (path) => {
         const aliases = find_aliases(path);
         if (aliases) {
             aliases.delete(title)
-            info = [...aliases].join(" / ")
+            info = [...aliases].join(" | ")
         }
     }
 

--- a/static/search.js
+++ b/static/search.js
@@ -163,8 +163,8 @@ class SearchController {
         this.spin(true)
 
         this.index = MiniSearch.loadJSON(await response.text(), {
-            fields: ['title', 'text', 'date'],
-            storeFields: ['title', 'path', 'date'],
+            fields: ['title', 'text', 'info'],
+            storeFields: ['title', 'path', 'info'],
             processTerm: this.depolonize
         })
     }
@@ -241,10 +241,10 @@ class SearchController {
 
         icon.href.baseVal = url.toString()
         const result = node.querySelector('#result')
-        if (item.date)
-            result.textContent = `${item.title} (${item.date})`
-        else
-            result.textContent = item.title
+        const info = node.querySelector('#info')
+        result.textContent = item.title
+        if (item.info)
+            info.textContent = `(${item.info})`
 
         return node
     }

--- a/static/search.js
+++ b/static/search.js
@@ -1,6 +1,6 @@
 class SearchController {
     options = {
-        boost: { 'title': 1.6 },
+        boost: { 'title': 1.8, 'info': 1.2 },
         combineWith: 'AND',
         prefix: true
     }

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -27,6 +27,7 @@
               <use href="{{ sprite }}"/>
             </svg> 
             <span id="result"></span>
+            <span id="info"></span>
           </a>
         </template>
       </div>


### PR DESCRIPTION
To verify: search for someone with aliases, e.g. Goblin, Johnny Blade or Ostrowski, by any of their aliases (not the main name).

This is a new attempt at the problem that #1007 tried to address, but with less drastic changes.