### PR TITLE
Die Ordnung Zwei Punkt Null: accept dots in team names

### DIFF
--- a/src/card.py
+++ b/src/card.py
@@ -236,7 +236,7 @@ class Match:
     def parse_partners(cls, partners: list[str]) -> Iterable[Union[Participant, Team]]:
         return [t for p in partners if (t := cls.parse_maybe_team(p))]
 
-    plain_name_re = r"[-'\w\s]+"
+    plain_name_re = r"[-.'\w\s]+"
     team_link_re = rf'''
         \[(?P<label>{plain_name_re})\] # Square brackets surround link text
         \((?P<target>.*?)\) # Then, parentheses surround link target


### PR DESCRIPTION
In general, the regex for capturing team name (inside a link target or not) is more restrictive than for individual names. Not sure why but there probably was a reason for that.