### PR TITLE
Fix bad math when counting crew appearances.

### DIFF
--- a/src/bin/metadata.py
+++ b/src/bin/metadata.py
@@ -35,14 +35,14 @@ def update_cbf(career, page: EventPage):
             year = cast(Counter, entry.setdefault(event_date.year, Counter()))
             year.update(orgs)
 
-        if not card.crew: return
-        for person in card.crew.members:
-            if not accepted_name(person.name): continue
-            key = person.link or person.name
+    if not card.crew: return
+    for person in card.crew.members:
+        if not accepted_name(person.name): continue
+        key = person.link or person.name
 
-            entry = career.setdefault(key, {})
-            year = cast(Counter, entry.setdefault(event_date.year, Counter()))
-            year.update(orgs)
+        entry = career.setdefault(key, {})
+        year = cast(Counter, entry.setdefault(event_date.year, Counter()))
+        year.update(orgs)
 
 
 


### PR DESCRIPTION
The code to count crew appearances was mistakenly ran in a loop for each match. Hence e.g. Seweryn's 10 appearances for LOW, because the card has 10 entries.