### PR TITLE
Usunięte `weight` z teczek fed

### DIFF
--- a/content/o/ddw.md
+++ b/content/o/ddw.md
@@ -1,6 +1,5 @@
 +++
 title = "Do Or Die Wrestling"
-weight = 0
 template = "org_page.html"
 authors = ["Krzysztof Zych"]
 [taxonomies]

--- a/content/o/dfw.md
+++ b/content/o/dfw.md
@@ -1,6 +1,5 @@
 +++
 title = "Dream Factory Wrestling"
-weight = 0
 template = "org_page.html"
 authors = ["Krzysztof Zych", "Szymon Iwulski"]
 [taxonomies]

--- a/content/o/ewenement-dojo.md
+++ b/content/o/ewenement-dojo.md
@@ -1,6 +1,5 @@
 +++
 title = "Ewenement Dojo"
-weight = 0
 template = "org_page.html"
 authors = ["Sewi The Referee"]
 [extra]

--- a/content/o/kpw.md
+++ b/content/o/kpw.md
@@ -1,6 +1,5 @@
 +++
 title = "Kombat Pro Wrestling"
-weight = 1
 authors = ["Krzysztof Zych"]
 template = "org_page.html"
 [extra]

--- a/content/o/low.md
+++ b/content/o/low.md
@@ -1,6 +1,5 @@
 +++
 title = "Legacy of Wrestling"
-weight = 1
 authors = ["M3n747", "Szymon Iwulski"]
 template = "org_page.html"
 [taxonomies]

--- a/content/o/lsw.md
+++ b/content/o/lsw.md
@@ -1,6 +1,5 @@
 +++
 title = "Łazieniec Superstar Wrestling"
-weight = 1
 authors = ["M3n747"]
 template = "org_page.html"
 [extra]

--- a/content/o/mcw.md
+++ b/content/o/mcw.md
@@ -1,6 +1,5 @@
 +++
 title = "Mine City Wrestling"
-weight = 0
 template = "org_page.html"
 authors = ["M3n747"]
 [extra]

--- a/content/o/mzw.md
+++ b/content/o/mzw.md
@@ -1,6 +1,5 @@
 +++
 title = "Maniac Zone Wrestling"
-weight = 2
 authors = ["Krzysztof Zych"]
 template = "org_page.html"
 [taxonomies]

--- a/content/o/nqw.md
+++ b/content/o/nqw.md
@@ -1,6 +1,5 @@
 +++
 title = "New Quality Wrestling"
-weight = 0
 template = "org_page.html"
 authors = ["M3n747"]
 [extra]

--- a/content/o/paw.md
+++ b/content/o/paw.md
@@ -1,6 +1,5 @@
 +++
 title = "Polska Akademia Wrestlingu"
-weight = 4
 template = "org_page.html"
 authors = ["Sewi The Referee"]
 [extra]

--- a/content/o/piwg.md
+++ b/content/o/piwg.md
@@ -1,6 +1,5 @@
 +++
 title = "Pomerania Indy Wrestling Group"
-weight = 1
 authors = ["M3n747"]
 template = "org_page.html"
 [extra]

--- a/content/o/ppw.md
+++ b/content/o/ppw.md
@@ -1,6 +1,5 @@
 +++
 title = "PpW Ewenement"
-weight = 3
 template = "org_page.html"
 authors = ["Krzysztof Zych"]
 [taxonomies]

--- a/content/o/ptw-academy.md
+++ b/content/o/ptw-academy.md
@@ -1,6 +1,5 @@
 +++
 title = "PTW Academy"
-weight = 0
 template = "org_page.html"
 authors = ["Sewi The Referee"]
 [extra]

--- a/content/o/ptw.md
+++ b/content/o/ptw.md
@@ -1,6 +1,5 @@
 +++
 title = "Prime Time Wrestling"
-weight = 4
 template = "org_page.html"
 authors = ["Szymon Iwulski", "Sewi The Referee"]
 [taxonomies]

--- a/content/o/pxw.md
+++ b/content/o/pxw.md
@@ -1,6 +1,5 @@
 +++
 title = "Polish Xtreme Wrestling"
-weight = 0
 template = "org_page.html"
 authors = ["M3n747", "Krzysztof Zych"]
 [taxonomies]

--- a/content/o/tbw.md
+++ b/content/o/tbw.md
@@ -2,7 +2,6 @@
 title = "Total Blast Wrestling"
 template = "org_page.html"
 authors = ["Krzysztof Zych"]
-weight = 2
 [extra]
 toclevel = 3
 compact_event_list = true

--- a/content/o/wksw.md
+++ b/content/o/wksw.md
@@ -1,6 +1,5 @@
 +++
 title = "Wrestlingowy Klub Sportowy Wołów"
-weight = 0
 template = "org_page.html"
 authors = ["Krzysztof Zych", "M3n747"]
 [taxonomies]

--- a/content/o/wwe.md
+++ b/content/o/wwe.md
@@ -1,7 +1,6 @@
 +++
 title = "WWE"
 template = "org_page.html"
-weight = 10
 [taxonomies]
 chrono_root = ["wwe"]
 [extra]

--- a/content/o/wws.md
+++ b/content/o/wws.md
@@ -1,7 +1,6 @@
 +++
 title = "World Wrestling Superstars"
 template = "org_page.html"
-weight = 9
 [taxonomies]
 chrono_root = ["wws"]
 [extra]


### PR DESCRIPTION
Niczemu nie służy, skoro i tak sortujemy ręcznie według dat/alfabetu, a po co ma zbędnie konfundować.