### PR TITLE
Łańcuch vs Stół

### DIFF
--- a/content/c/ppw-championship.md
+++ b/content/c/ppw-championship.md
@@ -296,7 +296,7 @@ Immediately after Biesiad won the title match at Ledwo Legalne IV, Mister Z gran
     en: '[PpW Hardcore Na Hucie](@/e/ppw/2026-04-25-ppw-hardcore-na-hucie.md)'
     ed: 2026-04-25
 - - '"Chain God" Olgierd (c)'
-  - '"Polski Cieśla" Biesiad Strong"
+  - '"Polski Cieśla" Biesiad Strong'
   - s: Singles Match
     en: '[PpW Ledwo Legalne 6](@/e/ppw/2026-05-16-ppw-ledwo-legalne-6.md)'
     ed: 2026-05-16

--- a/content/c/ppw-championship.md
+++ b/content/c/ppw-championship.md
@@ -295,9 +295,13 @@ Immediately after Biesiad won the title match at Ledwo Legalne IV, Mister Z gran
   - s: Dog Collar Match
     en: '[PpW Hardcore Na Hucie](@/e/ppw/2026-04-25-ppw-hardcore-na-hucie.md)'
     ed: 2026-04-25
+- - '"Chain God" Olgierd (c)'
+  - '"Polski Cieśla" Biesiad Strong"
+  - s: Singles Match
+    en: '[PpW Ledwo Legalne 6](@/e/ppw/2026-05-16-ppw-ledwo-legalne-6.md)'
+    ed: 2026-05-16
+    nc: upcoming
 {% end %}
-
-Olgierd also defended the title at a [show in Japan](@/a/ppw-hardcore-friday-the-13th-tokyo.md), against Dale Patricks.
 
 ## References
 

--- a/content/e/ppw/2026-05-16-ppw-ledwo-legalne-6.md
+++ b/content/e/ppw/2026-05-16-ppw-ledwo-legalne-6.md
@@ -19,6 +19,7 @@ Ledwo Legalne 6 (_Barely Legal 6_) is an upcoming [PpW Ewenement's](@/o/ppw.md) 
 * At [Teraz Albo Nigdy 2](@/e/ppw/2026-03-21-ppw-teraz-albo-nigdy-2.md) [Biesiad Strong](@/w/biesiad.md) won the 25 Typa 25 Broni Battle Royal, becoming the #1 contender for the [PpW Championship](@/c/ppw-championship.md) at this show.
 * On 16.04.2026 PpW announced the #1 Contender Ladder Match between [Leon Lato](@/w/leon-lato.md), [Antoni Ocean](@/w/antoni-ocean.md), [Vic Golden](@/w/vic-golden.md) and Belgian wrestler MBM "Sweetboy". MBM was last seen at [Miasto Bezprawia](@/e/ppw/2024-02-10-ppw-miasto-bezprawia.md) in February 2024.
 * On 22.04.2026 PpW announced that Bad Trip ([Goblin](@/w/goblin.md) & [Gustav Gryffin](@/w/gustav-gryffin.md)) will fight [Zmowa](@/tt/zmowa.md) for the [PpW Tag Team Championship](@/c/ppw-tag-team-championship.md), however neither Zmowa's exact line-up, nor the stipulation of the match, were given.
+* On 28.04.2026 came the announcement of [Olgierd](@/w/olgierd.md) vs [Biesiad Strong](@/w/biesiad.md) for the [PpW Championship](@/c/ppw-championship.md). Biesiad had previously won the Championship opportunity at [Teraz Albo Nigdy 2](@/e/ppw/2026-03-21-ppw-teraz-albo-nigdy-2.md) by coming up on top in the 25 Typa, 25 Broni Battle Royal.
 
 ## Predicted card
 
@@ -34,6 +35,10 @@ Ledwo Legalne 6 (_Barely Legal 6_) is an upcoming [PpW Ewenement's](@/o/ppw.md) 
   - '[Zmowa](@/tt/zmowa.md): ??? & ???'
   - c: '[PpW Tag Team Championship](@/c/ppw-tag-team-championship.md)'
     s: Tag Team Match
+    nc: upcoming
+- - '["Chain God" Olgierd](@/w/olgierd.md)(c)'
+  - '["Polski Cieśla" Biesiad Strong](@/w/biesiad.md)'
+  - c: '[PpW Championship](@/c/ppw-championship.md)'
     nc: upcoming
 {% end %}
 

--- a/content/e/ppw/2026-05-16-ppw-ledwo-legalne-6.toml
+++ b/content/e/ppw/2026-05-16-ppw-ledwo-legalne-6.toml
@@ -4,3 +4,4 @@
 005 = { path = "vic-golden.webp", caption = 'Image announcing [Vic Golden](@/w/vic-golden.md).', source = "Official PpW Facebook" }
 006 = { path = "mbm.webp", caption = 'Image announcing MBM.', source = "Official PpW Facebook" }
 007 = { path = "gusutav-i-gobolin-zawalacza.webp", caption = 'Image announcing [Gustav Gryffin](@/w/gustav-gryffin.md)& [Goblin](@/w/goblin.md). Note the typo: _zawalaczą_ instead of _zawalczą_.', source = "Official PpW Facebook" }
+008 = { path = "anton-lavey-vs-jezus.webp", caption = 'Image announcing [Olgierd](@/w/olgierd.md) vs [Biesiad Strong](@/w/biesiad.md).', source = "Official PpW Facebook" }


### PR DESCRIPTION
Plus wywaliłem linijkę o obronie w Tokio, skoro i tak jest wpisana na listę razem z innymi, więc po co się powtarzać i mówić dwa razy to samo powtarzając informacje, które zostały już wcześniej przekazane i są znane, ponieważ zostały upublicznione.