### PR TITLE
Foto GCSu, polskie nazwy lokali

### DIFF
--- a/content/e/kpw/2015-12-11-kpw-ggf.md
+++ b/content/e/kpw/2015-12-11-kpw-ggf.md
@@ -3,7 +3,7 @@ title = "KPW @ Gdynia Game Festival"
 template = "event_page.html"
 [taxonomies]
 chronology = ["kpw"]
-venue=["gdynia-sports-center"]
+venue=["gdynskie-centrum-sportu"]
 [extra]
 city = "Gdynia"
 toclevel = 2

--- a/content/e/kpw/2016-08-13-kpw-godzina-zero-2016.md
+++ b/content/e/kpw/2016-08-13-kpw-godzina-zero-2016.md
@@ -3,7 +3,7 @@ title = "KPW Godzina Zero 2016"
 template = "event_page.html"
 [taxonomies]
 chronology = ["kpw", "godzina-zero"]
-venue=["gdynia-sports-center"]
+venue=["gdynskie-centrum-sportu"]
 [extra]
 city = "Gdynia"
 toclevel = 2

--- a/content/e/kpw/2017-08-12-kpw-godzina-zero-2017.md
+++ b/content/e/kpw/2017-08-12-kpw-godzina-zero-2017.md
@@ -3,7 +3,7 @@ title = "KPW Godzina Zero 2017"
 template = "event_page.html"
 [taxonomies]
 chronology = ["kpw", "godzina-zero"]
-venue=["gdynia-sports-center"]
+venue=["gdynskie-centrum-sportu"]
 [extra]
 city = "Gdynia"
 toclevel = 2

--- a/content/e/kpw/2017-11-18-kpw-arena-8.md
+++ b/content/e/kpw/2017-11-18-kpw-arena-8.md
@@ -4,7 +4,7 @@ template = "event_page.html"
 aliases = ["/e/kpw/2017-11-18-kpw-arena-8-droga-bez-powrotu"]
 [taxonomies]
 chronology = ["kpw", "arena"]
-venue=["gdynia-sports-center"]
+venue=["gdynskie-centrum-sportu"]
 [extra]
 city = "Gdynia"
 toclevel = 2

--- a/content/e/kpw/2018-05-26-kpw-arena-x.md
+++ b/content/e/kpw/2018-05-26-kpw-arena-x.md
@@ -4,7 +4,7 @@ template = "event_page.html"
 aliases = ["/e/kpw/2018-05-26-kpw-arena-x-kawaleria-vs-sojusz"]
 [taxonomies]
 chronology = ["kpw", "arena"]
-venue=["gdynia-sports-center"]
+venue=["gdynskie-centrum-sportu"]
 [extra]
 city = "Gdynia"
 toclevel = 2

--- a/content/e/kpw/2018-08-11-kpw-godzina-zero-2018.md
+++ b/content/e/kpw/2018-08-11-kpw-godzina-zero-2018.md
@@ -3,7 +3,7 @@ title = "KPW Godzina Zero 2018"
 template = "event_page.html"
 [taxonomies]
 chronology = ["kpw", "godzina-zero"]
-venue=["gdynia-sports-center"]
+venue=["gdynskie-centrum-sportu"]
 [extra]
 city = "Gdynia"
 toclevel = 2

--- a/content/e/kpw/2018-11-03-kpw-arena-11.md
+++ b/content/e/kpw/2018-11-03-kpw-arena-11.md
@@ -4,7 +4,7 @@ template = "event_page.html"
 aliases = ["/e/kpw/2018-11-03-kpw-arena-11-podwojne-zagrozenie"]
 [taxonomies]
 chronology = ["kpw", "arena"]
-venue=["gdynia-sports-center"]
+venue=["gdynskie-centrum-sportu"]
 [extra]
 city = "Gdynia"
 toclevel = 2

--- a/content/e/kpw/2019-01-19-kpw-arena-12.md
+++ b/content/e/kpw/2019-01-19-kpw-arena-12.md
@@ -4,7 +4,7 @@ template = "event_page.html"
 aliases = ["/e/kpw/2019-01-19-kpw-arena-12-gwiazda-polnocy"]
 [taxonomies]
 chronology = ["kpw", "arena"]
-venue=["gdynia-sports-center"]
+venue=["gdynskie-centrum-sportu"]
 [extra]
 city = "Gdynia"
 toclevel = 2

--- a/content/e/kpw/2019-04-05-kpw-arena-13.md
+++ b/content/e/kpw/2019-04-05-kpw-arena-13.md
@@ -4,7 +4,7 @@ template = "event_page.html"
 aliases = ["/e/kpw/2019-04-05-kpw-arena-13-capo-di-tutti-capi"]
 [taxonomies]
 chronology = ["kpw", "arena"]
-venue=["gdynia-sports-center"]
+venue=["gdynskie-centrum-sportu"]
 [extra]
 city = "Gdynia"
 toclevel = 2

