### PR TITLE
Use browser default sans-serif only

### DIFF
--- a/themes/web/sass/_typography.sass
+++ b/themes/web/sass/_typography.sass
@@ -1,13 +1,7 @@
-//@import "fonts/inter/inter-web/inter.css"
-// @font-face
-//   font-family: 'Ubuntu Mono'
-//   src: url("fonts/ubuntu-mono/UbuntuMono-Regular.ttf")
-//   font-display: swap
-
 // Global variables
 \:root
   // Fonts
-  --sans-font: "Twemoji Country Flags", "Noto Sans", sans-serif
+  --sans-font: "Twemoji Country Flags", sans-serif
   --mono-font: "Ubuntu Mono", monospace
 
 html


### PR DESCRIPTION
Closes #1997. This implements the proposal to completely do away with Noto Sans, and use the browser-default sans serif font.