### PR TITLE
Arena 28 - mały update

### DIFF
--- a/content/e/kpw/2025-04-11-kpw-arena-28.md
+++ b/content/e/kpw/2025-04-11-kpw-arena-28.md
@@ -45,7 +45,7 @@ This show featured two championship fights - a Street Fight between [Chemik](@/w
   - '[Greg](@/w/greg.md)'
   - '[Leon Lato](@/w/leon-lato.md)'
   - '[Piotr Opolski](@/w/piotr-opolski.md)'
-  - '[Referee Kinga](@/w/kinga-miotke.md)'
+  - '[Sędzia Kinga](@/w/kinga-miotke.md)'
   - '[Krystian Malinowski](@/w/krystian-malinowski.md)'
   - g: Induction of the new KPW chairman
 - - '[Hans Schulte](@/w/hans-schulte.md)(c)'

--- a/content/w/kinga-miotke.md
+++ b/content/w/kinga-miotke.md
@@ -33,7 +33,7 @@ At first, she appeared under the ring name "Kinga Różańska", but beginning wi
 She is the first and, as of 2025, only female announcer on the Polish wrestling scene.
 
 After [Rosetti](@/w/rosetti.md) took over KPW as "acting chairman", he enforced numerous changes starting from [KPW Arena 27](@/e/kpw/2025-01-24-kpw-arena-27.md).
-Kinga was relieved of her ring announcing duties, and replaced by [Piotr Opolski](@/w/piotr-opolski.md). Instead, she was appointed the referee for the show, while [Krystian Czekaj](@/w/krystian-czekaj.md) (KPW's usual official) was demoted to the role of technical referee and timekeeper.
+Kinga was relieved of her ring announcing duties, and replaced by [Piotr Opolski](@/w/piotr-opolski.md). Instead, she was appointed the referee for the show, while [Krystian Czekaj](@/w/krystian-czekaj.md) (KPW's usual official) was demoted to the role of technical referee and timekeeper. This was a brief stint, however, as Kinga returned to her usual role with [Arena 29](@/e/kpw/2025-06-20-kpw-arena-29.md).
 
 ## In wrestling
 

--- a/content/w/kinga-miotke.md
+++ b/content/w/kinga-miotke.md
@@ -30,7 +30,7 @@ Kinga Miotke is a Polish ring announcer and on-screen personality currently work
 Kinga started out as a trainee in KPW's wrestling school, but had to abandon her trainings due to a neck injury.
 Instead of becoming a wrestler, she would conduct backstage interviews and with fans after shows, and eventually she'd take on her role as the ring announcer, starting with [Arena 14](@/e/kpw/2019-06-15-kpw-arena-14.md), taking over from [Arek Pawłowski](@/w/pan-pawlowski.md) who left after [Arena 13](@/e/kpw/2019-04-05-kpw-arena-13.md).
 At first, she appeared under the ring name "Kinga Różańska", but beginning with [Godzina Zero 2022](@/e/kpw/2022-09-17-kpw-godzina-zero-2022.md) she started using her real name, Kinga Miotke.
-She is the first and, as of 2025, only female announcer on the Polish wrestling scene.
+She is the first and, as of 2025, the only female announcer on the Polish wrestling scene.
 
 After [Rosetti](@/w/rosetti.md) took over KPW as "acting chairman", he enforced numerous changes starting from [KPW Arena 27](@/e/kpw/2025-01-24-kpw-arena-27.md).
 Kinga was relieved of her ring announcing duties, and replaced by [Piotr Opolski](@/w/piotr-opolski.md). Instead, she was appointed the referee for the show, while [Krystian Czekaj](@/w/krystian-czekaj.md) (KPW's usual official) was demoted to the role of technical referee and timekeeper. This was a brief stint, however, as Kinga returned to her usual role with [Arena 29](@/e/kpw/2025-06-20-kpw-arena-29.md).


### PR DESCRIPTION
Wszędzie na stronie w kartach mamy sędziów po polsku, w tym jednym przypadku było po angielsku - raz, że niekonsekwentnie, a dwa, że przez to były dwa osobne wpisy z linkiem do tej samej gali na liście osób.