### PR TITLE
Ryucon chronology

### DIFF
--- a/cloudflare-config.toml
+++ b/cloudflare-config.toml
@@ -93,12 +93,13 @@ text_fg = '#ffffff'
 
 
 [extra.chronology]
-underground = "PTW Underground"
-godzina-zero = "KPW Godzina Zero"
 arena = "KPW Arena"
-pyrkon = "Pyrkon"
-international = "International"
-poznan-fair = "Poznań International Fair"
 beer-expo = "Poznań Beer Expo"
+godzina-zero = "KPW Godzina Zero"
+international = "International"
 oldtown = "OldTown Festival"
+poznan-fair = "Poznań International Fair"
 project-basement = "Project Basement"
+pyrkon = "Pyrkon"
+ryucon = "Ryucon"
+underground = "PTW Underground"

--- a/config.toml
+++ b/config.toml
@@ -91,12 +91,13 @@ bg = '#000'
 text_fg = '#ffffff'
 
 [extra.chronology]
-underground = "PTW Underground"
-godzina-zero = "KPW Godzina Zero"
 arena = "KPW Arena"
-pyrkon = "Pyrkon"
-international = "International"
-poznan-fair = "Poznań International Fair"
 beer-expo = "Poznań Beer Expo"
+godzina-zero = "KPW Godzina Zero"
+international = "International"
 oldtown = "OldTown Festival"
+poznan-fair = "Poznań International Fair"
 project-basement = "Project Basement"
+pyrkon = "Pyrkon"
+ryucon = "Ryucon"
+underground = "PTW Underground"

--- a/content/e/ptw/2022-07-31-ptw-x-ryucon.md
+++ b/content/e/ptw/2022-07-31-ptw-x-ryucon.md
@@ -3,7 +3,7 @@ title = "PTW X RyuCon 2022"
 template = "event_page.html"
 authors = ["Szymon Iwulski"]
 [taxonomies]
-chronology = ["ptw"]
+chronology = ["ptw", "ryucon"]
 venue = ["tauron-arena"]
 [extra]
 city = "Kraków"

--- a/content/e/ptw/2023-07-16-ptw-x-ryucon.md
+++ b/content/e/ptw/2023-07-16-ptw-x-ryucon.md
@@ -3,7 +3,7 @@ title = "PTW x RyuCon 2"
 template = "event_page.html"
 author = ["Szymon Iwulski"]
 [taxonomies]
-chronology = ["ptw"]
+chronology = ["ptw", "ryucon"]
 venue = ["tauron-arena"]
 [extra]
 city = "Kraków"

--- a/content/e/ptw/2024-07-07-ptw-x-ryucon.md
+++ b/content/e/ptw/2024-07-07-ptw-x-ryucon.md
@@ -3,7 +3,7 @@ title = "PTW x RyuCon 3"
 template = "event_page.html"
 authors = ["Szymon Iwulski", "Joanna Ropelewska"]
 [taxonomies]
-chronology = ["ptw"]
+chronology = ["ptw", "ryucon"]
 venue = ["tauron-arena"]
 [extra]
 city = "Kraków"


### PR DESCRIPTION
Jako Pyrkon, tak i Ryucon. Wpisu dla Tauron Areny już nie dodaję, bo poza PTW nikt tam póki co nie występuje, ale jeżeli się kiedyś zdarzy, to się dopisze jak Targom Poznańskim.