### PR TITLE
La Parka (etc.), flagi i aliasy

### DIFF
--- a/const/aliases.yaml
+++ b/const/aliases.yaml
@@ -12,6 +12,7 @@ Damien Sandow: Damien Mizdow
 Dieter Schwartz: Deti Black
 Faust XIII: Faust
 Istotna Martynka: Siostra Kimono
+Leo Zayde: Lio Zayde
 Primo: Diego # WWE's Primo Colón
 Red Dorada:
   - Mati

--- a/const/aliases.yaml
+++ b/const/aliases.yaml
@@ -17,6 +17,9 @@ Red Dorada:
   - Mati
   - RoodWood
 Rambo: Salsakid Rambo
-Tomczak: Bodyguard
+Serg Sullivan: '"The Enigma" Serg Sullivan'
+Tomczak:
+  - Bodyguard
+  - TOMCZAK
 Tony Sheen: 'Tony "The River Man" Sheen'
 Wade Barrett: Bad News Barrett

--- a/const/aliases.yaml
+++ b/const/aliases.yaml
@@ -20,6 +20,6 @@ Rambo: Salsakid Rambo
 Serg Sullivan: '"The Enigma" Serg Sullivan'
 Tomczak:
   - Bodyguard
-  - TOMCZAK
+#  - TOMCZAK # Usunąć komentarz w razie potrzeby; na razie nie ma wpisanego żadnego wystąpienia wielkimi
 Tony Sheen: 'Tony "The River Man" Sheen'
 Wade Barrett: Bad News Barrett

--- a/const/name-to-flag.yaml
+++ b/const/name-to-flag.yaml
@@ -100,7 +100,6 @@ Denim Adams: HU
 Demolition Ax: US
 Demolition Blast: US
 Devlyn Macabre: US
-Diego: US
 Dieter Schwartz: DE # Dieter Schwartz == Deti Black
 Dirty Dango: US
 Dirty Devil: PL

--- a/const/name-to-flag.yaml
+++ b/const/name-to-flag.yaml
@@ -85,7 +85,6 @@ Cybernic Machine: BE
 # D
 D-Generation X (imitators): PL
 Damian Dunne: GB
-Damien Mizdow: US
 Damien Sandow: US
 Damon Brix: AT
 Dariusz Łępicki:  PL

--- a/const/name-to-flag.yaml
+++ b/const/name-to-flag.yaml
@@ -1,12 +1,12 @@
 # A
 Aaron Williams: US
+Abdullah the Hercules: PL
+Adam: PL
 Adam "Omega" Sekuła: PL
 Adam Rose: ZA
-Adi: PL # Adi == Adrian Zgórski
 Adrian Gawrychowski: PL
 Adrian Zgórski: PL # Adrian Zgórski == Adi
 Agent Agata: PL # Agent Agata == Agentka Agatka
-Agentka Agatka: PL # Agentka Agatka == Agent Agata
 Aigle Blanc: FR
 Ahmed Chaer: DE
 AJ Lee: US
@@ -20,8 +20,11 @@ Amale: FR
 Amskér: CZ
 Amy Heartbeat: DE
 Ania: PL # Ania z merchu
+Andrzej: PL
 Andrzej Supron: PL
+Angel Guerrero: PL
 Anita Vaughan: IE
+Antek Istociarz: PL
 Anton Green: ENGLAND
 Antonio Cesaro: CH
 Arczi Czajka: PL
@@ -36,15 +39,16 @@ Aytac Bahar: DE
 # B
 Baba-Thunder: PL
 Bad News Barrett: ENGLAND
+Bartosz: PL
 Benji: HU
 Benny Bacchus: DK
 Bernard Vandamme: BE
 Bestia: PL
 Beth Phoenix: US
 Big Geert: NL
-Big E: US # Big E == Big E. Langston
-Big E. Langston: US # Big E. Langston == Big E
+Big E. Langston: US
 The Big Show: US
+Billi Rox: PL
 Bittersweet Josh: IT
 Black Orion: PL
 Blue Nikita: GR
@@ -52,9 +56,11 @@ Blue Thunder: PL
 Bjørn Sem: "NO"
 Bob Orton: US
 Brad Maddox: US
+Brave Sky: US
 Bray Wyatt: US
 Brodus Clay: US
 # C
+Caein: PL
 Callum Beck: ENGLAND
 Cameron: US
 Carlos Zamora: ES
@@ -67,40 +73,49 @@ Chris Colen: AT
 Chris Masters: US
 Chris Steeler: PL
 Chris Tyson: DE
