### PR TITLE
Karta Areny 27, porządki we flagach

### DIFF
--- a/const/name-to-flag.yaml
+++ b/const/name-to-flag.yaml
@@ -23,7 +23,6 @@ Anita Vaughan: IE
 Anton Green: ENGLAND
 Antonio Cesaro: CH # Antonio Cesaro == Cesaro
 Arczi Czajka: PL
-Arkadiusz Paterek: PL
 Artur Dzwończak: PL
 Asara: CZ
 Audrey Bride: HU
@@ -34,7 +33,6 @@ Axel Tischer: DE
 Aytac Bahar: DE
 # B
 Baba-Thunder: PL
-Bad Bones: DE
 Bad News Barrett: ENGLAND
 Benji: HU
 Benny Bacchus: DK
@@ -51,7 +49,7 @@ Blue Nikita: GR
 Blue Thunder: PL # Blue Thunder == Szymon Kolanus
 Bjørn Sem: "NO"
 Bob Orton: US
-Bodyguard: PL
+Bodyguard: PL # Bodyguard == Tomczak
 Brad Maddox: US
 Bray Wyatt: US
 Brodus Clay: US
@@ -93,13 +91,11 @@ Deti Black: DE # Deti Black == Dieter Schwartz
 Devlyn Macabre: US
 Diego: US # Diego == Primo
 Dieter Schwartz: DE # Dieter Schwartz == Deti Black
-Direk: PL
 Dirty Dango: US
 Doink: US
 Dolph Ziggler: US
 Dominik Fischer: DE
 Dominik Więcek: PL
-Duende: PL # Duende == Sędzia Gocha == Sędzia Borys
 # E
 Eddie Rage: HU
 Edno: PL
@@ -159,11 +155,9 @@ Jack Swagger: US
 Jack Jester: SCOTLAND
 Jack Vaughn: US
 Jake Omen: US
-Jakob Sigmarsson: PL
 Jarek Nowak: PL
 Javier Vives: ES
 Jay Revolt: PL
-Jeff: PL # Jeff == Michael HT
 Jerry "Rich" Mandecki: PL
 Jim Duggan: US
 Jimmy Uso: US
@@ -173,8 +167,6 @@ Joe Bravo: AT
 Joey Ozbourne: ENGLAND
 Joey Riddic: PL
 John Cena: US
-John "Bad Bones" Klinger: DE
-Johny Vegas: PL
 Jon Hammer: ES # May prefer Catalan flag
 Jon Ryan: ENGLAND
 Joseph Conners: GB
@@ -188,8 +180,6 @@ Kaitlyn: US
 Kamil Kwiecień: PL
 Kamil Leśny: PL
 Kane: US
-Kapitan Testosteron: PL # Kapitan Testosteron = Marco Hammers
-Karol Górski (2): PL # Karol Górski (2) == Sędzia Karol Górski
 Karol M: PL
 Karyna: PL
 Kasandra: PL
@@ -210,13 +200,10 @@ Layla: ENGLAND
 Leo Zayde: PL
 Leśny: PL
 Lexi Luxx: SE
-Lider: PL
 Lince Dorado: US
 Lord Tensai: US
 Lucas Robinson: DE
 Ludy Lohan: DE
-Luca Bjorn: IT
-Łukasz "Balik" Baliński: PL
 Łukasz Okoński: PL
 # M
 Makoto Morimitsu: JP
@@ -243,14 +230,12 @@ Maverick: HU
 MBM: BE
 Mef the Death: PL
 Mexx: AT
-Michael HT: PL # Michael HT == Jeff
-Michael Kovac: AT
 Michael McGillicutty: US
 Michael Payne: PL
+Michael Schenkenberg: DE
 Mika The Polish Punisher: PL
 Mike D. Vecchio: BE
 Mikk Vainula: EE
-Miyagi Shida: PL # Miyagi Shida == Shida z MCW
 The Miz: US
 '"Modzel" Szymon Modzelewski': PL
 Mr Chairman: PL # Prezes Legacy
@@ -266,20 +251,15 @@ Nina Samuels: ENGLAND
 Noah Charon: GR
 # O
 Omen: IE
-Ostrowski: PL
 Otto Stahl: DE
 # P
 Pacjent: PL
 Pahlevan Nima: IR
 Pastor William Eaver: GB
-Paweł Borkowski: PL
-Paweł "Boryss" Borkowski: PL
 Pedrolo: ES
 Peter Tihanyi: HU
 PG Hooker: HU
 Piotr Opolski: PL
-Piotr Małecki: PL # Piotr Małecki == Piotr "ShowOff" Małecki
-Piotr "ShowOff" Małecki: PL # Piotr "ShowOff" Małecki == Piotr Małecki
 PJ Black: ZA
 Polish Giant: PL
 Primo: US # Primo == Diego
@@ -287,11 +267,9 @@ Psychodela: PL
 # R
 R1: FR
 Rambo: DO # Rambo == Salsakid Rambo
-RAV: PL
 Reece Alexios: GR
 Reinbakh: CA
 Reyca: HU
-Ricky Sky: SK
 Ritshy Rage: AT
 RJ Kolda: CZ
 Randy Orton: US
