### PR TITLE
Use new venue linking feature to denote events in Stocznia

### DIFF
--- a/content/e/kpw/2017-02-04-kpw-szlamfest.md
+++ b/content/e/kpw/2017-02-04-kpw-szlamfest.md
@@ -3,7 +3,7 @@ title = "KPW Szlamfest"
 template = "event_page.html"
 [taxonomies]
 chronology = ["kpw", "stocznia-gdanska"]
-venue = ["stocznia-gdanska"]
+venue = ["b90"]
 [extra]
 city = "Gdańsk"
 [extra.gallery]

--- a/content/e/kpw/2018-03-10-kpw-arena-9.md
+++ b/content/e/kpw/2018-03-10-kpw-arena-9.md
@@ -4,7 +4,7 @@ template = "event_page.html"
 aliases = ["/e/kpw/2018-03-10-kpw-arena-9-na-krawedzi"]
 [taxonomies]
 chronology = ["kpw", "arena", "stocznia-gdanska"]
-venue = ["stocznia-gdanska"]
+venue = ["b90"]
 [extra]
 city = "Gdańsk"
 [extra.gallery]

--- a/content/e/kpw/2019-06-15-kpw-arena-14.md
+++ b/content/e/kpw/2019-06-15-kpw-arena-14.md
@@ -4,7 +4,7 @@ template = "event_page.html"
 aliases = ["/e/kpw/2019-06-15-kpw-arena-14-nastepny-poziom"]
 [taxonomies]
 chronology = ["kpw", "arena", "stocznia-gdanska"]
-venue = ["stocznia-gdanska"]
+venue = ["b90"]
 [extra]
 city = "Gdynia"
 [extra.gallery]

--- a/content/e/ppw/2025-05-16-ppw-lucha-libre-extravaganza.md
+++ b/content/e/ppw/2025-05-16-ppw-lucha-libre-extravaganza.md
@@ -4,7 +4,7 @@ template = "event_page.html"
 authors = ["M3n747"]
 [taxonomies]
 chronology = ["ppw", "stocznia-gdanska"]
-venue = ["stocznia-gdanska"]
+venue = ["plenum"]
 [extra]
 hide_results = true
 city = "Gdańsk"

--- a/content/v/stocznia-gdanska.md
+++ b/content/v/stocznia-gdanska.md
@@ -2,6 +2,11 @@
 title = "Stocznia Gdańska"
 template = "venue_page.html"
 authors = ["M3n747"]
+[taxonomies]
+same-venue = ["b90", "plenum"]
+[extra.venue_names]
+b90 = "B90"
+plenum = "Plenum Hall"
 [extra.gallery]
 manifest = "@/v/stocznia-gdanska-gallery.toml"
 +++


### PR DESCRIPTION
This restores some of the changes from #1549:

- Szlamfests are back to B90
- LL Extravaganza is back to Plenum

but both are now aliases of Stocznia (using features from #1495).