+Claymore: SCOTLAND
 CMD: PL
 CM Punk: US
 Cody Rhodes: US
+Columbus: PL
 Crazy Sexy Mike: DE
 Crowchester: DE
 Cowboy James Storm: US
 Cybernic Machine: BE
 # D
+D-Generation X (imitators): PL
 Damian Dunne: GB
 Damien Sandow: US
 Damon Brix: AT
 Dariusz Łępicki:  PL
 Dark Black Skull: PL
+Darko Hammers: PL
 Daniel Bryan: US
 Dave Bradshaw: ENGLAND
 David Otunga: US
+Deadman: PL
+Demencjusz Wolski: PL
 Denim Adams: HU
 Demolition Ax: US
 Demolition Blast: US
 Devlyn Macabre: US
 Dieter Schwartz: DE # Dieter Schwartz == Deti Black
 Dirty Dango: US
+Dirty Devil: PL
 Doink: US
 Dolph Ziggler: US
 Dominik Fischer: DE
 Dominik Więcek: PL
+Doomfist: PL
 # E
 Eddie Rage: HU
 Edno: PL
 El Generico: CA
 Electra: IT
+Electrico: PL
 Emilian Lewis: DK
 Emma: AU
-'"The Enigma" Serg Sullivan': RU # "The Enigma" Serg Sullivan == Serg Sullivan
+Epic Angel Guerrero: PL
 Epico: US
 Erick Rowan: US
 Erik Isaksen: "NO"
@@ -123,6 +138,7 @@ Flying Dragon: DE
 Franz Schlederer: AT
 # G
 Gabriel Magic: HU
+Gangsta: PL
 Garett Noah: DE
 Gaya Glass: IL
 Gianni Valletta: MT
@@ -132,29 +148,38 @@ Gulyás Öcsi: HU
 Gulyás Vilmos: HU
 # H
 Harley Hudson: ENGLAND
+Hardcore Icon: PL
+The Hardy Boyz (imitators): PL
+Havro: PL
 Heath Slater: US
 Heidi Katrina: ENGLAND
 Heimo Ukonselkä: FI
 Hekate: PL
 Herco Wisky: AR
-Hirinus: PL
+Human: PL
 Hunico: US
 # I
 Icarus: HU
 Iestyn Rees: WALES
 Ilja Dragunov: RU
+Iron Mike Sharpe: CA
 Istotna Martynka: PL
 Iva Kolasky: HU
+Ivan Boikov: UA
 Ivan Kiev: DE
+Izray: PL
 # J
 Jack Swagger: US
 Jack Jester: SCOTLAND
+Jack Kalom: PL
 Jack Vaughn: US
 Jake Omen: US
+Jake Young: PL
 Jarek Nowak: PL
 Javier Vives: ES
 Jay Revolt: PL
 Jerry "Rich" Mandecki: PL
+Jędrzej Jezierski: PL
 Jim Duggan: US
 Jimmy Uso: US
 Jinder Mahal: CA
@@ -163,6 +188,7 @@ Joe Bravo: AT
 Joey Ozbourne: ENGLAND
 Joey Riddic: PL
 John Cena: US
+John the Motherfucker King: PL
 Jon Hammer: ES # May prefer Catalan flag
 Jon Ryan: ENGLAND
 Joseph Conners: GB
@@ -181,18 +207,25 @@ Karyna: PL
 Kasandra: PL
 Kat Von Kaige: WALES
 Kelly Kelly: US
+Kevin Kevin: PL
 Kevin Williams: SCOTLAND
 Kofi Kingston: GH
 Koko B. Ware: US
 Koppany: HU
 Koteł: PL
 Král Slova Kuba: CZ
+Krasso: PL
 Krzysztof Skwarczyński: PL
 Kuba Wątły: PL
+Kuba z WWEPolandNatioN: PL
+Kurosh: PL
 # L/Ł
 Lanny Poffo: CA
+La Parka (Który nie jest prawdziwym etc.): PL
 Laurance Roman: DE
 Layla: ENGLAND
+LaVonce: US
+Learson: PL
 Leo Zayde: PL
 Leśny: PL
 Lexi Luxx: SE
@@ -200,7 +233,6 @@ Lince Dorado: US
 Lord Tensai: US
 Lucas Robinson: DE
 Ludy Lohan: DE
-Łukasz Okoński: PL
 # M
 Makoto Morimitsu: JP
 Mansoor: SA
@@ -213,16 +245,20 @@ Mario Rodriguez: PL
 Marius Al-Ani: DE
 Mark Haskins: GB
 Mark Henry: US
