### PR TITLE
Multiple venue names

### DIFF
--- a/cloudflare-config.toml
+++ b/cloudflare-config.toml
@@ -17,6 +17,7 @@ theme = "web"
 taxonomies =  [
   { name = "chronology", render = false },
   { name = "venue", render = false },
+  { name = "same-venue", render = false },
   { name = "chrono_root", render = false },
   { name = "country", render = false },
 ]

--- a/config.toml
+++ b/config.toml
@@ -17,6 +17,7 @@ theme = "web"
 taxonomies = [
   { name = "chronology", render = false },
   { name = "venue", render = false },
+  { name = "same-venue", render = false },
   { name = "chrono_root", render = false },
   { name = "country", render = false },
 ]

--- a/content/e/kpw/2017-01-14-kpw-arena-v.md
+++ b/content/e/kpw/2017-01-14-kpw-arena-v.md
@@ -3,7 +3,7 @@ title = "KPW Arena V: Atlantic City"
 template = "event_page.html"
 [taxonomies]
 chronology = ["kpw", "arena"]
-venue=["atlantic-nh-gdynia"]
+venue=["atlantic"]
 [extra]
 city = "Gdynia"
 [extra.gallery]

--- a/content/e/kpw/2017-04-08-kpw-arena-6.md
+++ b/content/e/kpw/2017-04-08-kpw-arena-6.md
@@ -4,7 +4,7 @@ template = "event_page.html"
 aliases = ["/e/kpw/2017-04-08-kpw-arena-6-selekcja"]
 [taxonomies]
 chronology = ["kpw", "arena"]
-venue=["atlantic-nh-gdynia"]
+venue=["atlantic"]
 [extra]
 city = "Gdynia"
 [extra.gallery]

--- a/content/e/kpw/2017-06-10-kpw-arena-7.md
+++ b/content/e/kpw/2017-06-10-kpw-arena-7.md
@@ -4,7 +4,7 @@ template = "event_page.html"
 aliases = ["/e/kpw/2017-06-10-kpw-arena-7-wysoka-stawka"]
 [taxonomies]
 chronology = ["kpw", "arena"]
-venue=["atlantic-nh-gdynia"]
+venue=["atlantic"]
 [extra]
 city = "Gdynia"
 [extra.gallery]

--- a/content/e/kpw/2022-03-18-kpw-arena-18.md
+++ b/content/e/kpw/2022-03-18-kpw-arena-18.md
@@ -4,7 +4,7 @@ template = "event_page.html"
 aliases = ["/e/kpw/2022-03-18-kpw-arena-18-powrot-do-przyszlosci"]
 [taxonomies]
 chronology = ["kpw", "arena"]
-venue=["atlantic-nh-gdynia"]
+venue=["nowy-harem"]
 [extra]
 city = "Gdynia"
 [extra.gallery]

--- a/content/e/kpw/2022-06-10-kpw-arena-19.md
+++ b/content/e/kpw/2022-06-10-kpw-arena-19.md
@@ -4,7 +4,7 @@ template = "event_page.html"
 aliases = ["/e/kpw/2022-06-10-kpw-arena-19-oko-za-oko"]
 [taxonomies]
 chronology = ["kpw", "arena"]
-venue=["atlantic-nh-gdynia"]
+venue=["nowy-harem"]
 [extra]
 city = "Gdynia"
 [extra.gallery]

--- a/content/e/kpw/2022-09-17-kpw-godzina-zero-2022.md
+++ b/content/e/kpw/2022-09-17-kpw-godzina-zero-2022.md
@@ -3,7 +3,7 @@ title = "KPW Godzina Zero 2022"
 template = "event_page.html"
 [taxonomies]
 chronology = ["kpw", "godzina-zero"]
-venue=["atlantic-nh-gdynia"]
+venue=["nowy-harem"]
 [extra]
 city = "Gdynia"
 [extra.gallery.1]

--- a/content/e/kpw/2022-12-16-kpw-arena-20.md
+++ b/content/e/kpw/2022-12-16-kpw-arena-20.md
@@ -4,7 +4,7 @@ template = "event_page.html"
 aliases = ["/e/2022-12-16-kpw-arena-20"]
 [taxonomies]
 chronology = ["kpw", "arena"]
-venue=["atlantic-nh-gdynia"]
+venue=["nowy-harem"]
 [extra]
 city = "Gdynia"
 [extra.gallery.1]

