### PR TITLE
Improve notation in card

### DIFF
--- a/content/e/ppw/2024-11-15-ppw-piwo-przyjacielem-wrestlingu-2.md
+++ b/content/e/ppw/2024-11-15-ppw-piwo-przyjacielem-wrestlingu-2.md
@@ -24,11 +24,10 @@ The only exceptions were Isnorr's title defense against Prince Striker, and Aron
 - - '[Aron Wake](@/w/aron-wake.md)'
   - '[Sambor](@/w/sambor.md)'
   - s: Singles Match
-- - 'Rodzina Kimono: [Brat Kimono](@/w/goblin.md), [Steven Kimono](@/w/biesiad.md); Siostra Kimono'
-  - 'Tourists: Alvaro, [Ignacio](@/w/sedzia-kornel.md); [Tomisław Apoloniusz Curuś-Bachleda Farrell](@/w/joker.md)'
-  # Alvaro is Rookie Karol, Siostra Kimono = Martyna.
+- - 'Rodzina Kimono: [Brat Kimono](@/w/goblin.md), [Steven Kimono](@/w/biesiad.md) w/ Siostra Kimono'
+  - 'Tourists: Alvaro, [Ignacio](@/w/sedzia-kornel.md) w/ [Tomisław Apoloniusz Curuś-Bachleda Farrell](@/w/joker.md)'
   - s: Tag Team Match
-- - 'Bracia Kimono: [Brat Kimono](@/w/goblin.md), [Steven Kimono](@/w/biesiad.md); Siostra Kimono'
+- - 'Bracia Kimono: [Brat Kimono](@/w/goblin.md), [Steven Kimono](@/w/biesiad.md) w/ Siostra Kimono'
   - 'The Feagers: [Bill Feager](@/w/feager.md), Phil Feager'
   - s: Tag Team Match
 - - '[Isnorr](@/w/isnorr.md)(c)'
@@ -72,7 +71,7 @@ The only exceptions were Isnorr's title defense against Prince Striker, and Aron
   - '[Sambor](@/w/sambor.md)'
   - s: Singles Match
 - - 'Istotna Martynka'
-  - '[Marco Hammers](@/w/marco-hammers.md)(c); [Olgierd](@/w/olgierd.md), Darko Hammers'
+  - '[Marco Hammers](@/w/marco-hammers.md)(c) w/ [Olgierd](@/w/olgierd.md) & Darko Hammers'
   - s: Singles Match
     c: '[PTW Intergender Championship](@/c/ptw-intergender-championship.md)'
 - - '[Aron Wake](@/w/aron-wake.md)'
@@ -91,7 +90,7 @@ The only exceptions were Isnorr's title defense against Prince Striker, and Aron
 - - '[Biesiad Strong](@/w/biesiad.md)'
   - '[Scarecrow](@/w/mister-z.md)'
   - s: ECW Rules Match
-- - '[Marco Hammers](@/w/marco-hammers.md); [Olgierd](@/w/olgierd.md); Darko Hammers'
+- - '[Marco Hammers](@/w/marco-hammers.md) w/ [Olgierd](@/w/olgierd.md) & Darko Hammers'
   - 'Istotna Martynka(c)'
   - s: Singles Match
     c: '[PTW Intergender Championship](@/c/ptw-intergender-championship.md)'

--- a/content/e/ppw/2024-12-06-ppw-hardcore-friday-barszcz-z-krzeslami.md
+++ b/content/e/ppw/2024-12-06-ppw-hardcore-friday-barszcz-z-krzeslami.md
@@ -24,7 +24,7 @@ The show was quickly sold out, so the attendance can be approximated at about 22
 - - '[Gabriel Queen](@/w/gabriel-queen.md)'
   - '[Olgierd](@/w/olgierd.md)'
   - '[Goblin](@/w/goblin.md)'
-  - '[Oskar Aleksander](@/w/oskar-aleksander.md); Agent Agata'
+  - '[Oskar Aleksander](@/w/oskar-aleksander.md) w/ Agent Agata'
   - s: Four-way Match
 - - '[Santa Biesiad](@/w/biesiad.md)'
   - '[Gabriel Queen](@/w/gabriel-queen.md)'

--- a/content/e/ppw/2025-01-25-ppw-gruba-przesada.md
+++ b/content/e/ppw/2025-01-25-ppw-gruba-przesada.md
@@ -57,13 +57,13 @@ The event saw three Hungarian wrestlers debut for PpW: masked luchadors Sentinel
   - '[Bill Feager](@/w/feager.md)'
   - s: Gauntlet Survivor Challenge
 - - '[Vic Golden](@/w/vic-golden.md)'
-  - '[Oskar Aleksander](@/w/oskar-aleksander.md); Agentka Agatka'
+  - '[Oskar Aleksander](@/w/oskar-aleksander.md) w/ Agentka Agatka'
 - - '[Mister Z](@/w/mister-z.md)'
   - '[Axel Fox](@/w/axel-fox.md)'
   - '[Marco Hammers](@/w/marco-hammers.md)'
   - '[Olgierd](@/w/olgierd.md)'
   - g: 'Z coaxes Fox to join [Zmowa](@/a/the-collusion.md); Fox chooses his closest friends instead.'
