### PR TITLE
Artwall: build the photo index JSON also from all other page types.

### DIFF
--- a/content/a/ptw-exits-gallery.toml
+++ b/content/a/ptw-exits-gallery.toml
@@ -1,22 +1,114 @@
-01 = { path = "rafi-exit-insta.jpg", caption = "Screenshot of [Rafi](@/w/rafi.md)'s goodbye post. His instagram profile is currently (June 2024) set to private.", source = "Instagram @rafirarytaswrestling"}
-02 = { path = "sambor-insta-thanks.jpg", caption = '[Sambor](@/w/sambor.md) thanking the fans, organization and Pawłowski for support. The text states that his time in wrestling is not over, and his story will be told in many taverns.'}
-03 = { path = "boro-au-revoir.png", caption = "Au revoir, from Boro's Last Dance Instagram Story'", source = "Instagram @borogng"}
-04 = { path = "dziedzic-goodbye.jpg", caption = "[Dziedzic](@/w/dziedzic.md)'s farewell post on Instagram.'", source = "Instagram @dziedzicwrestling"}
-05 = { path = "sinister-farewell-insta.jpg", caption = "[Sinister](@/w/sinister.md) thanking everyone in his farewell post.", source = "Instagram @sinister_wrestler"}
-06 = { path = "ptw_dismissal.jpg", caption = "PTW firing Jacob Crane in August 2022."}
-07 = { path = "owczy-ped.jpg", caption = "[Puncher's](@/w/puncher.md) comic titled 'Herd Instinct', comparing the talent quitting PTW to sheep heading into a pig's anus (referring to [PpW](@/o/ppw.md))", source = "Facebook @PTWpuncher"}
-08 = { path = "leak-puncher-fox.png", caption = "[Puncher](@/w/puncher.md) leaking info about Axel Fox's possible exit in a discussion thread on the House Of Wrestling Facebook group.", source = "Facebook HouseOfWrestling"}
-09 = { path = "paterek-tweet.jpg", caption = "Arek Paterek's tweet signing out of the commentary desk.", source = "Twitter @APaterek" }
-10 = { path = "paterek-o-baliku.png", caption = "Paterek mentioning that Balik also quit PTW.", source = "Twitter @APaterek" }
-11 = { path = "paterek-o-pawlowskim.png", caption = "Paterek criticizing Pawłowski for not responding to his farewell message, among other things.", source = "Twitter @APaterek" }
-12 = { path = "dziedzic-goodbye.jpg", caption = "[Dziedzic](@/w/dziedzic.md)'s farewell post on Instagram.'", source = "Instagram @dziedzicwrestling"}
-13 = { path = "sinister-farewell-insta.jpg", caption = "[Sinister](@/w/sinister.md) thanking everyone in his farewell post.", source = "Instagram @sinister_wrestler"}
-14 = { path = "sinister-farewell-text.png", caption = "Full text from Sinister's farewell post.", source = "Instagram @sinister_wrestling" }
-15 = { path = "sewi-exit.jpg", caption = "[Ref Seweryn](@/w/sedzia-seweryn.md)'s farewell story on Instagram.", source = "Instagram @sewi_the_ref"}
-16 = { path = "boro-ptw-last-dance-1.jpg", caption = "[Boro](@/w/boro.md) at a PTW event, from his Last Dance Instagram Story", source = "Instagram @borogng"}
-17 = { path = "boro-ptw-last-dance-2.jpg", caption = "MZW wrestlers [Queen](@/w/gabriel-queen.md), [Crane](@/w/jacob-crane.md), [Fox](@/w/axel-fox.md), [Isnorr](@/w/isnorr.md), [Madman Charlie](@/w/madman-charlie.md), [Rafael Kid](@/w/rafael-kid.md), [Aron Wake](@/w/aron-wake.md) (as Pikachu), [Olgierd](@/w/olgierd.md) and others, from Boro's Last Dance Instagram story. Bottom text says 'The message is clear'.", source = "Instagram @borogng"}
-18 = { path = "boro-ptw-last-dance-3.jpg", caption = "[Boro](@/w/boro.md), [Taras](@/w/taras.md) and [Disco Pablo](@/w/disco-pablo.md) from Boro's Last Dance Instagram Story", source = "Instagram @borogng"}
-19 = { path = "boro-ptw-last-dance-4.jpg", caption = "MZW wrestlers holding a Dave Batista poster and a banner. The first visible word on the banner is [Zieloni](@/a/the-greens.md) (_The Greens_), from Boro's Last Dance Instagram Story", source = "Instagram @borogng"}
-20 = { path = "boro-au-revoir.png", caption = "Au revoir, from Boro's Last Dance Instagram Story'", source = "Instagram @borogng"}
-21 = { path = "mutant-stare-smieci.jpg", caption = 'Instagram story by Michał "Mutant" Świątkowski, polling the followers where should he continue training wrestling.', source = "Instagram @mutant_wrestler"}
-22 = { path = "mutant-hammers.jpg", caption = 'Michał "Mutant" Świątkowski taking a selfie with [Marco Hammers](@/w/marco-hammers.md) backstage at [Ledwo Legalne IV](@/e/ppw/2024-06-08-ppw-ledwo-legalne-4.md)', source = "Instagram @mutant_wrestler"}
+[01]
+path = "rafi-exit-insta.jpg"
+caption = "Screenshot of [Rafi](@/w/rafi.md)'s goodbye post. His instagram profile is currently (June 2024) set to private."
+source = "Instagram @rafirarytaswrestling"
+skip_art = true
+
+[02]
+path = "sambor-insta-thanks.jpg"
+caption = "[Sambor](@/w/sambor.md) thanking the fans, organization and Pawłowski for support. The text states that his time in wrestling is not over, and his story will be told in many taverns."
+
+[03]
+path = "boro-au-revoir.png"
+caption = "Au revoir, from Boro's Last Dance Instagram Story'"
+source = "Instagram @borogng"
+skip_art = true
+
+[04]
+path = "dziedzic-goodbye.jpg"
+caption = "[Dziedzic](@/w/dziedzic.md)'s farewell post on Instagram.'"
+source = "Instagram @dziedzicwrestling"
+
+[05]
+path = "sinister-farewell-insta.jpg"
+caption = "[Sinister](@/w/sinister.md) thanking everyone in his farewell post."
+source = "Instagram @sinister_wrestler"
+
+[06]
+path = "ptw_dismissal.jpg"
+caption = "PTW firing Jacob Crane in August 2022."
+
+[07]
+path = "owczy-ped.jpg"
+caption = "[Puncher's](@/w/puncher.md) comic titled 'Herd Instinct', comparing the talent quitting PTW to sheep heading into a pig's anus (referring to [PpW](@/o/ppw.md))"
+source = "Facebook @PTWpuncher"
+
+[08]
+path = "leak-puncher-fox.png"
+caption = "[Puncher](@/w/puncher.md) leaking info about Axel Fox's possible exit in a discussion thread on the House Of Wrestling Facebook group."
+source = "Facebook HouseOfWrestling"
+skip_art = true
+
+[09]
+path = "paterek-tweet.jpg"
+caption = "Arek Paterek's tweet signing out of the commentary desk."
+source = "Twitter @APaterek"
+
+[10]
+path = "paterek-o-baliku.png"
+caption = "Paterek mentioning that Balik also quit PTW."
+source = "Twitter @APaterek"
+skip_art = true
+
+[11]
+path = "paterek-o-pawlowskim.png"
+caption = "Paterek criticizing Pawłowski for not responding to his farewell message, among other things."
+source = "Twitter @APaterek"
+skip_art = true
+
+[12]
+path = "dziedzic-goodbye.jpg"
+caption = "[Dziedzic](@/w/dziedzic.md)'s farewell post on Instagram.'"
+source = "Instagram @dziedzicwrestling"
+
+[13]
+path = "sinister-farewell-insta.jpg"
+caption = "[Sinister](@/w/sinister.md) thanking everyone in his farewell post."
+source = "Instagram @sinister_wrestler"
+
+[14]
+path = "sinister-farewell-text.png"
+caption = "Full text from Sinister's farewell post."
+source = "Instagram @sinister_wrestling"
+skip_art = true
+
+[15]
+path = "sewi-exit.jpg"
+caption = "[Ref Seweryn](@/w/sedzia-seweryn.md)'s farewell story on Instagram."
+source = "Instagram @sewi_the_ref"
+
+[16]
+path = "boro-ptw-last-dance-1.jpg"
+caption = "[Boro](@/w/boro.md) at a PTW event, from his Last Dance Instagram Story"
+source = "Instagram @borogng"
+
+[17]
+path = "boro-ptw-last-dance-2.jpg"
+caption = """\
+MZW wrestlers [Queen](@/w/gabriel-queen.md), [Crane](@/w/jacob-crane.md), [Fox](@/w/axel-fox.md),
+[Isnorr](@/w/isnorr.md), [Madman Charlie](@/w/madman-charlie.md), [Rafael Kid](@/w/rafael-kid.md),
+[Aron Wake](@/w/aron-wake.md) (as Pikachu), [Olgierd](@/w/olgierd.md) and others,
+from Boro's Last Dance Instagram story. Bottom text says 'The message is clear'.
+"""
+source = "Instagram @borogng"
+
+[18]
+path = "boro-ptw-last-dance-3.jpg"
+caption = "[Boro](@/w/boro.md), [Taras](@/w/taras.md) and [Disco Pablo](@/w/disco-pablo.md) from Boro's Last Dance Instagram Story"
+source = "Instagram @borogng"
+
+[19]
+path = "boro-ptw-last-dance-4.jpg"
+caption = "MZW wrestlers holding a Dave Batista poster and a banner. The first visible word on the banner is [Zieloni](@/a/the-greens.md) (_The Greens_), from Boro's Last Dance Instagram Story"
+source = "Instagram @borogng"
+
+[20]
+path = "mutant-stare-smieci.jpg"
+caption = 'Instagram story by Michał "Mutant" Świątkowski, polling the followers where should he continue training wrestling.'
+source = "Instagram @mutant_wrestler"
+skip_art = true
+
+[21]
+path = "mutant-hammers.jpg"
+caption = 'Michał "Mutant" Świątkowski taking a selfie with [Marco Hammers](@/w/marco-hammers.md) backstage at [Ledwo Legalne IV](@/e/ppw/2024-06-08-ppw-ledwo-legalne-4.md)'
+source = "Instagram @mutant_wrestler"