--- a/content/e/kpw/2023-02-24-kpw-arena-21.md
+++ b/content/e/kpw/2023-02-24-kpw-arena-21.md
@@ -4,7 +4,7 @@ template = "event_page.html"
 aliases = ["/e/2023-02-24-kpw-arena-21"]
 [taxonomies]
 chronology = ["kpw", "arena"]
-venue=["atlantic-nh-gdynia"]
+venue=["nowy-harem"]
 [extra]
 city = "Gdynia"
 [extra.gallery.1]

--- a/content/e/kpw/2023-05-19-kpw-arena-22.md
+++ b/content/e/kpw/2023-05-19-kpw-arena-22.md
@@ -4,7 +4,7 @@ template = "event_page.html"
 aliases = ["/e/2023-05-19-kpw-arena-22"]
 [taxonomies]
 chronology = ["kpw", "arena"]
-venue=["atlantic-nh-gdynia"]
+venue=["nowy-harem"]
 [extra]
 city = "Gdynia"
 [extra.gallery.1]

--- a/content/e/kpw/2023-08-18-kpw-godzina-zero-2023.md
+++ b/content/e/kpw/2023-08-18-kpw-godzina-zero-2023.md
@@ -4,7 +4,7 @@ template = "event_page.html"
 aliases = ["/e/2023-08-18-kpw-godzina-zero-2023"]
 [taxonomies]
 chronology = ["kpw", "godzina-zero"]
-venue=["atlantic-nh-gdynia"]
+venue=["nowy-harem"]
 [extra]
 city = "Gdynia"
 [extra.gallery]

--- a/content/e/kpw/2023-11-24-kpw-arena-23.md
+++ b/content/e/kpw/2023-11-24-kpw-arena-23.md
@@ -5,7 +5,7 @@ aliases = ["/e/2023-11-24-kpw-arena-23"]
 authors = ["Krzysztof Zych"]
 [taxonomies]
 chronology = ["kpw", "arena"]
-venue=["atlantic-nh-gdynia"]
+venue=["nowy-harem"]
 [extra]
 city = "Gdynia"
 [extra.gallery]

--- a/content/e/kpw/2024-02-16-kpw-arena-24.md
+++ b/content/e/kpw/2024-02-16-kpw-arena-24.md
@@ -4,7 +4,7 @@ template = "event_page.html"
 aliases = ["/e/kpw/2024-02-16-kpw-arena-24-zagrozenie-lawinowe"]
 [taxonomies]
 chronology = ["kpw", "arena"]
-venue=["atlantic-nh-gdynia"]
+venue=["nowy-harem"]
 [extra]
 city = "Gdynia"
 [extra.gallery.1]

--- a/content/e/kpw/2024-05-17-kpw-arena-25.md
+++ b/content/e/kpw/2024-05-17-kpw-arena-25.md
@@ -4,7 +4,7 @@ template = "event_page.html"
 authors = ["Krzysztof Zych"]
 [taxonomies]
 chronology = ["kpw", "arena"]
-venue=["atlantic-nh-gdynia"]
+venue=["nowy-harem"]
 [extra]
 city = "Gdynia"
 [extra.gallery]

--- a/content/e/kpw/2024-11-15-kpw-arena-26.md
+++ b/content/e/kpw/2024-11-15-kpw-arena-26.md
@@ -4,7 +4,7 @@ template = "event_page.html"
 authors = ["M3n747"]
 [taxonomies]
 chronology = ["kpw", "arena"]
-venue=["atlantic-nh-gdynia"]
+venue=["nowy-harem"]
 [extra]
 city = "Gdynia"
 [extra.gallery]

--- a/content/e/kpw/2025-01-24-kpw-arena-27.md
+++ b/content/e/kpw/2025-01-24-kpw-arena-27.md
@@ -4,7 +4,7 @@ template = "event_page.html"
 authors = ["M3n747", "Krzysztof Zych"]
 [taxonomies]
 chronology = ["kpw", "arena"]
-venue=["atlantic-nh-gdynia"]
+venue=["nowy-harem"]
 [extra]
 city = "Gdynia"
 [extra.gallery]

--- a/content/e/kpw/2025-04-11-kpw-arena-28.md
+++ b/content/e/kpw/2025-04-11-kpw-arena-28.md
@@ -4,7 +4,7 @@ template = "event_page.html"
 authors = ["M3n747", "Krzysztof Zych"]
 [taxonomies]
 chronology = ["kpw", "arena"]
-venue=["atlantic-nh-gdynia"]
+venue=["nowy-harem"]
 [extra]
 city = "Gdynia"
 [extra.gallery]