-- - '[Axel Fox](@/w/axel-fox.md), [Biesiad Strong](@/w/biesiad.md), [Johnny Blade](@/w/johnny-blade.md); [Goblin](@/w/goblin.md)'
+- - '[Axel Fox](@/w/axel-fox.md), [Biesiad Strong](@/w/biesiad.md), [Johnny Blade](@/w/johnny-blade.md) w/ [Goblin](@/w/goblin.md)'
   - 'Zmowa: [Mister Z](@/w/mister-z.md), [Marco Hammers](@/w/marco-hammers.md), [Olgierd](@/w/olgierd.md)'
   - s: Six-Man Tornado Tag Team match
 - - '[Isnorr](@/w/isnorr.md)(c)'
@@ -72,7 +72,7 @@ The event saw three Hungarian wrestlers debut for PpW: masked luchadors Sentinel
     c: '[PpW European Ultraviolent Championship](@/c/ppw-european-ultraviolent-championship.md)'
     n: 'Stipulation selected by fans on social media'
 - - '[Gustav Gryffin](@/w/gustav-gryffin.md)(c)'
-  - '[Gabriel Queen](@/w/gabriel-queen.md); [Vic Golden](@/w/vic-golden.md)'
+  - '[Gabriel Queen](@/w/gabriel-queen.md) w/ [Vic Golden](@/w/vic-golden.md)'
   - c: '[PpW Championship](@/c/ppw-championship.md)'
     r: Time-Out
     n: 15 minute time limit

--- a/content/e/ppw/2025-02-21-ppw-hardcore-friday.md
+++ b/content/e/ppw/2025-02-21-ppw-hardcore-friday.md
@@ -52,7 +52,7 @@ Hardcore Friday 21.000 was a show by [PpW Ewenement](@/o/ppw.md), held on Friday
 - - '[Gabriel Queen](@/w/gabriel-queen.md)'
   - '[Gustav Gryffin](@/w/gustav-gryffin.md)'
   - g: Gabriel demands a rematch
-- - '[Olgierd](@/w/olgierd.md); [Marco Hammers](@/w/marco-hammers.md)'
+- - '[Olgierd](@/w/olgierd.md) w/ [Marco Hammers](@/w/marco-hammers.md)'
   - >
     [Sędzia Seweryn](@/w/sedzia-seweryn.md),
     [Sędzia Kornel](@/w/sedzia-kornel.md),

--- a/doc/CARD.md
+++ b/doc/CARD.md
@@ -43,7 +43,7 @@ The recommended style is to use block-style for the matches list, but inline-sty
 - ["Bob Backlund", "Randy Savage"]
 ```
 
-However, nested block-style is also legal, and may be useful for multi-man matches like rumbles.
+However, nested block-style is most readable, and the recommended way to note all matches
 
 ```yaml
 # The following is a single match with four participants
@@ -77,6 +77,31 @@ But when it's an ad-hoc team, it's fine to use commas:
 
 ```
 "Hikaru Shida, Skye Blue, Willow Nightingale"
+```
+
+## Roles in the match
+
+Except for segments, each side has at least one fighter in the match. Often, additional people should not be counted as fighters, but rather as valets or managers. To denote a manager, use a semicolon `;` or `w/` before their name. For example, here's  two equivalent ways to note a team of two plus a manager.
+
+```
+Cash Wheeler, Dax Harwood; Tully Blanchard
+Cash Wheeler, Dax Harwood w/ Tully Blanchard
+```
+
+When multiple people have the same role, ampersands (`&`) can be used instead of repeating the other symbols. A person that is listed **after** an ampersand will have the **same role** as the person listed **before**. For example:
+
+All three fighters:
+
+```
+Matt Hardy, Jeff Hardy, Johnny Hardy
+Matt Hardy, Jeff Hardy & Johnny Hardy
+Matt Hardy & Jeff Hardy & Johnny Hardy
+```
+
+Multiple managers:
+
+```
+Galeno Del Mal w/ Hijo del Dr. Wagner & Silver King
 ```
 
 ## Championships