-Martin Guerrerro: DE
+Martin Guerrero: DE
 Martn Pain: AT
 Martyn Stallyon: SCOTLAND
 Mason Madden: US
+Master Punk: PL
+Mateusz Mazurowski: PL
 Mateusz "Orzech" Orzechowski: PL
+Matt2Hot Jr.: PL
 Matt Miric: HU
 Matt Sydal: US
 Matthias Bernstein: DE
 Matuch: PL
 Maverick: HU
+Max Moon: HR
 MBM: BE
 Mef the Death: PL
 Mexx: AT
@@ -232,17 +268,22 @@ Michael Schenkenberg: DE
 Mika The Polish Punisher: PL
 Mike D. Vecchio: BE
 Mikk Vainula: EE
+Minder: PL
 The Miz: US
 '"Modzel" Szymon Modzelewski': PL
 Mr Chairman: PL # Prezes Legacy
 "Ms. XXX": PL
+Mystic Tiger: PL
 # N
 Natalia Dinges: PL
 Natalya: US
+Nathan Flame: PL
 Newt Nova: ES
 Nick Schreier: DE
+Nick Violent: PL
 Nickolas von Rijk: DE
 Nightshade: ENGLAND
+Nikona: US
 Nina Samuels: ENGLAND
 Noah Charon: GR
 # O
@@ -255,7 +296,9 @@ Pastor William Eaver: GB
 Pedrolo: ES
 Peter Tihanyi: HU
 PG Hooker: HU
-Piotr Opolski: PL
+Phantom: PL
+Phil Feager: PL
+Piotr Walkowiak: PL
 PJ Black: ZA
 Polish Giant: PL
 Primo: US
@@ -263,55 +306,73 @@ Psychodela: PL
 # R
 R1: FR
 Rambo: DO
+Razor: PL
+Red Dorada: PL # Red Dorada == Mati == RoodWood
 Reece Alexios: GR
 Reinbakh: CA
 Reyca: HU
 Ritshy Rage: AT
 RJ Kolda: CZ
 Randy Orton: US
+Resh: PL
+Rey Mysterio (knock-off): PL
+Rob Cage: ENGLAND
+Rob Crowley: PL
 Robert Dreissker: AT
+Roger Kevin: PL
+Rogerek: PL
 Roman Reigns: US
 Rosa Mendes: CA
 Roy Johnson: ENGLAND
 R-Truth: US
 Rubix: DE
+Rusałka: PL
 Ryback: US
 # S
 Šakal: CZ
 Salomon Strid: FI
 Sam Gradwell: GB
 Samuray Del Sol: US
-Scarecrow: PL # Alias of Mister Z
 Scott Rider: FR
+SD Jones: AG
 Sebastien: CZ
 Senza Volto: FR
+Sędzia Herno: PL
+Sędzia Jędrek: PL
 Sędzia Matt2Hot: PL
 Serg Sullivan: RU # "The Enigma" Serg Sullivan == Serg Sullivan
 Session Moth Martina: IE
 Seth Donner: BY
 Shane Baker: HU
 Shigehiro Irie: JP
+Sigurd: PL
+Sin Cara: PL
 Sixt: SE
 Spartan: PL
 Speedball Mike Bailey: CA
+Stanisław Stachowiak: PL
 Starbuck: CA
 Steinbolt: SE
 Sunny Beach: US
 Svedberg: SE
+Szymon Kuciok: PL
 Szymon "Modzel" Modzelewski: PL
 # T
 Tamina Snuka: US
 Ted DiBiase: US
 Tensai: US
+Terror: PL
 The Iron Sheik: IR
 Tito Santana: US
 TJ Charles: IE
 Tobiasz "Skyver" Korzybski: PL
 Tom Fulton: SCOTLAND
 Tom LaRuffa: FR
-Tomczak: PL
+Tomczak: PL # Tomczak == TOMCZAK
 Tommy Freeman: GB
 Tommy Kyle: GB
+Tommy Tornado: AT
+Tommy Torpedo: AT
 Tony Sheen: PL
 Tony "The River Man" Sheen: PL
 Trent Seven: ENGLAND
@@ -320,12 +381,19 @@ Tucker: GB # Northern Ireland
 Tyson Kidd: CA
 # U
 Ultimo Chingon: MX
+Ultimate Mike: PL
 # V
+Vairen: PL
+Van Hammer: US
+Vandal: PL
+'"The Veteran" Jack Vaughn': US
 Viking: CZ
 Violet Nyte: GB
-'"The Veteran" Jack Vaughn': US
+The Viper: PL
 # W
 Wade Barrett: ENGLAND
