### PR TITLE
Migrate to cf workers

### DIFF
--- a/bin/cf-build.sh
+++ b/bin/cf-build.sh
@@ -1,11 +1,19 @@
 #! /bin/bash
 # set -x
 
+install_zola() {
+	asdf plugin add zola https://github.com/salasrod/asdf-zola
+	asdf install zola 0.20.0
+	asdf global zola 0.20.0
+}
+
 lint() {
     bin/lint || true
 }
 
 create_config() {
+  # This env setup step is useless now - these variables aren't exposed to workers,
+  # and there is no replacement. base_url should be set to '/' always
   case $CF_PAGES_BRANCH in
       main)
           export BASE_URL=$PRODUCTION_URL
@@ -48,6 +56,7 @@ build() {
 }
 
 lint
+install_zola
 create_config
 setup_seo
 build

--- a/cloudflare-config.toml
+++ b/cloudflare-config.toml
@@ -1,5 +1,5 @@
 # The URL the site will be built for
-base_url = "${BASE_URL}"
+base_url = "/"
 
 # Whether to automatically compile all Sass files in the sass directory
 compile_sass = true
@@ -35,7 +35,7 @@ paths_keep_dates = true
 
 [extra]
 # Put all your custom variables here
-new_issue_url = "https://github.com/k3rni/teczki-polskiego-wrestlingu/issues/new"
+new_issue_url = "https://github.com/tpwres/teczki-polskiego-wrestlingu/issues/new"
 
 # Display matchfinder links next to unlinked names in roster pages
 mf_links_in_roster = true

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,8 @@
+name = 'tpw2025'
+compatibility_date = '2025-06-18'
+preview_urls = true
+
+[assets]
+directory = './public'
+not_found_handling = '404-page'
+html_handling = 'auto-trailing-slash'


### PR DESCRIPTION
- [ ] Verify calendar files are served with correct mimetype. For the original site, this was done with some response header rules, may not apply now
- [ ] Sitemap needs full urls. 


Check if WORKERS_CI_BRANCH ([docs](https://developers.cloudflare.com/workers/ci-cd/builds/configuration/)) does the job. Add the suffix as a variable in cf, and concatenate the two when building sitemap