--- a/content/e/kpw/2025-06-20-kpw-arena-29.md
+++ b/content/e/kpw/2025-06-20-kpw-arena-29.md
@@ -4,7 +4,7 @@ template = "event_page.html"
 authors = ["M3n747"]
 [taxonomies]
 chronology = ["kpw", "arena"]
-venue=["atlantic-nh-gdynia"]
+venue=["nowy-harem"]
 [extra]
 hide_results = true
 city = "Gdynia"

--- a/content/e/ptw/2024-04-13-ptw-underground-21.md
+++ b/content/e/ptw/2024-04-13-ptw-underground-21.md
@@ -4,7 +4,7 @@ template = "event_page.html"
 authors = ["Krzysztof Zych", "Szymon Iwulski"]
 [taxonomies]
 chronology = ["ptw", "underground"]
-venue = ["dworek-kozlow"]
+venue = ["pod-platanem"]
 [extra]
 city = "Kozłów"
 [extra.gallery]

--- a/content/e/ptw/2024-11-16-ptw-underground-24.md
+++ b/content/e/ptw/2024-11-16-ptw-underground-24.md
@@ -4,7 +4,7 @@ template = "event_page.html"
 authors = ["M3n747"]
 [taxonomies]
 chronology = ["ptw", "underground"]
-venue = ["dworek-kozlow"]
+venue = ["szafirowy-dwor"]
 [extra]
 city = "Kozłów"
 [extra.gallery]

--- a/content/e/ptw/2024-12-07-ptw-underground-25.md
+++ b/content/e/ptw/2024-12-07-ptw-underground-25.md
@@ -4,7 +4,7 @@ template = "event_page.html"
 authors = ["Sewi The Referee"]
 [taxonomies]
 chronology = ["ptw", "underground"]
-venue = ["dworek-kozlow"]
+venue = ["szafirowy-dwor"]
 [extra]
 city = "Kozłów"
 [extra.gallery.poster]

--- a/content/e/ptw/2025-01-11-ptw-nowe-porzadki.md
+++ b/content/e/ptw/2025-01-11-ptw-nowe-porzadki.md
@@ -4,7 +4,7 @@ template = "event_page.html"
 authors = ["M3n747", "Krzysztof Zych"]
 [taxonomies]
 chronology = ["ptw"]
-venue = ["dworek-kozlow"]
+venue = ["szafirowy-dwor"]
 [extra]
 city = "Kozłów"
 [extra.gallery]

--- a/content/e/ptw/2025-02-15-ptw-wrestlingowe-walentynki.md
+++ b/content/e/ptw/2025-02-15-ptw-wrestlingowe-walentynki.md
@@ -4,7 +4,7 @@ template = "event_page.html"
 authors = ["M3n747", "Szymon Iwulski"]
 [taxonomies]
 chronology = ["ptw"]
-venue = ["dworek-kozlow"]
+venue = ["szafirowy-dwor"]
 [extra]
 city = "Kozłów"
 [extra.gallery]

--- a/content/e/ptw/2025-03-15-ptw-wiosenna-bijatyka.md
+++ b/content/e/ptw/2025-03-15-ptw-wiosenna-bijatyka.md
@@ -4,7 +4,7 @@ template = "event_page.html"
 authors = ["M3n747"]
 [taxonomies]
 chronology = ["ptw"]
-venue = ["dworek-kozlow"]
+venue = ["szafirowy-dwor"]
 [extra]
 city = "Kozłów"
 [extra.gallery]

--- a/content/e/ptw/2025-04-12-ptw-prezes-vs-prezes.md
+++ b/content/e/ptw/2025-04-12-ptw-prezes-vs-prezes.md
@@ -4,7 +4,7 @@ template = "event_page.html"
 authors = ["M3n747", "Szymon Iwulski"]
 [taxonomies]
 chronology = ["ptw"]
-venue = ["dworek-kozlow"]
+venue = ["szafirowy-dwor"]
 [extra]
 city = "Kozłów"
 [extra.gallery]

--- a/content/e/ptw/2025-05-31-ptw-dzien-dziecka.md
+++ b/content/e/ptw/2025-05-31-ptw-dzien-dziecka.md
@@ -4,7 +4,7 @@ template = "event_page.html"
 authors = ["M3n747"]
 [taxonomies]
 chronology = ["ptw"]
-venue = ["dworek-kozlow"]
+venue = ["szafirowy-dwor"]
 [extra]
 hide_results = true
 city = "Kozłów"