+Wielki G: PL
+Wiktor: PL
 Wojciech "Vice" Baranowski: PL
 # X
 Xia Brookside: ENGLAND

--- a/const/name-to-flag.yaml
+++ b/const/name-to-flag.yaml
@@ -85,6 +85,7 @@ Cybernic Machine: BE
 # D
 D-Generation X (imitators): PL
 Damian Dunne: GB
+Damien Mizdow: US
 Damien Sandow: US
 Damon Brix: AT
 Dariusz Łępicki:  PL
@@ -99,6 +100,7 @@ Denim Adams: HU
 Demolition Ax: US
 Demolition Blast: US
 Devlyn Macabre: US
+Diego: US
 Dieter Schwartz: DE # Dieter Schwartz == Deti Black
 Dirty Dango: US
 Dirty Devil: PL

--- a/content/e/dfw/2016-08-20-dfw-tournament-of-dreams-2.md
+++ b/content/e/dfw/2016-08-20-dfw-tournament-of-dreams-2.md
@@ -35,7 +35,7 @@ This event saw the DFW debuts of [Rob Scaffold](@/w/rob-scaffold.md) and [Direk]
   - c: '[DFW Championship](@/c/dfw-championship.md)'
     s: Tournament Final Match
 - credits:
-    Commentary: 'Seth Donner, WWEPolandNatioN'
+    Commentary: 'Seth Donner, Kuba z WWEPolandNatioN'
 {% end %}
 
 ### References

--- a/content/e/kpw/2017-08-12-kpw-godzina-zero-2017.md
+++ b/content/e/kpw/2017-08-12-kpw-godzina-zero-2017.md
@@ -7,7 +7,7 @@ venue=["gdynia-sports-center"]
 [extra]
 city = "Gdynia"
 [extra.gallery]
-1 = { path = "2017-08-12-kpw-godzina-zero-2017-plakat.jpg", caption = "Official poster, showing [Bianca](@/w/bianca.md), Joey Ozbourne, [Fynn Freyhard](@/w/fynn-freyhart.md), [Kamil Aleksander](@/w/kamil-aleksander.md), [Ron Corvus](@/w/ron-corvus.md), [Piękny Kawaler](@/w/piekny-kawaler.md), [Greg](@/w/greg.md), [Wild Boar](@/w/wild-boar.md), Kat Von Kaige, Mika the Polish Punisher, [David Oliwa](@/w/david-oliwa.md), [Peter Pannache](@/w/peter-pannache.md) and [Robert Star](@/w/robert-star.md).", source = "kpwrestling.pl / Official KPW Facebook" }
+1 = { path = "2017-08-12-kpw-godzina-zero-2017-plakat.jpg", caption = "Official poster, showing [Bianca](@/w/bianca.md), Joey Ozbourne, [Fynn Freyhard](@/w/fynn-freyhart.md), [Kamil Aleksander](@/w/kamil-aleksander.md), [Ron Corvus](@/w/ron-corvus.md), [Piękny Kawaler](@/w/piekny-kawaler.md), [Greg](@/w/greg.md), [Wild Boar](@/w/wild-boar.md), Kat Von Kaige, Mika The Polish Punisher, [David Oliwa](@/w/david-oliwa.md), [Peter Pannache](@/w/peter-pannache.md) and [Robert Star](@/w/robert-star.md).", source = "kpwrestling.pl / Official KPW Facebook" }
 +++
 
 The second Godzina Zero (_Zero Hour_) was a massive event by KPW standards. Both championships were defended against foreign opponents. Not one but two women's matches were held, and a huge 8-man elimination ladder match led the second half.
@@ -21,7 +21,7 @@ The other challenger was Welsh wrestler Wild Boar, by then already a veteran of 
 {% card() %}
 - ['[Peter Pannache](@/w/peter-pannache.md)', '[Kaszub](@/w/kaszub.md)']
 - ['[Alisa](@/w/alisa.md)', '[Mira](@/w/mira.md)', {nc: No Contest}]
-- ['[Kamil Aleksander](@/w/kamil-aleksander.md)', Mika the Polish Punisher]
+- ['[Kamil Aleksander](@/w/kamil-aleksander.md)', Mika The Polish Punisher]
 - ['[Gracjan Korpo](@/w/gracjan-korpo.md)', '[Krzysztof Zasada](@/w/krzysztof-zasada.md)']
 - ['[Greg](@/w/greg.md)(c)', '[Fynn Freyhart](@/w/fynn-freyhart.md)', {c: "[KPW OldTown Championship](@/c/kpw-old-town-championship.md)"}]
 - ['[Robert Star](@/w/robert-star.md)', Joey Ozbourne, {s: "No Disqualification Match"}]

