### PR TITLE
MZW Green Madness - jeszcze tyci drobiażdżek

### DIFF
--- a/content/e/mzw/2025-06-28-mzw-green-madness-gallery.toml
+++ b/content/e/mzw/2025-06-28-mzw-green-madness-gallery.toml
@@ -40,5 +40,5 @@
 8009 = { path = "mister-z-walizką.webp", caption = "[Mister Z](@/w/mister-z.md) wins the briefcase; [Adrian Zgórski](@/w/adrian-zgorski.md) stands in the background.", source = "M3n747" }
 8010 = { path = "arona-odwiazuja.webp", caption = "Referees Seweryn and Kornel untie Aron Wake, who's being attended to by a medical staff member.", source = "M3n747" }
 9001 = { path = "walizka.webp", caption = "The championship contract hanging above the ring, waiting for the show to start.", source = "M3n747" }
-9002 = { path = "oskar-i-martyna.webp", caption = "[Oskar Aleksander](@/w/oskar-aleksander.md) and Istotna Martynka after the show.", source = "Istotna Martynka" }
+9002 = { path = "oskar-i-martyna.webp", caption = "Istotna Martynka and [Oskar Aleksander](@/w/oskar-aleksander.md) after the show.", source = "Istotna Martynka" }
 9003 = { path = "auuuu.webp", caption = "[Goblin](@/w/goblin.md) with a fan.", source = "Istotna Martynka." }


### PR DESCRIPTION
Żeby kolejność imion pasowała do zdjęcia, od lewej do prawej.