--- a/content/a/tv.md
+++ b/content/a/tv.md
@@ -7,14 +7,17 @@ authors = ["Krzysztof Zych"]
 path = "teletydzien-19990118-tnt.webp"
 caption = "TV listing for TNT on Friday Jan 22, 1999, poorly cropped. The wrestler shown is Big Van Vader."
 source = "archive.org [tele-tydzien-nr-5-18.01.1999-skan_20220929](https://archive.org/details/tele-tydzien-nr-4-18.01.1999-skan_20220929), page 17/63"
+skip_art = true
 [extra.gallery.2]
 path = "teletydzien-19990118-dsf.webp"
 caption = "TV listing for DSF on Saturday, Jan 23, 1999."
 source = "archive.org [tele-tydzien-nr-5-18.01.1999-skan_20220929](https://archive.org/details/tele-tydzien-nr-4-18.01.1999-skan_20220929), page 23/63"
+skip_art = true
 [extra.gallery.3]
 path = "supertv-19940114-dsf.webp"
 caption = "TV listing for DSF on Friday, Jan 14 1994."
 source = "archive.org [super-tv-3-94](https://archive.org/details/super-tv-3-94)"
+skip_art = true
 +++
 
 Polish wrestling has only very recently gained any media attention and coverage. It has never been very popular