--- a/content/e/mzw/2021-08-14-mzw-project-8-golden-road-finals.md
+++ b/content/e/mzw/2021-08-14-mzw-project-8-golden-road-finals.md
@@ -30,7 +30,7 @@ source = "Official MZW Facebook"
   - Chris Tyson
 - -  'Michael Payne'
   -  '[Prince Striker](@/w/royal-striker.md)'
-  -  'Lio Zayde'
+  -  'Leo Zayde'
   -  '[Chris X](@/w/chris-x.md)'
   -  '???'
   -  s: "Seven Man Rookie Battle Royal"

--- a/content/e/mzw/2021-08-14-mzw-project-8-golden-road-finals.md
+++ b/content/e/mzw/2021-08-14-mzw-project-8-golden-road-finals.md
@@ -30,7 +30,7 @@ source = "Official MZW Facebook"
   - Chris Tyson
 - -  'Michael Payne'
   -  '[Prince Striker](@/w/royal-striker.md)'
-  -  'Leo Zayde'
+  -  'Lio Zayde'
   -  '[Chris X](@/w/chris-x.md)'
   -  '???'
   -  s: "Seven Man Rookie Battle Royal"

--- a/content/e/ppw/2011-07-01-ppw-neomania-i.md
+++ b/content/e/ppw/2011-07-01-ppw-neomania-i.md
@@ -18,7 +18,7 @@ Neomania was the inaugural show in the Neomania series of [PpW's](@/o/ppw.md) ea
 
 {% card() %}
 - - '[Ultimo Combo](@/w/johnny-blade.md)'
-  - 'La Parka (Który nie jest prawdziwym La Parką ale to szczegół)'
+  - 'La Parka (Który nie jest prawdziwym etc.)'
   - r: 'Submission'
 - - 'Black Tiger'
   - 'Red Dorada'
@@ -32,7 +32,7 @@ Neomania was the inaugural show in the Neomania series of [PpW's](@/o/ppw.md) ea
 #### Recap
 
 * The only surviving video from the event is Ultimo Combo vs La Parka (Który nie jest prawdziwym La Parką ale to szczegół).
-* According to the [PpW Wikia][ppw-wiki-neo-1], "La Parka (Który nie jest prawdziwym La Parką ale to szczegół)" appears to be the full name of this contestant. It translates to "La Parka (Who isn't the real La Parka, but that's a minor detail)".
+* According to the [PpW Wikia][ppw-wiki-neo-1], the full name of this version of La Parka appears to be "La Parka (Który nie jest prawdziwym La Parką ale to szczegół)". This translates to "La Parka (Who isn't the real La Parka, but that's a minor detail)". (The name was shortened in this entry for technical reasons.)
 * The cameraman/commentator refers to La Parka (etc.) in the feminine grammatical gender, as "La Parka (_Która_ nie jest _prawdziwą_ La Parką ale to szczegół)" - most likely because in the Polish language, names ending with an "a" are almost exclusively feminine.
 * When the first match begins, the cameraman says "But this has to be pretend, right?"
 * Also, [PpW Wikia][ppw-wiki-neo-1] notes that Black Tiger was standing in for Pan Pionha (roughly _Mister Feest_), who no-showed the fight. A similar situation later happened at [Neomania II](@/e/ppw/2012-07-01-ppw-neomania-ii.md).

--- a/content/e/ppw/2024-11-15-ppw-piwo-przyjacielem-wrestlingu-2.md
+++ b/content/e/ppw/2024-11-15-ppw-piwo-przyjacielem-wrestlingu-2.md
@@ -72,7 +72,7 @@ The only exceptions were Isnorr's title defense against Prince Striker, and Aron
   - '[Sambor](@/w/sambor.md)'
   - s: Singles Match
 - - 'Istotna Martynka'
-  - '[Marco Hammers](@/w/marco-hammers.md)(c); [Olgierd](@/w/olgierd.md); Darko Hammers'
+  - '[Marco Hammers](@/w/marco-hammers.md)(c); [Olgierd](@/w/olgierd.md), Darko Hammers'
   - s: Singles Match
     c: '[PTW Intergender Championship](@/c/ptw-intergender-championship.md)'
 - - '[Aron Wake](@/w/aron-wake.md)'


### PR DESCRIPTION
Plus ujednolicenie pisowni Polish Punishera, bo był podwójnie przez jedną literkę.