### PR TITLE
Collapse gallery to first 6 photos and show a link to display the rest.

### DIFF
--- a/GALLERY.md
+++ b/GALLERY.md
@@ -43,7 +43,14 @@ The value is always a map (another list of key-value pairs), which **must contai
 
 ### Collapsing
 
-If `collapse_gallery` is present in the extra section, and has a value of `true`, the gallery will start in a collapsed state, only showing the first six photos, and a link to display the rest.
+The extra section may contain a key named `collapse_gallery`. Depending on its value, the gallery may be collapsed:
+
+* when set to `true`: gallery is always collapsed, only showing the first six thumbnails, and a link to display the rest.
+* when set to `"auto"`: gallery is only collapsed if it has more than 12 items
+* when set to `false`: gallery is never collapsed
+* when the key is missing: same as `"auto"`
+
+Regardless of whether the gallery is collapsed or not, the lightbox can navigate between all photos without expanding it first.
 
 ### Alternate TOML format
 

--- a/GALLERY.md
+++ b/GALLERY.md
@@ -26,6 +26,7 @@ title = "PpW Ale Grzeje"
 template = "event_page.html"
 [extra]
 venue = "teatr-komuna"
+collapse_gallery = true
 [extra.gallery]
 1 = { path = "ale-grzeje-poster.jpg", caption = "The show's official poster. Top photo shows [Gustav Gryffin](@/w/gustav-gryffin.md) standing face to face with [Biesiad Strong](@/w/biesiad.md). The bottom one has [Jakob Sigmarsson](@/w/jakub-linde.md) and [Rafi](@/w/rafi.md) celebrating Gustav's victory.", source = "Facebook PPW Ewenement"}
 +++
@@ -39,6 +40,10 @@ The value is always a map (another list of key-value pairs), which **must contai
 * `path` must name a file in the page's images folder (see above). There is no way to link images from other articles, and copying them is the only solution for now.
 * `caption` is the text to display under the thumbnail in the gallery grid. Markdown can be used in this text, as shown in the example, so it can link to other pages. However, shortcodes and template markup cannot be used.
 * `source` is the attribution. While currently it's not displayed, we still want to collect it to have a grasp on where the images came from.
+
+### Collapsing
+
+If `collapse_gallery` is present in the extra section, and has a value of `true`, the gallery will start in a collapsed state, only showing the first six photos, and a link to display the rest.
 
 ### Alternate TOML format
 

--- a/content/e/low/2024-12-01-low-1.md
+++ b/content/e/low/2024-12-01-low-1.md
@@ -7,6 +7,7 @@ chronology = ["low"]
 venue=["krolestwo-katowice"]
 [extra]
 city = "Katowice"
+collapse_gallery = true
 [extra.gallery]
 manifest = "@/e/low/2024-12-01-low-1-gallery.toml"
 +++

--- a/content/e/low/2024-12-01-low-1.md
+++ b/content/e/low/2024-12-01-low-1.md
@@ -7,7 +7,6 @@ chronology = ["low"]
 venue=["krolestwo-katowice"]
 [extra]
 city = "Katowice"
-collapse_gallery = true
 [extra.gallery]
 manifest = "@/e/low/2024-12-01-low-1-gallery.toml"
 +++

--- a/sass/_gallery.sass
+++ b/sass/_gallery.sass
@@ -33,7 +33,6 @@ ul.gallery
       background-size: contain
 
   .expand-gallery
-    color: red
     flex-grow: 2
     text-align: end
     background: var(--accent-bg)

--- a/sass/_gallery.sass
+++ b/sass/_gallery.sass
@@ -32,6 +32,15 @@ ul.gallery
       background-repeat: no-repeat
       background-size: contain
 
+  .expand-gallery
+    color: red
+    flex-grow: 2
+    text-align: end
+    background: var(--accent-bg)
+
+    a
+      cursor: pointer
+
 details > summary.h2-like
   font-size: 2.6rem
   margin-top: 3rem