--- a/content/e/tbw/2010-02-27-tbw-1-gallery.toml
+++ b/content/e/tbw/2010-02-27-tbw-1-gallery.toml
@@ -1,41 +1,244 @@
-01 = { path = "2010-02-27-tbw-1-plakat.jpg", caption = "Official poster, with Starbuck in the bottom-right corner.", source = "MyWrestling.com.pl" }
-02 = { path = "DSC_4585_1.JPG", caption = "Andrzej Supron opening the show", source = "wrestling.nazwa.pl" }
-03 = { path = "DSC_4597_1.JPG", caption = "Show hosts", source = "wrestling.nazwa.pl" }
-04 = { path = "DSC_4601_1.JPG", caption = "Chris Colen waving a Polish flag", source = "wrestling.nazwa.pl" }
-05 = { path = "DSC_4614_1.JPG", caption = "Chris Colen lifting Damon Brix", source = "wrestling.nazwa.pl" }
-06 = { path = "DSC_4636_1.JPG", caption = "Chris Colen and Damon Brix in the corner", source = "wrestling.nazwa.pl" }
-07 = { path = "DSC06404.JPG", caption = "Chris Colen jumping on Damon Brix", source = "wrestling.nazwa.pl" }
-08 = { path = "DSC_4656_1.JPG", caption = "Heimo Ukonselkä", source = "wrestling.nazwa.pl" }
-09 = { path = "DSC_4680_1.JPG", caption = "Erik Isaksen (white trunks) dropping Heimo Ukonselkä", source = "wrestling.nazwa.pl" }
-10 = { path = "DSC06429.JPG", caption = "Erik Isaksen (white trunks) throwing Heimo Ukonselkä", source = "wrestling.nazwa.pl" }
-11 = { path = "IMG_6385_1.JPG", caption = "Ivan Kiev (black and white pants) vs Bjørn Sem", source = "wrestling.nazwa.pl" }
-12 = { path = "DSC_4707_1.JPG", caption = "Ivan Kiev vs Bjørn Sem", source = "wrestling.nazwa.pl" }
-13 = { path = "DSC_4731_1.JPG", caption = "Polish Black Metal band Enthymion for August's entrance", source = "wrestling.nazwa.pl" }
-14 = { path = "DSC_4766_1.JPG", caption = "Enthymion's bassist and guitarist", source = "wrestling.nazwa.pl" }
-15 = { path = "DSC_4732_1.JPG", caption = "August (robe, white mask) confronting Bjørn Sem in the ring", source = "wrestling.nazwa.pl" }
-16 = { path = "DSC06465.JPG", caption = "August vs Bjørn Sem, Ivan Kiev in the other corner", source = "wrestling.nazwa.pl" }
-17 = { path = "DSC_4751_1.JPG", caption = "Kamil Bazelak attacking August", source = "wrestling.nazwa.pl" }
-18 = { path = "DSC_4788_1.JPG", caption = "Cybernic Machine", source = "wrestling.nazwa.pl" }
-19 = { path = "DSC_4793_1.JPG", caption = "Cybernic Machine, with Crazy Sexy Mike behind", source = "wrestling.nazwa.pl" }
-20 = { path = "DSC_4802_1.JPG", caption = "Cybernic Machine, Crazy Sexy Mike", source = "wrestling.nazwa.pl" }
-21 = { path = "DSC06495.JPG", caption = "Cybernic Machine's entrance", source = "wrestling.nazwa.pl" }
-22 = { path = "DSC06513.JPG", caption = "Cybernic Machine landing on Crazy Sexy Mike", source = "wrestling.nazwa.pl" }
-23 = { path = "DSC_4804_1.JPG", caption = "Cybernic Machine vs Ahmed Chaer tangled between the ropes", source = "wrestling.nazwa.pl" }
-24 = { path = "DSC_4818_1.JPG", caption = "Cybernic Machine with a double bodyslam to Ahmed Chaer and Crazy Sexy Mike", source = "wrestling.nazwa.pl" }
-25 = { path = "DSC_4841_1.JPG", caption = "Starbuck, wearing Canadian colors", source = "wrestling.nazwa.pl" }
-26 = { path = "DSC_4844_1.JPG", caption = "Starbuck dragging [Michael Kovac](@/w/michael-kovac.md) by the hair", source = "wrestling.nazwa.pl" }
-27 = { path = "DSC_4858_1.JPG", caption = "Starbuck vs [Kovac](@/w/michael-kovac.md)", source = "wrestling.nazwa.pl" }
-28 = { path = "DSC_4860_1.JPG", caption = "Starbuck vs [Kovac](@/w/michael-kovac.md)", source = "wrestling.nazwa.pl" }
-29 = { path = "DSC_4902_1.JPG", caption = "Starbuck's entrance", source = "wrestling.nazwa.pl" }
-30 = { path = "DSC_4907_1.JPG", caption = "Bernard Vandamme, with the Eurostars European Wrestling Championship", source = "wrestling.nazwa.pl" }
-31 = { path = "DSC_4916_1.JPG", caption = "[Borkowski](@/w/pawel-borkowski.md) and Supron in the commentary booth, with the Eurostars belt", source = "wrestling.nazwa.pl" }
-32 = { path = "DSC_4919_1.JPG", caption = "Vandamme vs Colossos", source = "wrestling.nazwa.pl" }
-33 = { path = "DSC_4963_1.JPG", caption = "Bernard Vandamme striking a victorious phose after defending the championship", source = "wrestling.nazwa.pl" }
-34 = { path = "DSC_5021_1.JPG", caption = "Rumble match: Crazy Sexy Mike, Damon Brix, [Michael Kovac](@/w/michael-kovac.md), Ahmed Chaer kneeling over Ivan Kiev", source = "wrestling.nazwa.pl" }
-35 = { path = "DSC_5035_1.JPG", caption = "Rumble Match: Starbuck trying to eliminate [Michael Kovac](@/w/michael-kovac.md)", source = "wrestling.nazwa.pl" }
-36 = { path = "DSC_5060_1.JPG", caption = "Rumble match: Colossos and Chris Colen trying to eliminate Cybernic Machine", source = "wrestling.nazwa.pl" }
-37 = { path = "DSC_5065_1.JPG", caption = "Rumble match: Cybernic Machine eliminating Bjørn Sem", source = "wrestling.nazwa.pl" }
-38 = { path = "DSC_5077_1.JPG", caption = "Rumble match: Starbuck with a top rope elbow to Cybernic Machine", source = "wrestling.nazwa.pl" }
-39 = { path = "DSC06593.JPG", caption = "Rumble Match action", source = "wrestling.nazwa.pl" }
-40 = { path = "DSC_5105_1.JPG", caption = "Afterparty: members of Enthymion vs Bernard Vandamme", source = "wrestling.nazwa.pl" }
-41 = { path = "DSC_4516_1.JPG", caption = "[Paweł Borkowski](@/w/pawel-borkowski.md) after the show", source = "wrestling.nazwa.pl" }
+[01]
+path = "2010-02-27-tbw-1-plakat.jpg"
+caption = "Official poster, with Starbuck in the bottom-right corner."
+source = "MyWrestling.com.pl"
+
+[02]
+path = "DSC_4585_1.JPG"
+caption = "Andrzej Supron opening the show"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[03]
+path = "DSC_4597_1.JPG"
+caption = "Show hosts"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[04]
+path = "DSC_4601_1.JPG"
+caption = "Chris Colen waving a Polish flag"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[05]
+path = "DSC_4614_1.JPG"
+caption = "Chris Colen lifting Damon Brix"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[06]
+path = "DSC_4636_1.JPG"
+caption = "Chris Colen and Damon Brix in the corner"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[07]
+path = "DSC06404.JPG"
+caption = "Chris Colen jumping on Damon Brix"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[08]
+path = "DSC_4656_1.JPG"
+caption = "Heimo Ukonselkä"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[09]
+path = "DSC_4680_1.JPG"
+caption = "Erik Isaksen (white trunks) dropping Heimo Ukonselkä"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[10]
+path = "DSC06429.JPG"
+caption = "Erik Isaksen (white trunks) throwing Heimo Ukonselkä"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[11]
+path = "IMG_6385_1.JPG"
+caption = "Ivan Kiev (black and white pants) vs Bjørn Sem"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[12]
+path = "DSC_4707_1.JPG"
+caption = "Ivan Kiev vs Bjørn Sem"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[13]
+path = "DSC_4731_1.JPG"
+caption = "Polish Black Metal band Enthymion for August's entrance"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[14]
+path = "DSC_4766_1.JPG"
+caption = "Enthymion's bassist and guitarist"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[15]
+path = "DSC_4732_1.JPG"
+caption = "August (robe, white mask) confronting Bjørn Sem in the ring"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[16]
+path = "DSC06465.JPG"
+caption = "August vs Bjørn Sem, Ivan Kiev in the other corner"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[17]
+path = "DSC_4751_1.JPG"
+caption = "Kamil Bazelak attacking August"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[18]
+path = "DSC_4788_1.JPG"
+caption = "Cybernic Machine"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[19]
+path = "DSC_4793_1.JPG"
+caption = "Cybernic Machine, with Crazy Sexy Mike behind"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[20]
+path = "DSC_4802_1.JPG"
+caption = "Cybernic Machine, Crazy Sexy Mike"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[21]
+path = "DSC06495.JPG"
+caption = "Cybernic Machine's entrance"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[22]
+path = "DSC06513.JPG"
+caption = "Cybernic Machine landing on Crazy Sexy Mike"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[23]
+path = "DSC_4804_1.JPG"
+caption = "Cybernic Machine vs Ahmed Chaer tangled between the ropes"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[24]
+path = "DSC_4818_1.JPG"
+caption = "Cybernic Machine with a double bodyslam to Ahmed Chaer and Crazy Sexy Mike"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[25]
+path = "DSC_4841_1.JPG"
+caption = "Starbuck, wearing Canadian colors"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[26]
+path = "DSC_4844_1.JPG"
+caption = "Starbuck dragging [Michael Kovac](@/w/michael-kovac.md) by the hair"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[27]
+path = "DSC_4858_1.JPG"
+caption = "Starbuck vs [Kovac](@/w/michael-kovac.md)"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[28]
+path = "DSC_4860_1.JPG"
+caption = "Starbuck vs [Kovac](@/w/michael-kovac.md)"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[29]
+path = "DSC_4902_1.JPG"
+caption = "Starbuck's entrance"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[30]
+path = "DSC_4907_1.JPG"
+caption = "Bernard Vandamme, with the Eurostars European Wrestling Championship"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[31]
+path = "DSC_4916_1.JPG"
+caption = "[Borkowski](@/w/pawel-borkowski.md) and Supron in the commentary booth, with the Eurostars belt"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[32]
+path = "DSC_4919_1.JPG"
+caption = "Vandamme vs Colossos"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[33]
+path = "DSC_4963_1.JPG"
+caption = "Bernard Vandamme striking a victorious phose after defending the championship"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[34]
+path = "DSC_5021_1.JPG"
+caption = "Rumble match: Crazy Sexy Mike, Damon Brix, [Michael Kovac](@/w/michael-kovac.md), Ahmed Chaer kneeling over Ivan Kiev"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[35]
+path = "DSC_5035_1.JPG"
+caption = "Rumble Match: Starbuck trying to eliminate [Michael Kovac](@/w/michael-kovac.md)"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[36]
+path = "DSC_5060_1.JPG"
+caption = "Rumble match: Colossos and Chris Colen trying to eliminate Cybernic Machine"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[37]
+path = "DSC_5065_1.JPG"
+caption = "Rumble match: Cybernic Machine eliminating Bjørn Sem"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[38]
+path = "DSC_5077_1.JPG"
+caption = "Rumble match: Starbuck with a top rope elbow to Cybernic Machine"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[39]
+path = "DSC06593.JPG"
+caption = "Rumble Match action"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[40]
+path = "DSC_5105_1.JPG"
+caption = "Afterparty: members of Enthymion vs Bernard Vandamme"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[41]
+path = "DSC_4516_1.JPG"
+caption = "[Paweł Borkowski](@/w/pawel-borkowski.md) after the show"
+source = "wrestling.nazwa.pl"
+skip_art = true

