### PR TITLE
Two-row topnav

### DIFF
--- a/themes/web/sass/_hamburger.sass
+++ b/themes/web/sass/_hamburger.sass
@@ -60,6 +60,7 @@
         li
           margin: 0.5rem 0
           font-size: 1.5rem
+          flex: 1 0
 
           a svg.feather-nav
             width: 2.25rem

--- a/themes/web/sass/_nav.sass
+++ b/themes/web/sass/_nav.sass
@@ -65,8 +65,12 @@ nav.level2
       display: flex
       flex-wrap: wrap
       justify-content: flex-start
+
       li
         white-space: nowrap
+        flex-basis: 20%
+        @media only screen and (max-width: 896px)
+          flex-basis: 25%
 
 .logo
   display: inline-block


### PR DESCRIPTION
We have 10 items in the top navigation, and have since given up on trying to fit them in a single row. Right now the elements spill to the second row freely based on available space.

This PR changes it so that there are two or more rows with regularly spaced items:

- by default, 5 items per row
- for narrower screens, at an unusual (eye-balled) breakpoint of 896px we go to 4 items per row and 3 rows
- which remains until a breakpoint of 720px when the whole menu is replaced with the hamburger

This is for TPW only and needs to be replicated to the subdomains separately.