### PR TITLE
Handle aliases of people who don't have their own article.

### DIFF
--- a/const/aliases.yaml
+++ b/const/aliases.yaml
@@ -1,0 +1,19 @@
+# "main name": "alias"
+# May repeat with different aliases. It is an error if a name is used both as name and as alias.
+# Alternatively: "main name": [list, of, aliases] (or in block form with dashes)
+# Think of this as formatted the same way you see it on the name list: main name first, then list of aliases.
+Wade Barrett: Bad News Barrett
+Bartosz: Bartek # Adept Shiplata
+Blue Thunder: Szymon Kolanus
+Adrian Zgórski: Adi
+Damien Sandow: Damien Mizdow
+Dieter Schwartz: Deti Black
+Primo: Diego # WWE's Primo Colón
+Faust XIII: Faust
+Istotna Martynka: Siostra Kimono
+Rambo: Salsakid Rambo
+Tomczak: Bodyguard
+Agent Agata:
+  - Agentka
+  - Agentka Agatka
+Tony Sheen: 'Tony "The River Man" Sheen'

--- a/const/name-to-flag.yaml
+++ b/const/name-to-flag.yaml
@@ -23,7 +23,7 @@ Ania: PL # Ania z merchu
 Andrzej Supron: PL
 Anita Vaughan: IE
 Anton Green: ENGLAND
-Antonio Cesaro: CH # Antonio Cesaro == Cesaro
+Antonio Cesaro: CH
 Arczi Czajka: PL
 Artur Dzwończak: PL
 Asara: CZ
@@ -48,10 +48,9 @@ The Big Show: US
 Bittersweet Josh: IT
 Black Orion: PL
 Blue Nikita: GR
-Blue Thunder: PL # Blue Thunder == Szymon Kolanus
+Blue Thunder: PL
 Bjørn Sem: "NO"
 Bob Orton: US
-Bodyguard: PL # Bodyguard == Tomczak
 Brad Maddox: US
 Bray Wyatt: US
 Brodus Clay: US
@@ -60,7 +59,6 @@ Callum Beck: ENGLAND
 Cameron: US
 Carlos Zamora: ES
 Carmen Rojas: BO
-Cesaro: CH # Cesaro == Antonio Cesaro
 Chakara: GB
 Chris The Bambikiller: AT
 Chris Botherway: ENGLAND
@@ -78,8 +76,7 @@ Cowboy James Storm: US
 Cybernic Machine: BE
 # D
 Damian Dunne: GB
-Damien Mizdow: US # Damien Mizdow == Damien Sandow
-Damien Sandow: US # Damien Sandow == Damien Mizdow
+Damien Sandow: US
 Damon Brix: AT
 Dariusz Łępicki:  PL
 Dark Black Skull: PL
@@ -89,9 +86,7 @@ David Otunga: US
 Denim Adams: HU
 Demolition Ax: US
 Demolition Blast: US
-Deti Black: DE # Deti Black == Dieter Schwartz
 Devlyn Macabre: US
-Diego: US # Diego == Primo
 Dieter Schwartz: DE # Dieter Schwartz == Deti Black
 Dirty Dango: US
 Doink: US
@@ -116,7 +111,6 @@ Fabio Ferrari: IT
 Falco: IT
 Fandango: US
 Fast Time Moodo: DE
-Faust: PL # Same as Faust XIII
 Faust XIII: PL
 Fernando: US
 Feyyaz Aguila: DE
@@ -149,7 +143,7 @@ Hunico: US
 Icarus: HU
 Iestyn Rees: WALES
 Ilja Dragunov: RU
-Istotna Martynka: PL # Istotna Martynka == Siostra Kimono
+Istotna Martynka: PL
 Iva Kolasky: HU
 Ivan Kiev: DE
 # J
@@ -264,11 +258,11 @@ PG Hooker: HU
 Piotr Opolski: PL
 PJ Black: ZA
 Polish Giant: PL
-Primo: US # Primo == Diego
+Primo: US
 Psychodela: PL
 # R
 R1: FR
-Rambo: DO # Rambo == Salsakid Rambo
+Rambo: DO
 Reece Alexios: GR
 Reinbakh: CA
 Reyca: HU
@@ -285,7 +279,6 @@ Ryback: US
 # S
 Šakal: CZ
 Salomon Strid: FI
-Salsakid Rambo: DO
 Sam Gradwell: GB
 Samuray Del Sol: US
 Scarecrow: PL # Alias of Mister Z
@@ -298,7 +291,6 @@ Session Moth Martina: IE
 Seth Donner: BY
 Shane Baker: HU
 Shigehiro Irie: JP
-Siostra Kimono: PL # Siostra Kimono == Istotna Martynka
 Sixt: SE
 Spartan: PL
 Speedball Mike Bailey: CA