--- a/content/e/ptw/2025-06-28-ptw-zloto-dla-zuchwalych.md
+++ b/content/e/ptw/2025-06-28-ptw-zloto-dla-zuchwalych.md
@@ -4,7 +4,7 @@ template = "event_page.html"
 authors = ["M3n747"]
 [taxonomies]
 chronology = ["ptw"]
-venue = ["dworek-kozlow"]
+venue = ["szafirowy-dwor"]
 [extra]
 hide_results = true
 city = "Kozłów"

--- a/content/v/atlantic-nh-gdynia.md
+++ b/content/v/atlantic-nh-gdynia.md
@@ -2,6 +2,11 @@
 title = "Atlantic / Nowy Harem"
 template = "venue_page.html"
 authors = ["Krzysztof Zych"]
+[taxonomies]
+same-venue = ["atlantic", "nowy-harem"]
+[extra.venue_names]
+atlantic = "Atlantic"
+nowy-harem = "Nowy Harem"
 [extra.gallery]
 1 = { path = "nowy-harem.jpg", caption = "Nowy Harem in late 2024.", source = "Ville Paananen" }
 2 = { path = "kino-atlantic.jpg", caption = 'Cinema "Atlantic" in the 1950s. The banner above the entrance says "Soviet cinema days".', source = "MojaGdynia.com" }

--- a/content/v/dworek-kozlow.md
+++ b/content/v/dworek-kozlow.md
@@ -2,6 +2,11 @@
 title = "Pod Platanem / Szafirowy Dwór"
 template = "venue_page.html"
 authors = ["M3n747"]
+[taxonomies]
+same-venue = ["pod-platanem", "szafirowy-dwor"]
+[extra.venue_names]
+pod-platanem = "Pod Platanem"
+szafirowy-dwor = "Szafirowy Dwór"
 [extra.gallery]
 1 = { path = "pod-platanem-performance-centre.jpg", caption = "Outside view of the venue.", source = "Ville Paananen" }
 2 = { path = "nowahala-1.webp", caption = "PTW's new venue with the ring, tables and giant posters.", source = "Instagram @lukasz_prezes_okonski"}

--- a/doc/FRONT-MATTER.md
+++ b/doc/FRONT-MATTER.md
@@ -48,6 +48,8 @@ Certain entries are mandatory for all files, and not including them is an error.
 ## Venue page
 
 * `template`: must be `venue_page.html`.
+* `extra.skip_event_list`: if present and set to true, prevents linking to the venue in the homepage event list. Only the city will be displayed.
+* `extra.venue_names`: a map of keys from the `same-venue` chronology to quoted strings. When this venue page is linked to from the homepage listing using a different `venue` key, these titles are preferred over the page title.
 
 ## Article
 

--- a/doc/TAXONOMIES.md
+++ b/doc/TAXONOMIES.md
@@ -122,7 +122,7 @@ However, its header will be displayed with multiple exclamation marks and in bol
 ## Venue
 
 This taxonomy applies only to event pages, and links events to their venue page.
-The allowed term values here are filename roots (filename minus the `.md` extension) of pages under `content/v/`, which is the directory for venue pages.
+The allowed term values here are filename roots (filename minus the `.md` extension) of pages under `content/v/`, which is the directory for venue pages. Additional legal values are of the `same-venue` taxonomy, described below.
 
 The venue page has a list of events as well, and this list shows exactly all the events that have a matching `venue` taxonomy term.
 
@@ -139,3 +139,21 @@ venue = ["ptw-targowa"]
 
 This event will be listed on the venue page for PTW Performance Center.
 The venue is not linked automatically on the event's page. Instead, it should be linked in the descriptive text.
+
+## Same-venue
+
+This taxonomy only applies to venue pages.
+
+Venues can change names over the years. To be able to keep linking to the same page, but use a different venue name in the listing, the `same-venue` taxonomy allows declaring alternate keys for the same venue page. These keys are then associated with titles, which are explained in `FRONT-MATTER.md`.
+
+#### Example
+
+```toml
+# Assume this file is venues/atlantic-nh.md
+title = "Atlantic / Nowy Harem"
+template = "venue_page.html"
+[taxonomies]
+same-venue = ["atlantic", "nowy-harem"]
+```
+
+With this, an event's `venue` taxonomy may now use any of `atlantic-nh, atlantic, nowy-harem`, and it will be correctly linked to and displayed in the event list on this page. It will also correctly link on the homepage event list. By default, the venue page's title is used, unless alternate titles are defined.

