### PR TITLE
Add another alias to The Greens' page

### DIFF
--- a/content/tt/zieloni.md
+++ b/content/tt/zieloni.md
@@ -1,7 +1,7 @@
 +++
 title = "Zieloni"
 template = "team_page.html"
-aliases = ["/a/the-greens", "/a/zieloni"]
+aliases = ["/a/the-greens", "/a/zieloni", "/a/chwasty"]
 authors = ["Sewi The Referee"]
 [extra]
 toclevel = 3


### PR DESCRIPTION
this is sort of an easter egg, since this page was never called that, and we only ever have "weeds" in Puncher's article.