--- a/content/e/tbw/2010-06-05-tbw-2-gallery.toml
+++ b/content/e/tbw/2010-06-05-tbw-2-gallery.toml
@@ -1,35 +1,209 @@
-01 = { path = "2010-06-05-tbw-2-plakat.jpg", caption = "Official poster, with Ultimo Chingón in the bottom-right corner.", source = "MyWrestling.com.pl" }
-02 = { path = "IMG_7220_1.jpeg", caption = "Show host Kuba Wątły", source = "wrestling.nazwa.pl" }
-03 = { path = "IMG_7221_1.jpeg", caption = "Show host Agnieszka Borkowska", source = "wrestling.nazwa.pl" }
-04 = { path = "IMG_7223_1.jpeg", caption = 'Owner, organiser and commentator Andrzej "The Professor of Wrestling" Supron', source = "wrestling.nazwa.pl" }
-05 = { path = "IMG_7228_1.jpeg", caption = 'Owner, organiser and commentator [Paweł "Boryss" Borkowski](@/w/pawel-borkowski.md)', source = "wrestling.nazwa.pl" }
-06 = { path = "IMG_7247_1.jpeg", caption = "Mexx (upright)", source = "wrestling.nazwa.pl" }
-07 = { path = "IMG_7252_1.jpeg", caption = "Rambo running into Chris the Bambikiller, with [Michael Kovac](@/w/michael-kovac.md) in the corner", source = "wrestling.nazwa.pl" }
-08 = { path = "IMG_7254_1.jpeg", caption = "[Michael Kovac](@/w/michael-kovac.md) chopping Rambo in the corner", source = "wrestling.nazwa.pl" }
-09 = { path = "IMG_7269_1.jpeg", caption = "Rambo and Mexx with a double suplex to [Kovac](@/w/michael-kovac.md)", source = "wrestling.nazwa.pl" }
-10 = { path = "IMG_7274_1.jpeg", caption = "Chris the Bambikiller landing a splash on Rambo", source = "wrestling.nazwa.pl" }
-11 = { path = "IMG_7279_1.jpeg", caption = "Mexx throwing [Kovac](@/w/michael-kovac.md)", source = "wrestling.nazwa.pl" }
-12 = { path = "IMG_7296_1.jpeg", caption = 'Kamil "Highlander" Bazelak', source = "wrestling.nazwa.pl" }
-13 = { path = "IMG_7353_1.jpeg", caption = "Commentary team: [Borkowski](@/w/pawel-borkowski.md) and Supron", source = "wrestling.nazwa.pl" }
-14 = { path = "IMG_7376_1.jpeg", caption = "Blue Nikita posing in the ring, Damon Brix sitting in the corner", source = "wrestling.nazwa.pl" }
-15 = { path = "IMG_7389_1.jpeg", caption = "Blue Nikita setting up a ladder", source = "wrestling.nazwa.pl" }
-16 = { path = "IMG_7394_1.jpeg", caption = "Blue Nikita with a chair to a laid-out Crazy Sexy Mike", source = "wrestling.nazwa.pl" }
-17 = { path = "IMG_7395_1.jpeg", caption = "Damon Brix (on the floor) attempting to topple Crazy Sexy Mike into a ladder", source = "wrestling.nazwa.pl" }
-18 = { path = "IMG_7444_1.jpeg", caption = "Dance group BellArto", source = "wrestling.nazwa.pl" }
-19 = { path = "IMG_7457_1.jpeg", caption = "Ultimo Chingon's entrance", source = "wrestling.nazwa.pl" }
-20 = { path = "IMG_7464_1.jpeg", caption = "Makoto Morimitsu landing on the ringmat, with Ultimo Chingon behind him", source = "wrestling.nazwa.pl" }
-21 = { path = "IMG_7506_1.jpeg", caption = "Ultimo Chingon doing flips, with Makoto Morimitsu striking a pose", source = "wrestling.nazwa.pl" }
-22 = { path = "IMG_7519_1.jpeg", caption = "Ultimo Chingon offering a handshake to Morimitsu", source = "wrestling.nazwa.pl" }
-23 = { path = "IMG_7535_1.jpeg", caption = "Cybernic Machine's entrance", source = "wrestling.nazwa.pl" }
-24 = { path = "IMG_7548_1.jpeg", caption = "Bernard Vandamme's entrance", source = "wrestling.nazwa.pl" }
-25 = { path = "IMG_7552_1.jpeg", caption = "Eurostars' European Wrestling Championship belt", source = "wrestling.nazwa.pl" }
-26 = { path = "IMG_7554_1.jpeg", caption = "Vandamme vs Cybernic Machine", source = "wrestling.nazwa.pl" }
-27 = { path = "IMG_7561_1.jpeg", caption = "Cybernic Machine trying to throw Vandamme over the ropes", source = "wrestling.nazwa.pl" }
-28 = { path = "IMG_7582_1.jpeg", caption = "Bernard Vandamme and Cybernic Machine in the corner", source = "wrestling.nazwa.pl" }
-29 = { path = "IMG_7598_1.jpeg", caption = "Cybernic Machine dropping from the top rope", source = "wrestling.nazwa.pl" }
-30 = { path = "IMG_7603_1.jpeg", caption = "Bernard Vandamme escaping a splash from Cybernic Machine", source = "wrestling.nazwa.pl" }
-31 = { path = "IMG_7622_1.jpeg", caption = "Vandamme handing over the European Wrestling Championship belt to Cybernic Machine", source = "wrestling.nazwa.pl" }
-32 = { path = "IMG_7625_1.jpeg", caption = "Cybernic Machine with the belt", source = "wrestling.nazwa.pl" }
-33 = { path = "IMG_7650_1.jpeg", caption = "[Michael Kovac](@/w/michael-kovac.md) signing autographs after the event", source = "wrestling.nazwa.pl" }
-34 = { path = "IMG_7667_1.jpeg", caption = "Cybernic Machine showing the Eurostars championship belt ", source = "wrestling.nazwa.pl" }
-35 = { path = "IMG_7677_1.jpeg", caption = "Andrzej Supron surrounded by women at the afterparty", source = "wrestling.nazwa.pl" }
+[01]
+path = "2010-06-05-tbw-2-plakat.jpg"
+caption = "Official poster, with Ultimo Chingón in the bottom-right corner."
+source = "MyWrestling.com.pl"
+skip_art = true
+
+[02]
+path = "IMG_7220_1.jpeg"
+caption = "Show host Kuba Wątły"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[03]
+path = "IMG_7221_1.jpeg"
+caption = "Show host Agnieszka Borkowska"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[04]
+path = "IMG_7223_1.jpeg"
+caption = 'Owner, organiser and commentator Andrzej "The Professor of Wrestling" Supron'
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[05]
+path = "IMG_7228_1.jpeg"
+caption = 'Owner, organiser and commentator [Paweł "Boryss" Borkowski](@/w/pawel-borkowski.md)'
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[06]
+path = "IMG_7247_1.jpeg"
+caption = "Mexx (upright)"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[07]
+path = "IMG_7252_1.jpeg"
+caption = "Rambo running into Chris the Bambikiller, with [Michael Kovac](@/w/michael-kovac.md) in the corner"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[08]
+path = "IMG_7254_1.jpeg"
+caption = "[Michael Kovac](@/w/michael-kovac.md) chopping Rambo in the corner"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[09]
+path = "IMG_7269_1.jpeg"
+caption = "Rambo and Mexx with a double suplex to [Kovac](@/w/michael-kovac.md)"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[10]
+path = "IMG_7274_1.jpeg"
+caption = "Chris the Bambikiller landing a splash on Rambo"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[11]
+path = "IMG_7279_1.jpeg"
+caption = "Mexx throwing [Kovac](@/w/michael-kovac.md)"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[12]
+path = "IMG_7296_1.jpeg"
+caption = 'Kamil "Highlander" Bazelak'
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[13]
+path = "IMG_7353_1.jpeg"
+caption = "Commentary team: [Borkowski](@/w/pawel-borkowski.md) and Supron"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[14]
+path = "IMG_7376_1.jpeg"
+caption = "Blue Nikita posing in the ring, Damon Brix sitting in the corner"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[15]
+path = "IMG_7389_1.jpeg"
+caption = "Blue Nikita setting up a ladder"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[16]
+path = "IMG_7394_1.jpeg"
+caption = "Blue Nikita with a chair to a laid-out Crazy Sexy Mike"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[17]
+path = "IMG_7395_1.jpeg"
+caption = "Damon Brix (on the floor) attempting to topple Crazy Sexy Mike into a ladder"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[18]
+path = "IMG_7444_1.jpeg"
+caption = "Dance group BellArto"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[19]
+path = "IMG_7457_1.jpeg"
+caption = "Ultimo Chingon's entrance"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[20]
+path = "IMG_7464_1.jpeg"
+caption = "Makoto Morimitsu landing on the ringmat, with Ultimo Chingon behind him"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[21]
+path = "IMG_7506_1.jpeg"
+caption = "Ultimo Chingon doing flips, with Makoto Morimitsu striking a pose"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[22]
+path = "IMG_7519_1.jpeg"
+caption = "Ultimo Chingon offering a handshake to Morimitsu"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[23]
+path = "IMG_7535_1.jpeg"
+caption = "Cybernic Machine's entrance"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[24]
+path = "IMG_7548_1.jpeg"
+caption = "Bernard Vandamme's entrance"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[25]
+path = "IMG_7552_1.jpeg"
+caption = "Eurostars' European Wrestling Championship belt"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[26]
+path = "IMG_7554_1.jpeg"
+caption = "Vandamme vs Cybernic Machine"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[27]
+path = "IMG_7561_1.jpeg"
+caption = "Cybernic Machine trying to throw Vandamme over the ropes"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[28]
+path = "IMG_7582_1.jpeg"
+caption = "Bernard Vandamme and Cybernic Machine in the corner"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[29]
+path = "IMG_7598_1.jpeg"
+caption = "Cybernic Machine dropping from the top rope"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[30]
+path = "IMG_7603_1.jpeg"
+caption = "Bernard Vandamme escaping a splash from Cybernic Machine"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[31]
+path = "IMG_7622_1.jpeg"
+caption = "Vandamme handing over the European Wrestling Championship belt to Cybernic Machine"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[32]
+path = "IMG_7625_1.jpeg"
+caption = "Cybernic Machine with the belt"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[33]
+path = "IMG_7650_1.jpeg"
+caption = "[Michael Kovac](@/w/michael-kovac.md) signing autographs after the event"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[34]
+path = "IMG_7667_1.jpeg"
+caption = "Cybernic Machine showing the Eurostars championship belt "
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[35]
+path = "IMG_7677_1.jpeg"
+caption = "Andrzej Supron surrounded by women at the afterparty"
+source = "wrestling.nazwa.pl"
+skip_art = true