--- a/static/gallery.js
+++ b/static/gallery.js
@@ -153,13 +153,19 @@ class GalleryController {
 
     collapse_main() {
         if (!this.root.classList.contains('main-gallery')) return
-        if (!this.root.dataset.allowCollapse) return
+        const when = this.root.dataset.allowCollapse
+        if (!when) return
+
         const thumbs = this.root.querySelectorAll('li')
         const total_photo_count = thumbs.length
+        if (when == 'auto' && total_photo_count < 12) return
+
         Array.from(thumbs).slice(6).forEach((el) => el.style.display = 'none')
 
         const display_more = document.createElement('a')
-        display_more.textContent = `Expand gallery (${total_photo_count - 6} photos hidden)`
+        const keep_visible = 6
+        const hidden_text = this.pluralize('photos hidden', total_photo_count - keep_visible)
+        display_more.textContent = `Expand gallery (${hidden_text})`
         const el = document.createElement('li')
         el.classList.add('expand-gallery')
         el.appendChild(display_more)
@@ -170,6 +176,18 @@ class GalleryController {
         this.root.appendChild(el)
     }
 
+    pluralize(term, n) {
+        const rules = JSON.parse(document.querySelector('#pluralization-rules').textContent)
+        const matching_rule = rules[term]
+        if (!matching_rule)
+            return `${n} ${term}`
+        switch (n) {
+        case 1:
+            return matching_rule.one.replace('$n', n)
+        default:
+            return matching_rule.other.replace('$n', n)
+        }
+    }
 }
 
 const dialog = document.querySelector('dialog#lb')

--- a/static/gallery.js
+++ b/static/gallery.js
@@ -153,7 +153,7 @@ class GalleryController {
 
     collapse_main() {
         if (!this.root.classList.contains('main-gallery')) return
-        const when = this.root.dataset.allowCollapse
+        const when = this.root.dataset.collapseGallery
         if (!when) return
 
         const thumbs = this.root.querySelectorAll('li')

--- a/static/gallery.js
+++ b/static/gallery.js
@@ -127,6 +127,7 @@ class GalleryController {
     static outlets = ["lightbox"]
 
     constructor(gallery_list, lightbox) {
+        this.root = gallery_list
         this.lightbox = lightbox
         this.connect(gallery_list)
     }
@@ -156,11 +157,31 @@ class GalleryController {
         return [prevFig, nextFig]
     }
 
+    collapse_main() {
+        if (!this.root.classList.contains('main-gallery')) return
+        if (!this.root.dataset.allowCollapse) return
+        const thumbs = this.root.querySelectorAll('li')
+        const total_photo_count = thumbs.length
+        Array.from(thumbs).slice(6).forEach((el) => el.style.display = 'none')
+
+        const display_more = document.createElement('a')
+        display_more.textContent = `Expand gallery (${total_photo_count - 6} photos hidden)`
+        const el = document.createElement('li')
+        el.classList.add('expand-gallery')
+        el.appendChild(display_more)
+        display_more.addEventListener('click', () => {
+            Array.from(thumbs).slice(6).forEach((el) => el.style.display = 'initial')
+            el.remove()
+        })
+        this.root.appendChild(el)
+    }
+
 }
 
 const dialog = document.querySelector('dialog#lb')
 const lightbox = new LightboxController(dialog)
 // TODO: more than one gallery, normal on talent pages
 document.querySelectorAll('ul.gallery').forEach((gal) => {
-    new GalleryController(gal, lightbox)
+    const gc = new GalleryController(gal, lightbox)
+    gc.collapse_main()
 })

--- a/static/gallery.js
+++ b/static/gallery.js
@@ -1,7 +1,4 @@
 class LightboxController {
-    static targets = ["dialog", "close", "prev", "next", "maximize", "minimize",
-                      "container", "img", "caption", "desc", "attribution"]
-
     paginator
     maximised
 
@@ -123,9 +120,6 @@ class LightboxController {
 }
 
 class GalleryController {
-    static targets = ["figure"]
-    static outlets = ["lightbox"]
-
     constructor(gallery_list, lightbox) {
         this.root = gallery_list
         this.lightbox = lightbox

--- a/templates/event_page.html
+++ b/templates/event_page.html
@@ -9,9 +9,7 @@
   <time class="event-date">{{ page.date }}</time>
   {% include "events/location.html" %}
 </span>
-<h1>
-{{ page.title }}
-</h1>
+<h1>{{ page.title }}</h1>
 
 {{ page.content | safe }}
 

--- a/templates/shared/auto_lightbox_dialog.html
+++ b/templates/shared/auto_lightbox_dialog.html
@@ -20,7 +20,7 @@
 {% include "shared/lightbox.html" %}
 {% if gallery_items %}
   <h2 id="gallery">Gallery</h2>
-    <ul class="gallery">
+    <ul class="gallery main-gallery" {% if page.extra.collapse_gallery %} data-allow-collapse="allow" {% endif %}>
       {% for key, item in gallery_items %}
         {% set path = item.path -%}
         {% set caption = item | get(key="caption", default="") -%}

--- a/templates/shared/auto_lightbox_dialog.html
+++ b/templates/shared/auto_lightbox_dialog.html
@@ -19,8 +19,15 @@
 {% endif %}
 {% include "shared/lightbox.html" %}
 {% if gallery_items %}
+  {% set collapse = page.extra | get(key='collapse_gallery', default='auto') %}
   <h2 id="gallery">Gallery</h2>
-    <ul class="gallery main-gallery" {% if page.extra.collapse_gallery %} data-allow-collapse="allow" {% endif %}>
+    <ul class="gallery main-gallery"
+        {% if collapse == 'auto' %}
+          data-allow-collapse="auto"
+        {% elif collapse == true %}
+          data-allow-collapse="always"
+        {% endif %}
+    >
       {% for key, item in gallery_items %}
         {% set path = item.path -%}
         {% set caption = item | get(key="caption", default="") -%}
@@ -40,4 +47,12 @@
     </ul>
   </details>
 {% endif %}
+<script id="pluralization-rules" type="text/json">
+{
+    "photos hidden": {
+      "one": "1 photo hidden",
+      "other": "$n photos hidden"
+    }
+}
+</script>
 <script type="module" src="/gallery.js"></script>

--- a/templates/shared/auto_lightbox_dialog.html
+++ b/templates/shared/auto_lightbox_dialog.html
@@ -23,9 +23,9 @@
   <h2 id="gallery">Gallery</h2>
     <ul class="gallery main-gallery"
         {% if collapse == 'auto' %}
-          data-allow-collapse="auto"
+          data-collapse-gallery="auto"
         {% elif collapse == true %}
-          data-allow-collapse="always"
+          data-collapse-gallery="collapse"
         {% endif %}
     >
       {% for key, item in gallery_items %}


### PR DESCRIPTION
This is the gallery idea from #1210. Test it on Legacy's first event, which has 59 photos.

Also, because of how the gallery works, the fact that some thumbnails are now hidden doesn't stop the lightbox from navigating to them. I think this is a happy accident, and prefer to keep it that way.