--- a/templates/events/alt_venue_name.html
+++ b/templates/events/alt_venue_name.html
@@ -1,0 +1,19 @@
+{# Display alternate venue name if the venue key doesn't match a page directly #}
+{# Variables:
+  `venue` a page slug
+  `cities` city name to display
+  `venues_section` the section containing venue pages
+#}
+{%- set main_page = venues_section.pages | filter(attribute="slug", value=venue) | first -%}
+{%- if main_page and not main_page.extra.skip_event_list -%}
+  {{ cities }}, <a href="{{ main_page.path }}">{{ main_page.title }}</a>
+{%- elif not main_page -%}
+  {%- set term = get_taxonomy_term(kind="same-venue", term=venue, required=false) -%}
+  {%- if not term -%}
+    {{ cities }}
+  {%- else -%}
+    {%- set page = term.pages | first -%}
+    {%- set alt_title = page.extra.venue_names | get(key=venue, default=page.title) -%}
+    {{ cities }}, <a href="{{ page.path }}">{{ alt_title }}</a>
+  {%- endif -%}
+{%- endif -%}

--- a/templates/venue/events_from_taxonomy.html
+++ b/templates/venue/events_from_taxonomy.html
@@ -2,7 +2,11 @@
 {% set main_slug = page.slug %}
 {% set other_keys =page.taxonomies | get(key="same-venue", default=[])  %}
 
-{% set venue_event_pages = events_taxonomy.items | filter(attribute="slug", value=main_slug) | map(attribute="pages") | first %}
+{% set venue_event_pages = [] %}
+{% set main_slug_events = events_taxonomy.items | filter(attribute="slug", value=main_slug) | map(attribute="pages") | first %}
+{% if main_slug_events %}
+  {% set_global venue_event_pages = venue_event_pages | concat(with=main_slug_events) %}
+{% endif %}
 {% for key in other_keys %}
   {% set key_event_pages = get_taxonomy_term(kind="venue", term=key, required=false) %}
   {% if not key_event_pages %}{% continue %}{% endif %}

--- a/templates/venue/events_from_taxonomy.html
+++ b/templates/venue/events_from_taxonomy.html
@@ -1,7 +1,15 @@
 {% set events_taxonomy = get_taxonomy(kind="venue") %}
-{% set venue_event_pages = events_taxonomy.items | filter(attribute="slug", value=page.slug) | map(attribute="pages") | first %}
+{% set main_slug = page.slug %}
+{% set other_keys =page.taxonomies | get(key="same-venue", default=[])  %}
 
-{% if venue_event_pages != "" %}
+{% set venue_event_pages = events_taxonomy.items | filter(attribute="slug", value=main_slug) | map(attribute="pages") | first %}
+{% for key in other_keys %}
+  {% set key_event_pages = get_taxonomy_term(kind="venue", term=key, required=false) %}
+  {% if not key_event_pages %}{% continue %}{% endif %}
+  {% set_global venue_event_pages = venue_event_pages | concat(with=key_event_pages.pages) %}
+{% endfor %}
+
+{% if venue_event_pages | length > 0 %}
   {% set events_by_year = venue_event_pages | group_by(attribute="year") -%}
   {% set_global years = [] -%}
   {% for year, _ign in events_by_year -%}{% set_global years = years | concat(with=year) %}{% endfor -%}

--- a/themes/web/templates/events/cm_list.html
+++ b/themes/web/templates/events/cm_list.html
@@ -32,13 +32,11 @@
               {% else %}
                 {% set cities = "" %}
               {% endif %}
-             {{ cities -}}
               {%- if cities and page.taxonomies.venue -%}
                 {%- set venue = page.taxonomies.venue | first -%}
-                {%- set venue_page = venues_section.pages | filter(attribute="slug", value=venue) | first -%}
-                {%- if venue_page and not venue_page.extra.skip_event_list -%}
-                  , <a href="{{ venue_page.path }}">{{ venue_page.title }}</a>
-                {%- endif -%}
+                {%- include "events/alt_venue_name.html" -%}
+              {% elif cities %}
+                {{ cities }}
               {% endif %}
            </span>
         </li>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ae1a918f-04df-478f-b3dd-414d1a2bc85b)

Allows using alternate keys in the `venue` taxonomy on event pages which display a different, more specific name but still link to the same page. Check out `atlantic-nh-gdynia` and `dworek-kozlow` to see how this works.