--- a/content/o/lsw.md
+++ b/content/o/lsw.md
@@ -7,10 +7,16 @@ template = "org_page.html"
 toclevel = 3
 hide_roster = true
 hide_events = true
-[taxonomies]
-[extra.gallery]
-1 = { path = "diving-elbow-drop.jpg", caption = "More professional than [WWE](@/o/wwe.md). Not.", source = "Official ŁSW YouTube" }
-2 = { path = "tombstone-piledriver.jpg", caption = "Do not try this at home, or at all.", source = "Official ŁSW YouTube" }
+[extra.gallery.1]
+path = "diving-elbow-drop.jpg"
+caption = "More professional than [WWE](@/o/wwe.md). Not."
+source = "Official ŁSW YouTube"
+skip_art = true
+[extra.gallery.2]
+path = "tombstone-piledriver.jpg"
+caption = "Do not try this at home, or at all."
+source = "Official ŁSW YouTube"
+skip_art = true
 +++
 
 Łazieniec Superstar Wrestling was a short-lived backyard group from the village of Łazieniec. Little is known about them, as all that can be found is their YouTube channel with only four videos, 4.5 to 5.5 minutes in length, in which they demonstrate a variety of popular wrestling moves.

--- a/content/o/ptw-gallery.toml
+++ b/content/o/ptw-gallery.toml
@@ -1,25 +1,137 @@
-01 = { path = "rzezniczek-departs.png", caption = "Marcin Rzeźniczek announcing his departure from PTW" }
-02 = { path = "ptw6_leak.png", caption = "Sabinq from Wrestlefans realising he leaked a match. Further down, Taras admits to being on a break from the ring.", source = "Twitter/X"}
-03 = { path = "taras_cyrk.jpg", caption = 'Taras seemingly happy that he is no longer part of "this circus".', source = "Twitter/X"}
-04 = { path = "taras_60.png", caption = "Jakub Tyczyński accusing Taras of ratting out other wrestlers to boss Pawłowski. Jacob Crane is named for holding an exhausting training session, and Axel Fox for some crude humor during training. Also mocking his debut victory over Tischer, as something that the entire German scene supposedly derides.", source = "PTW's public Facebook group"}
-05 = { path = "taras_done.png", caption = "Arek Roter criticizes that a 10-year old car is pushed way more than any wrestler in PTW. Taras declares he's done with wrestling for the time.", source = "Twitter/X"}
-06 = { path = "sabinq_done.png", caption = "Sabinq from Wrestlefans declaring he know nothing about Stonoga's involvement, and dropping out of collaboration with PTW.", source = "Twitter/X"}
-07 = { path = "ppw_wrestlers_stonoga.jpg", caption = 'Zbigniew Stonoga posing outside of a McDonalds kids playground, with "fans" wearing PpW merchandise. Except one, these fans are PpW wrestlers and personnel.', source = "Gazeta Stonoga's Facebook page" }
-08 = { path = "pozdro_dla_tych.png", caption = "Group post re-sharing Stonoga's announcement. The comment mocks people who spent their own money on the show. The bottom popup text is an alert that the post was removed.", source = "PTW's public Facebook Group"}
-09 = { path = "ludwiczek-babs.png", caption = 'Kacper "Ludwiczek" Bociański next to Baba-thunder. The post promotes [Total Blast From The Past](@/e/ptw/2024-05-11-ptw-6.md) and the lottery.', source = "Instagram profile @ludwiczek_top"}
-10 = { path = "dziedzic-sinister-marcelito-facebook.png", caption = "Anonymous post on the PTW Fan group, mockingly asking for at least 3 matches on the upcoming Ryucon show, and wishing well to Dziedzic, Marcelito and Sinister.", source = "Facebook PTW Grupa Fanów"}
-11 = { path = "puncher-chapter-closed.jpg", caption = "[Puncher's](@/w/puncher.md) Instagram post stating 'Chapter closed', which spurred rumors about his exit.", source = "Instagram @ptwpuncher" }
-12 = { path = "puncher-1.png", caption = "Puncher's long letter, page 1: meeting Pawłowski, training.", source = "Twitter @PuncherShow"}
-13 = { path = "puncher-2.png", caption = "Puncher's long letter, page 2: honing his skills, first PTW events, sleeping in the ring.", source = "Twitter @PuncherShow"}
-14 = { path = "puncher-3.png", caption = "Puncher's long letter, page 3: anonymous accusations, the lottery flop.", source = "Twitter @PuncherShow"}
-15 = { path = "sambor-insta-thanks.jpg", caption = '[Sambor](@/w/sambor.md) thanking the fans, organization and Pawłowski for support. The text states that his time in wrestling is not over, and his story will be told in many taverns.'}
-16 = { path = "hammers-vs-caravaggio.png", caption = "[Marco Hammers](@/w/marco-hammers.md) feuding online with Vincent Caravaggio, three days before his surprise debut for PpW. He links to Kornel Tomicki's (Vincent's real name) site, where prior to his wrestling career, Tomicki offered coaching, prominently promising successful dating.", source = "Facebook Marco Hammers"}
-17 = { path = "ludwiczek-stonoga.png", caption = "Kacper \"Ludwiczek\" Bociański and Zbigniew Stonoga, in front of the lottery grand prize Nissan GTR. They building in the background is located in Warsaw's old town, next to Piłsudski Square.", source = "Instagram profile @ludwiczek_top"}
-18 = { path = "ludwiczek-insta-1.png", caption = "Ludwiczek's instagram post. In the comments, several PTW personalities point out the author's hypocrisy.", source = "Instagram profile @ludwiczek_top"}
-19 = { path = "ludwiczek-insta-2.png", caption = "Discussion under Ludwiczek's instagram post. He criticizes the organization, its \"mouldy\" ring, and writes about \"protecting the lottery\".", source = "Instagram profile @ludwiczek_top"}
-20 = { path = "ludwiczek-insta-3.png", caption = "Further discussion under Ludwiczek's instagram post. Pawłowski is called a manipulator who keeps pretending he's the victim of circumstances. Former PTW wrestler [Justin Joy](@/w/justin-joy.md) (as oski_ninja) praises Ludwiczek for talking sense, while [Samson](@/w/samson.md) wants a match against Pawłowski."}
-21 = { path = "botte-da-bestya.webp", caption = "ICW's poster advertising Botte da Bestya 2. Near the bottom are Iva Kolasky and [Puncher](@/w/puncher.md). Luca Bjorn, who also appeared for PTW is first in the second row."}
-22 = { path = "piekny-fakolec.webp", caption = "Post by [Piękny Kawaler](@/w/piekny-kawaler.md) responding to statements made by [Arkadiusz Pawłowski](@/w/pan-pawlowski.md) on Marcin Najman's YouTube channel, with comments by fans and other wrestlers.", source = "Piękny Kawaler @ Facebook"}
-23 = { path = "okonskie-peeleny.png", caption = "Comment by Łukasz Okoński regarding his financial input into PTW.", source = "Official PTW Facebook"}
-24 = { path = "roster-2024-05-09.webp", caption = "PTW's roster page prior to being taken down.", source = "Archive.org"}
-25 = { path = "debt.webp", caption = "Screenshot from a January 2025 post. In the highlighted comment, the producers of [PTW #6](@/e/ptw/2024-05-11-ptw-6.md) ask about the money they're owed. ", source = "Official PTW Facebook"}
+[01]
+path = "rzezniczek-departs.png"
+caption = "Marcin Rzeźniczek announcing his departure from PTW"
+skip_art = true
+
+[02]
+path = "ptw6_leak.png"
+caption = "Sabinq from Wrestlefans realising he leaked a match. Further down, Taras admits to being on a break from the ring."
+source = "Twitter/X"
+skip_art = true
+
+[03]
+path = "taras_cyrk.jpg"
+caption = 'Taras seemingly happy that he is no longer part of "this circus".'
+source = "Twitter/X"
+skip_art = true
+
+[04]
+path = "taras_60.png"
+caption = "Jakub Tyczyński accusing Taras of ratting out other wrestlers to boss Pawłowski. Jacob Crane is named for holding an exhausting training session, and Axel Fox for some crude humor during training. Also mocking his debut victory over Tischer, as something that the entire German scene supposedly derides."
+source = "PTW's public Facebook group"
+skip_art = true
+
+[05]
+path = "taras_done.png"
+caption = "Arek Roter criticizes that a 10-year old car is pushed way more than any wrestler in PTW. Taras declares he's done with wrestling for the time."
+source = "Twitter/X"
+skip_art = true
+
+[06]
+path = "sabinq_done.png"
+caption = "Sabinq from Wrestlefans declaring he know nothing about Stonoga's involvement, and dropping out of collaboration with PTW."
+source = "Twitter/X"
+skip_art = true
+
+[07]
+path = "ppw_wrestlers_stonoga.jpg"
+caption = 'Zbigniew Stonoga posing outside of a McDonalds kids playground, with "fans" wearing PpW merchandise. Except one, these fans are PpW wrestlers and personnel.'
+source = "Gazeta Stonoga's Facebook page"
+
+[08]
+path = "pozdro_dla_tych.png"
+caption = "Group post re-sharing Stonoga's announcement. The comment mocks people who spent their own money on the show. The bottom popup text is an alert that the post was removed."
+source = "PTW's public Facebook Group"
+skip_art = true
+
+[09]
+path = "ludwiczek-babs.png"
+caption = 'Kacper "Ludwiczek" Bociański next to Baba-thunder. The post promotes [Total Blast From The Past](@/e/ptw/2024-05-11-ptw-6.md) and the lottery.'
+source = "Instagram profile @ludwiczek_top"
+
+[10]
+path = "dziedzic-sinister-marcelito-facebook.png"
+caption = "Anonymous post on the PTW Fan group, mockingly asking for at least 3 matches on the upcoming Ryucon show, and wishing well to Dziedzic, Marcelito and Sinister."
+source = "Facebook PTW Grupa Fanów"
+
+[11]
+path = "puncher-chapter-closed.jpg"
+caption = "[Puncher's](@/w/puncher.md) Instagram post stating 'Chapter closed', which spurred rumors about his exit."
+source = "Instagram @ptwpuncher"
+
+[12]
+path = "puncher-1.png"
+caption = "Puncher's long letter, page 1: meeting Pawłowski, training."
+source = "Twitter @PuncherShow"
+skip_art = true
+
+[13]
+path = "puncher-2.png"
+caption = "Puncher's long letter, page 2: honing his skills, first PTW events, sleeping in the ring."
+source = "Twitter @PuncherShow"
+skip_art = true
+
+[14]
+path = "puncher-3.png"
+caption = "Puncher's long letter, page 3: anonymous accusations, the lottery flop."
+source = "Twitter @PuncherShow"
+skip_art = true
+
+[15]
+path = "sambor-insta-thanks.jpg"
+caption = '[Sambor](@/w/sambor.md) thanking the fans, organization and Pawłowski for support. The text states that his time in wrestling is not over, and his story will be told in many taverns.'
+
+[16]
+path = "hammers-vs-caravaggio.png"
+caption = "[Marco Hammers](@/w/marco-hammers.md) feuding online with Vincent Caravaggio, three days before his surprise debut for PpW. He links to Kornel Tomicki's (Vincent's real name) site, where prior to his wrestling career, Tomicki offered coaching, prominently promising successful dating."
+source = "Facebook Marco Hammers"
+skip_art = true
+
+[17]
+path = "ludwiczek-stonoga.png"
+caption = "Kacper \"Ludwiczek\" Bociański and Zbigniew Stonoga, in front of the lottery grand prize Nissan GTR. They building in the background is located in Warsaw's old town, next to Piłsudski Square."
+source = "Instagram profile @ludwiczek_top"
+
+[18]
+path = "ludwiczek-insta-1.png"
+caption = "Ludwiczek's instagram post. In the comments, several PTW personalities point out the author's hypocrisy."
+source = "Instagram profile @ludwiczek_top"
+skip_art = true
+
+[19]
+path = "ludwiczek-insta-2.png"
+caption = "Discussion under Ludwiczek's instagram post. He criticizes the organization, its \"mouldy\" ring, and writes about \"protecting the lottery\"."
+source = "Instagram profile @ludwiczek_top"
+skip_art = true
+
+[20]
+path = "ludwiczek-insta-3.png"
+caption = "Further discussion under Ludwiczek's instagram post. Pawłowski is called a manipulator who keeps pretending he's the victim of circumstances. Former PTW wrestler [Justin Joy](@/w/justin-joy.md) (as oski_ninja) praises Ludwiczek for talking sense, while [Samson](@/w/samson.md) wants a match against Pawłowski."
+skip_art = true
+
+[21]
+path = "botte-da-bestya.webp"
+caption = "ICW's poster advertising Botte da Bestya 2. Near the bottom are Iva Kolasky and [Puncher](@/w/puncher.md). Luca Bjorn, who also appeared for PTW is first in the second row."
+
+[22]
+path = "piekny-fakolec.webp"
+caption = "Post by [Piękny Kawaler](@/w/piekny-kawaler.md) responding to statements made by [Arkadiusz Pawłowski](@/w/pan-pawlowski.md) on Marcin Najman's YouTube channel, with comments by fans and other wrestlers."
+source = "Piękny Kawaler @ Facebook"
+skip_art = true
+
+[23]
+path = "okonskie-peeleny.png"
+caption = "Comment by Łukasz Okoński regarding his financial input into PTW."
+source = "Official PTW Facebook"
+skip_art = true
+
+[24]
+path = "roster-2024-05-09.webp"
+caption = "PTW's roster page prior to being taken down."
+source = "Archive.org"
+
+[25]
+path = "debt.webp"
+caption = "Screenshot from a January 2025 post. In the highlighted comment, the producers of [PTW #6](@/e/ptw/2024-05-11-ptw-6.md) ask about the money they're owed. "
+source = "Official PTW Facebook"
+skip_art = true

