### PR TITLE
Autodiscover gallery manifest

### DIFF
--- a/content/a/tuba-jednosci-wrestlingowej.md
+++ b/content/a/tuba-jednosci-wrestlingowej.md
@@ -4,7 +4,6 @@ template = "article.html"
 weight = 0
 authors = ["M3n747"]
 [extra.gallery]
-manifest = "@/a/tuba-jednosci-wrestlingowej-gallery.toml"
 +++
 
 "Tuba Jedności Wrestlingowej" (_The Tube of Wrestling Unity_) is a cardboard tube signed by multiple people (wrestlers and otherwise) from the Polish wrestling scene.

--- a/content/e/ppw/2025-09-20-ppw-mistrzowskie-rozdanie-2.md
+++ b/content/e/ppw/2025-09-20-ppw-mistrzowskie-rozdanie-2.md
@@ -9,7 +9,6 @@ venue=["hala-labo"]
 city = "Warszawa"
 toclevel = 2
 [extra.gallery]
-manifest = "@/e/ppw/2025-09-20-ppw-mistrzowskie-rozdanie-2-gallery.toml"
 +++
 
 Mistrzowskie Rozdanie 2 (roughly _A Champion's Hand 2_) is an upcoming show by [PpW Ewenement Wrestling](@/o/ppw.md), and an apparent "sequel" to [a show from 2023](@/e/ppw/2023-05-06-ppw-mistrzowskie-rozdanie.md). It'll be set in [Mińska&nbsp;65's](@/v/minska-65.md) _Hala Labo_.

--- a/templates/article.html
+++ b/templates/article.html
@@ -2,7 +2,7 @@
 {%- import "macros/career.html" as macros %}
 
 {% block content %}
-{% if page.extra.gallery -%}{% set has_gallery = true %}{% endif %}
+{% if page.extra.gallery is defined -%}{% set has_gallery = true %}{% endif %}
 
 <h1>{{ page.title }}</h1>
 
@@ -12,7 +12,7 @@
 
 {{ page.content | safe }}
 
-{% if page.extra.gallery -%}
+{% if page.extra.gallery is defined -%}
   {% include "shared/auto_lightbox_dialog.html" -%}
 {% endif -%}
 {% endblock content %}

--- a/templates/event_page.html
+++ b/templates/event_page.html
@@ -19,7 +19,7 @@
 
 {{ page.content | safe }}
 
-{% if page.extra.gallery -%}
+{% if page.extra.gallery is defined -%}
   {% include "shared/auto_lightbox_dialog.html" -%}
 {% endif -%}
 

--- a/templates/macros/articles.html
+++ b/templates/macros/articles.html
@@ -1,10 +1,23 @@
 {% macro cover(article) %}
   <div class="cover-image">
-    {% if article.extra.gallery %}
+    {% if article.extra.gallery is defined %}
       {% if article.extra.gallery.manifest %}
-        {% set gallery_items = load_data(path=article.extra.gallery.manifest) %}
-      {% else %}
-        {% set gallery_items = article.extra.gallery %}
+        {% set manifest_location = article.extra.gallery.manifest %}
+        {% set gallery_items = load_data(path=manifest_location) %}
+      {% else %}{# Manifest unset, try autodiscovering it. #}
+        {% set manifest_location = '@/' ~ article.relative_path | replace(from='.md', to='.toml') %}
+        {% set manifest_items = load_data(path=manifest_location, required=false) %}
+        {% if manifest_items %}
+            {% set gallery_items = manifest_items %}
+        {% endif %}
+        {% set manifest_location = '@/' ~ article.relative_path | replace(from='.md', to='-gallery.toml') %}
+        {% set manifest_items = load_data(path=manifest_location, required=false) %}
+        {% if manifest_items %}
+            {% set gallery_items = manifest_items %}
+        {% endif %}
+        {% if not gallery_items %}
+            {% set gallery_items = article.extra.gallery %}
+        {% endif %}
       {% endif %}
       {% set root = config.extra.gallery_root ~ article.path ~ "tn/" %}
       {% for key, item in gallery_items %}

--- a/templates/org_page.html
+++ b/templates/org_page.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 {# NOTE: must be in block content #}
-{% if page.extra.gallery -%}{% set has_gallery = true %}{% endif %}
+{% if page.extra.gallery is defined -%}{% set has_gallery = true %}{% endif %}
 {% if not page.extra.hide_events -%}{% set has_events = true %}{% endif %}
 {% if not page.extra.hide_roster -%}{% set has_roster = true %}{% endif %}
 

--- a/templates/shared/auto_lightbox_dialog.html
+++ b/templates/shared/auto_lightbox_dialog.html
@@ -1,11 +1,27 @@
 {% set root = config.extra.gallery_root ~ page.path %}
 {% set sprite = get_url(path="lucide-sprite.svg", trailing_slash=false) %}
 {% set empty_obj = []|group_by(attribute='0') %}
+{# NOTE: This logic is repeated in articles.html macro, and in og_gallery_extractor.html #}
 {% if page.extra.gallery.manifest %}
-  {% set gallery_items = load_data(path=page.extra.gallery.manifest) %}
-{% else %}
-  {% set gallery_items = page.extra | get(key='gallery', default=empty_obj) %}
+  {% set manifest_location = page.extra.gallery.manifest %}
+  {% set gallery_items = load_data(path=manifest_location) %}
+{% else %}{# Manifest unset. Try autodiscovering it. #}
+    {% set manifest_location = '@/' ~ page.relative_path | replace(from='.md', to='.toml') %}
+    {% set manifest_items = load_data(path=manifest_location, required=false) %}
+    {% if manifest_items %}
+        {% set gallery_items = manifest_items %}
+    {% endif %}
+    {% set manifest_location = '@/' ~ page.relative_path | replace(from='.md', to='-gallery.toml') %}
+    {% set manifest_items = load_data(path=manifest_location, required=false) %}
+    {% if manifest_items %}
+        {% set gallery_items = manifest_items %}
+    {% endif %}
 {% endif %}
+
+{% if not gallery_items %}
+    {% set gallery_items = page.extra | get(key='gallery', default=empty_obj) %}
+{% endif %}
+
 {% if use_extra_gallery %}
   {% set all_photos = load_data(path='data/all_photos.json') %}
   {% set photo_taggings = load_data(path='data/photo_taggings.json') %}

--- a/templates/shared/og_gallery_extractor.html
+++ b/templates/shared/og_gallery_extractor.html
@@ -1,6 +1,18 @@
 {% if page.extra.gallery.manifest %}
   {% set gallery_items = load_data(path=page.extra.gallery.manifest) %}
-{% else %}
+{% else %}{# Manifest unset. Try autodiscovering it. #}
+    {% set manifest_location = '@/' ~ page.relative_path | replace(from='.md', to='.toml') %}
+    {% set manifest_items = load_data(path=manifest_location, required=false) %}
+    {% if manifest_items %}
+        {% set gallery_items = manifest_items %}
+    {% endif %}
+    {% set manifest_location = '@/' ~ page.relative_path | replace(from='.md', to='-gallery.toml') %}
+    {% set manifest_items = load_data(path=manifest_location, required=false) %}
+    {% if manifest_items %}
+        {% set gallery_items = manifest_items %}
+    {% endif %}
+{% endif %}
+{% if not gallery_items %}
   {% set gallery_items = page.extra.gallery %}
 {% endif %}
 {% set root = config.extra.gallery_root ~ page.path %}

--- a/templates/venue_page.html
+++ b/templates/venue_page.html
@@ -13,7 +13,7 @@
 <h2>Events</h2>
 {% include "venue/events_from_taxonomy.html" %}
 
-{% if page.extra.gallery -%}
+{% if page.extra.gallery is defined -%}
   {% include "shared/auto_lightbox_dialog.html" -%}
 {% endif -%}
 

--- a/themes/web/templates/base.html
+++ b/themes/web/templates/base.html
@@ -31,7 +31,7 @@
       {% elif page.summary -%}
         <meta property="og:description" content="{{ page.summary | striptags }}" />
       {% endif -%}
-      {% if page.extra.gallery -%}
+      {% if page.extra.gallery is defined -%}
         {% include "shared/og_gallery_extractor.html" -%}
       {% else %}
         <meta property="og:image" content="{{ get_url(path='og-default.png') }}" />


### PR DESCRIPTION
Resolves #1747, using both suggested filenames. Tuba and MR2 had their explicit manifest line removed to test the functionality.

Note however, the page still needs to have an empty `[extra.gallery]` section for this to work.

Testing: check that both pages still have their gallery. For MR2 also check that its photos get added to the generated `all_photos.json` which Art consumes - but that's not testable with Art itself. Checked manually by doing a local build.