### PR TITLE
Drop the Inter font

### DIFF
--- a/themes/web/sass/_typography.sass
+++ b/themes/web/sass/_typography.sass
@@ -7,7 +7,7 @@
 // Global variables
 \:root
   // Fonts
-  --sans-font: "Twemoji Country Flags", "Inter", sans-serif
+  --sans-font: "Twemoji Country Flags", "Noto Sans", sans-serif
   --mono-font: "Ubuntu Mono", monospace
 
 html


### PR DESCRIPTION
New device which actually had Inter preloaded, site doesn't look good because it selects the thinnest variant possible. As we're used to the sans-serif look, replacing Inter with Noto Sans and keeping whatever default sans-serif the browser has as fallback.

A followup should be to update styles in all the sub-sites too.