--- a/content/e/kpw/2019-08-17-kpw-godzina-zero-2019.md
+++ b/content/e/kpw/2019-08-17-kpw-godzina-zero-2019.md
@@ -3,7 +3,7 @@ title = "KPW Godzina Zero 2019"
 template = "event_page.html"
 [taxonomies]
 chronology = ["kpw", "godzina-zero"]
-venue=["gdynia-sports-center"]
+venue=["gdynskie-centrum-sportu"]
 [extra]
 city = "Gdynia"
 toclevel = 2

--- a/content/e/kpw/2019-11-16-kpw-arena-15.md
+++ b/content/e/kpw/2019-11-16-kpw-arena-15.md
@@ -4,7 +4,7 @@ template = "event_page.html"
 aliases = ["/e/kpw/2019-11-16-kpw-arena-15-swieza-krew"]
 [taxonomies]
 chronology = ["kpw", "arena"]
-venue=["gdynia-sports-center"]
+venue=["gdynskie-centrum-sportu"]
 [extra]
 city = "Gdynia"
 toclevel = 2

--- a/content/e/kpw/2020-02-01-kpw-arena-16.md
+++ b/content/e/kpw/2020-02-01-kpw-arena-16.md
@@ -4,7 +4,7 @@ template = "event_page.html"
 aliases = ["/e/kpw/2020-02-01-kpw-arena-16-polowanie"]
 [taxonomies]
 chronology = ["kpw", "arena"]
-venue=["gdynia-sports-center"]
+venue=["gdynskie-centrum-sportu"]
 [extra]
 city = "Gdynia"
 toclevel = 2

--- a/content/e/kpw/2021-08-21-kpw-arena-17.md
+++ b/content/e/kpw/2021-08-21-kpw-arena-17.md
@@ -4,7 +4,7 @@ template = "event_page.html"
 aliases = ["/e/kpw/2021-08-21-kpw-arena-17-odrodzenie"]
 [taxonomies]
 chronology = ["kpw", "arena"]
-venue=["gdynia-sports-center"]
+venue=["gdynskie-centrum-sportu"]
 [extra]
 city = "Gdynia"
 toclevel = 2

