### PR TITLE
Add Tokyo show to PpW's chronology and see if it works

### DIFF
--- a/content/a/ppw-hardcore-friday-the-13th-tokyo.md
+++ b/content/a/ppw-hardcore-friday-the-13th-tokyo.md
@@ -1,6 +1,6 @@
 +++
 title = "PpW Hardcore Friday the 13th 東京"
-template = "article.html"
+template = "event_page.html"
 weight = 0
 authors = ["M3n747"]
 [taxonomies]


### PR DESCRIPTION
It does work, listing the article page after Dwa Na Dwa; after swapping templates it also has a timeline paginator itself. But do we want it there?