--- a/src/test/card_test.py
+++ b/src/test/card_test.py
@@ -1,0 +1,48 @@
+
+from card import parse_group, Fighter, Manager
+
+def test_commas():
+    result = parse_group('Biesiad, Goblin, Axel Fox')
+    assert len(result) == 3
+    assert all(isinstance(p, Fighter) for p in result)
+
+def test_with_and_semi_are_equivalent():
+    result1 = parse_group('Biesiad, Goblin; Axel Fox')
+    result2 = parse_group('Biesiad, Goblin w/ Axel Fox')
+    assert result2 == result1
+    biesiad, goblin, fox = result1
+    assert isinstance(biesiad, Fighter)
+    assert isinstance(goblin, Fighter)
+    assert isinstance(fox, Manager)
+
+def test_ampersand_manager():
+    result1 = parse_group('Biesiad w/ Goblin & Axel Fox')
+    biesiad, goblin, fox = result1
+    assert isinstance(biesiad, Fighter)
+    assert isinstance(goblin, Manager)
+    assert isinstance(fox, Manager)
+
+def test_ampersand_fighter():
+    result1 = parse_group('Biesiad & Goblin w/ Axel Fox')
+    biesiad, goblin, fox = result1
+    assert isinstance(biesiad, Fighter)
+    assert isinstance(goblin, Fighter)
+    assert isinstance(fox, Manager)
+
+def test_ampersand_madness():
+    result1 = parse_group('Biesiad, Sambor & Goblin w/ Axel Fox & Johnny Blade')
+    biesiad, sambor, goblin, fox, johnny = result1
+    assert isinstance(biesiad, Fighter)
+    assert isinstance(sambor, Fighter)
+    assert isinstance(goblin, Fighter)
+    assert isinstance(fox, Manager)
+    assert isinstance(johnny, Manager)
+
+def test_with_and_linked_names():
+    result1 = parse_group('[Biesiad](@/w/biesiad.md) w/ [Goblin](@/w/goblin.md) & [Axel Fox](@/w/axel-fox.md)')
+    biesiad, goblin, fox = result1
+    print(biesiad)
+    assert isinstance(biesiad, Fighter) and biesiad.link == '@/w/biesiad.md'
+    assert isinstance(goblin, Manager) and goblin.link == '@/w/goblin.md'
+    assert isinstance(fox, Manager) and fox.link == '@/w/axel-fox.md'
+

--- a/templates/card/free_result_row.html
+++ b/templates/card/free_result_row.html
@@ -36,10 +36,10 @@
           {% if bodies == 0 %}
             Winner:
           {% endif %}
-          {{ winner | markdown(inline=true) | safe }}
+          {{ winner | replace(from=";", to=" w/") | markdown(inline=true) | safe }}
           {% if bodies > 0 %}
               {{ sep | safe }}
-              {{ others | join(sep=" and ") | markdown(inline=true) | safe }}
+              {{ others | join(sep=" and ") | replace(from=";", to=" w/") | markdown(inline=true) | safe }}
           {% endif %}
           {% if result %}
               via {{ final.r }}

--- a/templates/card/match_row.html
+++ b/templates/card/match_row.html
@@ -21,7 +21,7 @@
       {% if segment %}
         <strong>Segment:</strong> {{ talent | join(sep=", ") | markdown(inline=true) | safe }}
       {% else %}
-        {{ talent | join(sep=sep) | markdown(inline=true) | safe }}
+        {{ talent | join(sep=sep) | replace(from=";", to=" w/") | markdown(inline=true) | safe }}
       {% endif %}
     </span>
     <span class="c">

--- a/templates/card/result_row.html
+++ b/templates/card/result_row.html
@@ -32,10 +32,10 @@
           {% if bodies == 0 %}
             Winner:
           {% endif %}
-          {{ winner | markdown(inline=true) | safe }}
+          {{ winner | replace(from=";", to=" w/") | markdown(inline=true) | safe }}
           {% if bodies > 0 %}
               {{ sep | safe }}
-              {{ others | join(sep=" and ") | markdown(inline=true) | safe }}
+              {{ others | join(sep=" and ") | replace(from=";", to=" w/") | markdown(inline=true) | safe }}
           {% endif %}
           {% if result %}
               via {{ final.r }}

--- a/templates/career/result_row.html
+++ b/templates/career/result_row.html
@@ -29,23 +29,22 @@
 {% else %}
   {% if bodies == 0 and not final.nc %} Winner: {% endif %}
   {% if 0 in positions %}
-    <strong>{{ winner | markdown(inline=true) | safe }}</strong>
+    <strong>{{ winner | replace(from=";", to=" w/") | markdown(inline=true) | safe }}</strong>
   {% else %}
-    {{ winner | markdown(inline=true) | safe }}
+    {{ winner | replace(from=";", to=" w/") | markdown(inline=true) | safe }}
   {% endif %}
   {% if bodies > 0 %}
     {{ sep }}
     {% for opponent in others %}
       {% if loop.index in positions %}
-        <strong>{{ opponent | markdown(inline=true) | safe }}</strong>
+        <strong>{{ opponent | replace(from=";", to=" w/") | markdown(inline=true) | safe }}</strong>
       {% else %}
-        {{ opponent | markdown(inline=true) | safe }}
+        {{ opponent | replace(from=";", to=" w/") | markdown(inline=true) | safe }}
       {% endif %}
       {% if not loop.last %}
         and
       {% endif %}
     {% endfor %}
-    {# {{ others | join(sep=" and ") | markdown(inline=true) | safe }} #}
   {% endif %}
   {% if final.r %}
       via {{ final.r }}


### PR DESCRIPTION
Instead of the semicolon to note a valet or manager, `w/` is now a valid notation to do the same. Additionally, ampersand `&` is also supported as a delimiter, and causes the next person to be given the same role as the previous one. See examples in `doc/CARD.md` for explanation.

To test this out, a couple of recent PPW events were updated to the new notation. Older events that were not updated, will now replace all instances of semicolons **visually** with `w/` as well.