### PR TITLE
Back to the OG - bez linków pod plakatem

### DIFF
--- a/content/e/ppw/2023-02-04-ppw-back-to-the-og.md
+++ b/content/e/ppw/2023-02-04-ppw-back-to-the-og.md
@@ -9,7 +9,7 @@ city = "Warszawa"
 toclevel = 2
 [extra.gallery.1]
 path = "2023-02-04-ppw-back-to-the-og-plakat.jpg"
-caption = "Official banner, showing a scene from [Mistrz Jest Tylko Jeden](@/e/ppw/2022-03-12-ppw-mistrz-jest-tylko-jeden.md), with [Rob Scaffold](@/w/rob-scaffold.md) and Biesiad perched on turnbuckles, ready to jump onto tables laid out with [Mister Z](@/w/mister-z.md) and [Johnny Blade](@/w/johnny-blade.md)."
+caption = "Official banner, showing a scene from [Mistrz Jest Tylko Jeden](@/e/ppw/2022-03-12-ppw-mistrz-jest-tylko-jeden.md), with Rob Scaffold (left) and Biesiad (right) perched on turnbuckles, ready to jump onto Mister Z and Johnny Blade laid out on tables."
 source = "Official PpW Facebook"
 [extra.gallery.2]
 path = "2023-02-04-ppw-back-to-the-og-plakat-blade.jpg"


### PR DESCRIPTION
Nie widać kto jest kim, więc linki są bezzasadne. Dodatkowo trochę przebudowane zdanie dla lepszego brzmienia i sensu.