@@ -301,8 +279,6 @@ Rosa Mendes: CA
 Roy Johnson: ENGLAND
 R-Truth: US
 Rubix: DE
-Rusałka: PL
-Rust: IT
 Ryback: US
 # S
 Šakal: CZ
@@ -314,17 +290,7 @@ Scarecrow: PL # Alias of Mister Z
 Scott Rider: FR
 Sebastien: CZ
 Senza Volto: FR
-Sędzia Borys: PL # Sędzia Borys == Sędzia Gocha == Duende
-Sędzia Gocha: PL # Sędzia Gocha == Sędzia Borys == Duende
-Sędzia Karol Górski: PL # Sędzia Karol Górski = Karol Górski (2)
-Sędzia Klaudiusz: PL
-Sędzia Kornel: PL # Sędzia Kornel == Kapral Kornel (nieoficjalnie)
-Sędzia Matek: PL
 Sędzia Matt2Hot: PL
-Sędzia Michał: PL
-Sędzia Rafał: PL
-Sędzia Rafael: PL # Rafael Kid/Revage
-Sędzia Tobias: DE
 Serg Sullivan: RU # "The Enigma" Serg Sullivan == Serg Sullivan
 Session Moth Martina: IE
 Seth Donner: BY
@@ -342,16 +308,15 @@ Szymon Kolanus: PL # Szymon Kolanus == Blue Thunder
 Szymon "Modzel" Modzelewski: PL
 # T
 Tamina Snuka: US
-TAXI Złotówa: PL
 Ted DiBiase: US
 Tensai: US
-Terry Shadow (impostor): PL # wyjątkowo nieprzekonywająco zamaskowany Rob Scaffold, ale oficjalnie tego nie wiadomo :P
 The Iron Sheik: IR
 Tito Santana: US
 TJ Charles: IE
 Tobiasz "Skyver" Korzybski: PL
 Tom Fulton: SCOTLAND
 Tom LaRuffa: FR
+Tomczak: PL # Tomczak == Bodyguard
 Tommy Freeman: GB
 Tommy Kyle: GB
 Tony Sheen: PL

--- a/content/e/kpw/2025-01-24-kpw-arena-27.md
+++ b/content/e/kpw/2025-01-24-kpw-arena-27.md
@@ -20,6 +20,7 @@ city = "Gdynia"
 * Rosetti then stated that the upcoming event would see many changes, the continuation of the tournament started at [Arena 26](@/e/kpw/2024-11-15-kpw-arena-26.md) and the debut of a Polish wrestler.
 * This wrestler was later revealed to be Tomczak, one of KPW dojo trainees. As an unnamed "Bodyguard", he already stepped into the ring at [Pyrkon 2023](@/e/kpw/2023-06-17-kpw-pyrkon-2023.md), teaming with [Chemik](@/w/chemik.md) against the Fux Brothers. His [vignette][tomczak-intro] strongly resembles [Moloch's](@/w/moloch.md), and the character is also portrayed as a tall, mask-wearing monster.
 * Initially this event was supposed to see the tournament semi-finals, however since only three people qualified, acting chairman Rosetti [decided][rosetti-finals] that the finalist would be determined in a three-way match.
+
 {% card(predicted=true) %}
 - - '[Filip Fux](@/w/filip-fux.md)'
   - '[Michał Fux](@/w/michal-fux.md)'
@@ -31,6 +32,13 @@ city = "Gdynia"
   - nc: upcoming
 - - '[Zefir](@/w/zefir.md)'
   - 'Callum Beck'
+  - nc: upcoming
+- - '[Greg](@/w/greg.md)'
+  - '[Rosetti](@/w/rosetti.md), Tomczak'
+  - s: Handicap match
+    nc: upcoming
+- - '[Chemik](@/w/chemik.md)'
+  - 'Michael Schenkenbert'
   - nc: upcoming
 {% end %}
 

--- a/content/e/kpw/2025-01-24-kpw-arena-27.md
+++ b/content/e/kpw/2025-01-24-kpw-arena-27.md
@@ -38,7 +38,7 @@ city = "Gdynia"
   - s: Handicap match
     nc: upcoming
 - - '[Chemik](@/w/chemik.md)'
-  - 'Michael Schenkenbert'
+  - 'Michael Schenkenberg'
   - s: '[KPW OldTown Championship](@/c/kpw-old-town-championship.md)'
     nc: upcoming
 {% end %}

--- a/content/e/kpw/2025-01-24-kpw-arena-27.md
+++ b/content/e/kpw/2025-01-24-kpw-arena-27.md
@@ -39,7 +39,8 @@ city = "Gdynia"
     nc: upcoming
 - - '[Chemik](@/w/chemik.md)'
   - 'Michael Schenkenbert'
-  - nc: upcoming
+  - s: '[KPW OldTown Championship](@/c/kpw-old-town-championship.md)'
+    nc: upcoming
 {% end %}
 
 [boss-rosetti]: https://www.youtube.com/watch?v=dUr5kiuQclg


### PR DESCRIPTION
Dopisałem Tomczaka i Schenkenberga do listy flag, powywalałem ludzi mających już teczki (przynajmniej tych, których znalazłem).