--- a/content/o/tbw-gallery.toml
+++ b/content/o/tbw-gallery.toml
@@ -1,20 +1,119 @@
-ahmed = { path = "ahmedchaer.jpg", caption = "Ahmed Chaer", source = "wrestling.nazwa.pl" }
-bjorn = { path = "bjornsem.jpg", caption = "Bjørn Sem", source = "wrestling.nazwa.pl" }
-chrisbambikiller = { path = "chrisbambikiller.jpg", caption = "Chris The Bambikiller", source = "wrestling.nazwa.pl"}
-chriscolen = { path = "chriscolen.jpg", caption = "Chris Colen", source = "wrestling.nazwa.pl"}
-colossos = { path = "collosos2.jpg", caption = "Colossos", source = "wrestling.nazwa.pl"}
-mike = { path = "crazysexymike.jpg", caption = "Crazy Sexy Mike", source = "wrestling.nazwa.pl"}
-cybernic = { path = "cybernic.jpg", caption = "Cybernic Machine", source = "wrestling.nazwa.pl"}
-damonbrix = { path = "damonbrix.jpg", caption = "Damon Brix", source = "wrestling.nazwa.pl"}
-erik = { path = "erikisaksen.jpg", caption = "Erik Isaksen", source = "wrestling.nazwa.pl"}
-dragon = { path = "flyingdragon.jpg", caption = "Flying Dragon", source = "wrestling.nazwa.pl"}
-heimo = { path = "heimo.jpg", caption = "Heimo Ukonselkä", source = "wrestling.nazwa.pl"}
-ivankiev = { path = "ivankiev.jpg", caption = "Ivan Kiev", source = "wrestling.nazwa.pl"}
-makoto = { path = "makoto.jpg", caption = "Makoto Morimitsu", source = "wrestling.nazwa.pl"}
-mertkaloglu = { path = "mertkaloglu.jpg", caption = "Mert Kaloglu", source = "wrestling.nazwa.pl"}
-mexx = { path = "mexx.jpg", caption = "Mexx", source = "wrestling.nazwa.pl"}
-kovac = { path = "michaelkovac.jpg", caption = "[Michael Kovac](@/w/michael-kovac.md)", source = "wrestling.nazwa.pl"}
-scott = { path = "scottrider.jpg", caption = "Scott Rider", source = "wrestling.nazwa.pl"}
-starbuck = { path = "starbuck.jpg", caption = "Starbuck", source = "wrestling.nazwa.pl"}
-ultimo = { path = "ultimochingon.jpg", caption = "Ultimo Chingon", source = "wrestling.nazwa.pl"}
-vandamme = { path = "vandamme.jpg", caption = "Bernard Vandamme wearing the Eurostars European Heavyweight Championship", source = "wrestling.nazwa.pl"}
+[ahmed]
+path = "ahmedchaer.jpg"
+caption = "Ahmed Chaer"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[bjorn]
+path = "bjornsem.jpg"
+caption = "Bjørn Sem"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[chrisbambikiller]
+path = "chrisbambikiller.jpg"
+caption = "Chris The Bambikiller"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[chriscolen]
+path = "chriscolen.jpg"
+caption = "Chris Colen"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[colossos]
+path = "collosos2.jpg"
+caption = "Colossos"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[mike]
+path = "crazysexymike.jpg"
+caption = "Crazy Sexy Mike"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[cybernic]
+path = "cybernic.jpg"
+caption = "Cybernic Machine"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[damonbrix]
+path = "damonbrix.jpg"
+caption = "Damon Brix"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[erik]
+path = "erikisaksen.jpg"
+caption = "Erik Isaksen"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[dragon]
+path = "flyingdragon.jpg"
+caption = "Flying Dragon"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[heimo]
+path = "heimo.jpg"
+caption = "Heimo Ukonselkä"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[ivankiev]
+path = "ivankiev.jpg"
+caption = "Ivan Kiev"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[makoto]
+path = "makoto.jpg"
+caption = "Makoto Morimitsu"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[mertkaloglu]
+path = "mertkaloglu.jpg"
+caption = "Mert Kaloglu"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[mexx]
+path = "mexx.jpg"
+caption = "Mexx"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[kovac]
+path = "michaelkovac.jpg"
+caption = "[Michael Kovac](@/w/michael-kovac.md)"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[scott]
+path = "scottrider.jpg"
+caption = "Scott Rider"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[starbuck]
+path = "starbuck.jpg"
+caption = "Starbuck"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[ultimo]
+path = "ultimochingon.jpg"
+caption = "Ultimo Chingon"
+source = "wrestling.nazwa.pl"
+skip_art = true
+
+[vandamme]
+path = "vandamme.jpg"
+caption = "Bernard Vandamme wearing the Eurostars European Heavyweight Championship"
+source = "wrestling.nazwa.pl"
+skip_art = true

