### PR TITLE
Świąt nie będzie - ampersand w nazwie TT

### DIFF
--- a/content/e/ptw/2025-12-13-ptw-swiat-nie-bedzie.md
+++ b/content/e/ptw/2025-12-13-ptw-swiat-nie-bedzie.md
@@ -39,7 +39,7 @@ toclevel = 2
   - '[Arkadiusz Pawłowski](@/w/pan-pawlowski.md)'
   - g: Łukasz Okoński announces Miyagi Sigma #1 Tag Team Contenders Match, gets interrpunted by Pawłowski.
 - - 'Miyagi Sigma: [Miyagi Shida](@/w/miyagi-shida.md) & [Sigma Boy xD](@/w/sigma-boy.md)'
-  - 'Drop &amp; Bump: Dropper & Bumper'
+  - 'Drop \u0026 Bump: Dropper & Bumper'
   - '[Blaze](@/w/blaze.md) & Bart Petro'
   - s: Triple Threat Tag Team Match
 - - '[Damian Lambert](@/w/damien-rothschild.md)'


### PR DESCRIPTION
Ampersand w nazwie TT powoduje traktowanie nazwy drużyny jak dwóch osobnych osób:

<img width="473" height="288" alt="image" src="https://github.com/user-attachments/assets/bb9ecf06-2f95-4249-a89e-3c120b2ecbb9" />

Być może da radę jakoś wyszlifować, żeby ignorowało `&` przed `:`? Patrz: #2282.