@@ -306,7 +298,6 @@ Starbuck: CA
 Steinbolt: SE
 Sunny Beach: US
 Svedberg: SE
-Szymon Kolanus: PL # Szymon Kolanus == Blue Thunder
 Szymon "Modzel" Modzelewski: PL
 # T
 Tamina Snuka: US
@@ -318,7 +309,7 @@ TJ Charles: IE
 Tobiasz "Skyver" Korzybski: PL
 Tom Fulton: SCOTLAND
 Tom LaRuffa: FR
-Tomczak: PL # Tomczak == Bodyguard
+Tomczak: PL
 Tommy Freeman: GB
 Tommy Kyle: GB
 Tony Sheen: PL

--- a/templates/alphabetical_talent_list.html
+++ b/templates/alphabetical_talent_list.html
@@ -81,9 +81,32 @@
           {% set_global appearances_entry = appearances|get(key=name, default=[]) %}
           {% set_global crew_appearances_entry = crew_appearances|get(key=name, default=[]) %}
           {% set_global display_match_links = true %}
-          <li class="pwf">
-            {% include "roster/unlinked_person.html" %}
-            {% include "roster/person_orgs_matches.html" %}
+          {# 'U'-flavor entries may have aliases which have flavor 'Y', and the main name at position 3, where regular aliases have the filename #}
+          {% set my_aliases = grouped_by_alias | get(key=name, default=[]) | sort(attribute="0") %}
+          <li class="{% if my_aliases|length > 0 %}pwa{% endif %}">
+            <span class="pwf">
+              {% include "roster/unlinked_person.html" %}
+              {% include "roster/person_orgs_matches.html" %}
+            </span>
+            {% if my_aliases|length > 0 %}
+              <ul>
+                {% for alias in my_aliases %}
+                  {% set name = alias[1] %}
+                  {% set flavor = alias[2] %}
+                  {% set flag = false %}
+                  {% set_global person_name = '<em>' ~ name ~ '</em>' %}
+                  {% set_global appearances_entry = appearances | get(key=name, default=[]) %}
+                  {% set_global crew_appearances_entry = crew_appearances|get(key=name, default=[]) %}
+                  {% set_global display_match_links = true %}
+                  <li>
+                    <span class="pwf">
+                      <span class="name">{{ person_name | safe }}</span>
+                      {% include "roster/person_orgs_matches.html" %}
+                    </span>
+                  </li>
+                {% endfor %}
+              </ul>
+            {% endif %}
           </li>
         {% endif %}
       {% endfor %}

--- a/templates/country_talent_list.html
+++ b/templates/country_talent_list.html
@@ -78,9 +78,31 @@
           {% set_global appearances_entry = appearances|get(key=name, default=[]) %}
           {% set_global crew_appearances_entry = crew_appearances|get(key=name, default=[]) %}
           {% set_global display_match_links = true %}
-          <li class="pwf">
-            <span class="name">{{ person_name }}</span>
-            {% include "roster/person_orgs_matches.html" %}
+          {% set my_aliases = grouped_by_alias | get(key=name, default=[]) | sort(attribute="0") %}
+          <li class="{% if my_aliases|length > 0 %}pwa{% endif %}">
+            <span class="pwf">
+              <span class="name">{{ person_name }}</span>
+              {% include "roster/person_orgs_matches.html" %}
+            </span>
+            {% if my_aliases|length > 0 %}
+              <ul class="nf">
+                {% for alias in my_aliases %}
+                  {% set name = alias[1] %}
+                  {% set flavor = alias[2] %}
+                  {% set flag = false %}
+                  {% set_global person_name = '<em>' ~ name ~ '</em>' %}
+                  {% set_global appearances_entry = appearances | get(key=name, default=[]) %}
+                  {% set_global crew_appearances_entry = crew_appearances|get(key=name, default=[]) %}
+                  {% set_global display_match_links = true %}
+                  <li>
+                    <span class="pwf">
+                      <span class="name">{{ person_name | safe }}</span>
+                      {% include "roster/person_orgs_matches.html" %}
+                    </span>
+                  </li>
+                {% endfor %}
+              </ul>
+            {% endif %}
           </li>
         {% endif %}
     {% endfor %}


### PR DESCRIPTION
Introduces a new auxiliary file: `const/aliases.yaml`. Its format is a mapping of a **main name** to either a single alias, or a list of these. For Example:

```yaml
Tomczak: Bodyguard
Wade Barrett:
  - Stu Bennett
  - Bad News Barrett
  - Lawrence Knight
```

Both name lists (alphabetical and country-grouped) will respect this, and list aliases indented under the main name, same as they do for aliases of people who have an article.