--- a/doc/GALLERY.md
+++ b/doc/GALLERY.md
@@ -40,6 +40,7 @@ The value is always a map (another list of key-value pairs), which **must contai
 * `path` must name a file in the page's images folder (see above). There is no way to link images from other articles, and copying them is the only solution for now.
 * `caption` is the text to display under the thumbnail in the gallery grid. Markdown can be used in this text, as shown in the example, so it can link to other pages. However, shortcodes and template markup cannot be used.
 * `source` is the attribution. While currently it's not displayed, we still want to collect it to have a grasp on where the images came from.
+* `skip_art` (optional). If present and set to true, this image will be excluded from Artwall. Recommended to set for photos that are low-resolution, or screenshots containing mostly text.
 
 ### Collapsing
 

--- a/src/bin/talent_gallery.py
+++ b/src/bin/talent_gallery.py
@@ -70,17 +70,13 @@ def combine_path(event_page: EventPage, subdir, photo_path: str) -> str:
 
 @singledispatch
 def generate_key(page, index: int):
-    raise ArgumentError
+    return f"{page.path.stem}_{index}"
 
 @generate_key.register
 def generate_event_key(page: EventPage, index: int):
     """Given an event page and photo index, generate an identifier unique within that page."""
     ymd = page.event_date.strftime("%Y%m%d")
     return f"{ymd}_{index}"
