### PR TITLE
Long-term fix for #1347

### DIFF
--- a/templates/org_page.html
+++ b/templates/org_page.html
@@ -38,7 +38,8 @@
 {% endblock content %}
 
 {% block extra_head %}
-  {% if not page.extra.hide_events -%}
+  {% if page.extra.hide_events or page.extra.compact_event_list -%}
+  {% else %}
     <script defer type="module">
       import { extractUpcoming, createSection, cleanEmptyYears } from '/events.js'
       document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
If an org page has its events section hidden, or is using the compact list format, then do not run the script that creates the "Upcoming Events" section.