--- a/content/o/kpw.md
+++ b/content/o/kpw.md
@@ -27,7 +27,7 @@ The two cities are more than 600&nbsp;km apart, and the team in Gdańsk began to
 
 That team, consisting of several DDW alumni, bought the ring and - after some deliberations regarding the name, with "White Eagle Wrestling" also being considered - relaunched themselves as Kombat Pro Wrestling. Their first event, [KPW vs the World](@/e/kpw/2015-11-14-kpw-vs-the-world-hungary-for-kombat.md), was held in the exact same venue as [DDW's final event proper](@/e/ddw/2015-05-02-ddw-house-show-2.md) (not counting their [appearance at a convention](@/e/ddw/2015-07-24-ddw-baltikon.md) two months later). Thus KPW is the direct descendant of Do Or Die Wrestling.
 
-In 2016 they would relocate to Gdynia, holding their shows in a recently reopened [music club](@/v/atlantic-nh-gdynia.md). That year, KPW held the first [Godzina Zero](@/e/kpw/2016-08-13-kpw-godzina-zero-2016.md), which would later become their annual supershow, where all championships were defended. 2017 saw them move to a bigger venue in the [Gdynia Sports Center](@/v/gdynia-sports-center.md), securing support from the city.
+In 2016 they would relocate to Gdynia, holding their shows in a recently reopened [music club](@/v/atlantic-nh-gdynia.md). That year, KPW held the first [Godzina Zero](@/e/kpw/2016-08-13-kpw-godzina-zero-2016.md), which would later become their annual supershow, where all championships were defended. 2017 saw them move to a bigger venue in [Gdyńskie Centrum Sportu](@/v/gdynskie-centrum-sportu.md), securing support from the city.
 
 #### 2020: COVID and losing talent to PTW
 

--- a/content/v/2kola.md
+++ b/content/v/2kola.md
@@ -1,5 +1,5 @@
 +++
-title = "2KOŁA Motorcycle Club"
+title = "2KOŁA Pub Motocyklowy"
 template = "venue_page.html"
 [extra]
 year_list_start = 2019
@@ -8,7 +8,7 @@ coordinates = '52.221859,20.969030'
 orgs = ['ppw']
 +++
 
-2KOŁA (_2WHEELS_) is a motorcycle bar and event venue in Warsaw. It's the first venue to host events by [PpW Ewenement](@/o/ppw.md).
+2KOŁA (_2WHEELS_) is a motorcycle pub and event venue in Warsaw. It's the first venue to host events by [PpW Ewenement](@/o/ppw.md).
 
 The bar opened in 1998. It is dedicated to biker culture, and decorated in an American biker bar style. A prominent feature is the wall of death: a wooden, curved wall with a horizontally mounted motorcycle, replicating this classic sideshow attraction. Below this wall is a small stage, often used for music performances, chiefly - but not exclusively - rock, hard rock and metal.
 

--- a/content/v/_index.md
+++ b/content/v/_index.md
@@ -14,13 +14,13 @@ template = "index.html"
 ### Tricity area
 
 * [Atlantic / Nowy Harem](@/v/atlantic-nh-gdynia.md) {{ org_badge(org='kpw') }}
-* [Gdynia Sports Center](@/v/gdynia-sports-center.md) {{ org_badge(org='kpw') }}
+* [Gdyńskie Centrum Sportu](@/v/gdynskie-centrum-sportu.md) {{ org_badge(org='kpw') }}
 * [Gimnazjum nr 8](@/v/gimnazjum-8-gdansk.md) {{ org_badge(orgs=['ddw', 'kpw']) }}
 * [Stocznia Gdańska](@/v/stocznia-gdanska.md) {{ org_badge(orgs=['kpw', 'ppw']) }}
 
 ### Warsaw
 
-* [2KOŁA Motorcycle Club](@/v/2kola.md) {{ org_badge(org='ppw') }}
+* [2KOŁA Pub Motocyklowy](@/v/2kola.md) {{ org_badge(org='ppw') }}
 * [Hala Bemowo](@/v/hala-bemowo.md) {{ org_badge(org='ptw') }}
 * [Mińska 65](@/v/minska-65.md) {{ org_badge(org='ppw') }}
 * [Praga Centrum](@/v/praga-centrum.md) {{ org_badge(org='ppw') }}
@@ -37,5 +37,5 @@ template = "index.html"
 
 ### Others
 
-* [Poznań International Fair](@/v/targi-poznan.md) {{ org_badge(orgs=['kpw', 'ppw']) }}
+* [Międzynarodowe Targi Poznańskie](@/v/targi-poznan.md) {{ org_badge(orgs=['kpw', 'ppw']) }}
 * [Tauron Arena Kraków](@/v/tauron-arena.md) {{ org_badge(orgs=['ptw', 'low']) }}

--- a/content/v/atlantic-nh-gdynia.md
+++ b/content/v/atlantic-nh-gdynia.md
@@ -41,7 +41,7 @@ However, after a few months they decided to lease the building to a new tenant, 
 
 #### KPW's return
 
-Between 2018 and 2021 KPW did not use the location, as they had a bigger venue to host their shows: the [Hall Of Games](@/v/gdynia-sports-center.md). In 2022 they returned to the club and since then held most events in there, starting from [Arena 18](@/e/kpw/2022-03-18-kpw-arena-18.md)
+Between 2018 and 2021 KPW did not use the location, as they had a bigger venue to host their shows: the [Hall Of Games](@/v/gdynskie-centrum-sportu.md). In 2022 they returned to the club and since then held most events in there, starting from [Arena 18](@/e/kpw/2022-03-18-kpw-arena-18.md)
 (excluding shows in other cities, such as [Pyrkon](@/e/kpw/2022-06-18-kpw-pyrkon-2022.md) in Poznań).
 
 ### References

--- a/content/v/gdynskie-centrum-sportu.md
+++ b/content/v/gdynskie-centrum-sportu.md
@@ -1,10 +1,13 @@
 +++
-title = "Gdynia Sports Center"
+title = "Gdyńskie Centrum Sportu"
 template = "venue_page.html"
+aliases = ["/v/gdynia-sports-center"]
 [extra.geo]
 coordinates = '54.495277/18.532164'
 type = 'historical-venue'
 orgs = ['kpw']
+[extra.gallery]
+1 = { path = "gcs-2025.webp", caption = "Outside view of the venue, as seen in mid-2025.", source = "M3n747" }
 +++
 
 Gdyńskie Centrum Sportu (_Gdynia Sports Center_) is a complex of sports facilities located in Gdynia, as well as the name of the city government's subdivision overseeing these facilities. Those include the football stadium used by Arka Gdynia, the multipurpose Gdynia Arena hall most known for hosting volleyball, and the National Rugby Stadium.

--- a/content/v/targi-poznan.md
+++ b/content/v/targi-poznan.md
@@ -1,5 +1,5 @@
 +++
-title = "Targi Poznań"
+title = "Międzynarodowe Targi Poznańskie"
 template = "venue_page.html"
 [taxonomies]
 chrono_root = ["targi-poznan"]


### PR DESCRIPTION
- Nazwy GCSu, 2Kół i Targów Poznańskich z angielskiego na polski, żeby było konsekwentnie.
- Foto GCSu, alias do starej nazwy.
- 2KOŁA zmieniłem z klubu na pub (tylko w teczce lokalu) - Google zwraca różne wersje nazwy, wybrałem tę najbliższą ich oficjalnemu Facebookowi.