-
-@generate_key.register
-def generate_talent_key(page: TalentPage, index: int):
-    return f"{page.path.stem}_{index}"
 
 def page_link(page: Page) -> str:
     content_root = Path.cwd() / 'content'

--- a/src/bin/talent_gallery.py
+++ b/src/bin/talent_gallery.py
@@ -99,6 +99,9 @@ def build_event_photos():
 
         for _, entry in gallery.items():
             path, caption, source = entry['path'], entry['caption'], entry.get('source')
+            if entry.get('skip_art', False):
+                continue
+
             taggings = set(parse_names(caption))
             for page_path in taggings:
                 entries = photo_taggings.setdefault(page_path.replace('@/', ''), [])

--- a/src/page.py
+++ b/src/page.py
@@ -89,11 +89,11 @@ def page(path: Path, verbose: bool = False) -> Page:
     for the path given."""
     if Path('content/e') in path.parents or EventPage.date_org_re.match(path.stem):
         return EventPage(path, verbose)
-    elif Path('content/o') in path.parents:
+    elif path.match('o/*.md'):
         return OrgPage(path, verbose)
-    elif Path('content/w') in path.parents:
+    elif path.match('w/*.md'):
         return TalentPage(path, verbose)
-    elif Path('content/v') in path.parents:
+    elif path.match('v/*.md'):
         return VenuePage(path, verbose)
     else:
         return Article(path, verbose)

--- a/src/page.py
+++ b/src/page.py
@@ -116,6 +116,10 @@ def all_event_pages(root: Optional[Path]=None, verbose: bool = False) -> Iterabl
                 for page_path in (root / 'content/e/').glob('**/????-??-??-*.md')
                 if page_path.stem != '_index')
 
+def pages_under(path: Path, verbose: bool = False) -> Iterable[Page]:
+    yield from (page(page_path, verbose=verbose)
+                for page_path in path.glob('*.md'))
+
 if __name__ == "__main__":
     import sys, code
     path = Path(sys.argv[1])


### PR DESCRIPTION
This introduces `skip_art`, an optional key for a gallery item. If present and set to true, this particular photo will never be shown in artwall. See documentation.

To make adding `skip_art` easier, several long galleries were converted to block-style TOML. One duplicated photo from PTW exits was removed.