### PR TITLE
Gallery in TOC for events with implicit manifest

### DIFF
--- a/templates/event_page.html
+++ b/templates/event_page.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block content %}
-{% if page.extra.gallery -%}{% set has_gallery = true %}{% endif %}
+{% if page.extra.gallery is defined -%}{% set has_gallery = true %}{% endif %}
 
 <span class="event-date-location">
   <time class="event-date">{{ page.date }}</time>


### PR DESCRIPTION
Make toc gallery link generate also for event galleries with implicit manifests (#1766). If it has a gallery section in the frontmatter, toc will include Gallery.

Fixes #1851 

Testing: one such event is GZ2025. Compare with live site.