### PR TITLE
Fix specialorgs breaking talentlist

### DIFF
--- a/templates/macros/career.html
+++ b/templates/macros/career.html
@@ -50,48 +50,48 @@
 {% endmacro %}
 
 {% macro promolink_color_span(code, hint_text='', styles) %}
-  {% set ib = true %}
-  {% set style = styles|get(key=code, default=[]|group_by(key=0)) %}
-  {% set text_fg = style|get(key='text_fg', default='#fff') %}
-  {% if code is starting_with("~") %}
-    {% set slug = code | replace(from="~", to="") %}
-  {% endif %}
-  {% if code == "mcw" %}
-    {% include "badges/mcw.html" %}
-  {% elif code == "ddw" %}
-    {% include "badges/ddw.html" %}
-  {% elif code == "kpw" %}
-    {% include "badges/kpw.html" %}
-  {% elif code == "ppw" %}
-    {% include "badges/ppw.html" %}
-  {% elif code == "mzw" %}
-    {% include "badges/mzw.html" %}
-  {% elif code == "ptw" %}
-    {% include "badges/ptw.html" %}
-  {% elif code == "tbw" %}
-    {% include "badges/tbw.html" %}
-  {% elif code == "dfw" %}
-    {% include "badges/dfw.html" %}
-  {% elif code == "wwe" %}
-    {% include "badges/wwe.html" %}
-  {% elif code == "low" %}
-    {% include "badges/low.html" %}
-  {% elif code == "pxw" %}
-    {% include "badges/pxw.html" %}
-  {% elif code == "piwg" %}
-    {% include "badges/piwg.html" %}
-  {% elif code == "twf" %}
-    {% include "badges/twf.html" %}
-  {% elif code == "splat" %}
-    {% include "badges/splat.html" %}
-  {% elif code == "ewenement-dojo" %}
-    {% include "badges/edojo.html" %}
-  {% elif code == "ryucon" %}
-    {% include "badges/ryu.html" %}
-  {% elif code == "pyrkon" %}
-    {% include "badges/pyrkon.html" %}
-  {% else %}
-    {% set org_slug = slug | default(value=code) %}
+  {% set ib = true -%}
+  {% set style = styles|get(key=code, default=[]|group_by(key=0)) -%}
+  {% set text_fg = style|get(key='text_fg', default='#fff') -%}
+  {% if code is starting_with("~") -%}
+    {% set slug = code | replace(from="~", to="") -%}
+  {% endif -%}
+  {% if code == "mcw" -%}
+    {% include "badges/mcw.html" -%}
+  {% elif code == "ddw" -%}
+    {% include "badges/ddw.html" -%}
+  {% elif code == "kpw" -%}
+    {% include "badges/kpw.html" -%}
+  {% elif code == "ppw" -%}
+    {% include "badges/ppw.html" -%}
+  {% elif code == "mzw" -%}
+    {% include "badges/mzw.html" -%}
+  {% elif code == "ptw" -%}
+    {% include "badges/ptw.html" -%}
+  {% elif code == "tbw" -%}
+    {% include "badges/tbw.html" -%}
+  {% elif code == "dfw" -%}
+    {% include "badges/dfw.html" -%}
+  {% elif code == "wwe" -%}
+    {% include "badges/wwe.html" -%}
+  {% elif code == "low" -%}
+    {% include "badges/low.html" -%}
+  {% elif code == "pxw" -%}
+    {% include "badges/pxw.html" -%}
+  {% elif code == "piwg" -%}
+    {% include "badges/piwg.html" -%}
+  {% elif code == "twf" -%}
+    {% include "badges/twf.html" -%}
+  {% elif code == "splat" -%}
+    {% include "badges/splat.html" -%}
+  {% elif code == "ewenement-dojo" -%}
+    {% include "badges/edojo.html" -%}
+  {% elif code == "ryucon" -%}
+    {% include "badges/ryu.html" -%}
+  {% elif code == "pyrkon" -%}
+    {% include "badges/pyrkon.html" -%}
+  {% else -%}
+    {% set org_slug = slug | default(value=code) -%}
     {% set org_path = "@/o/" ~ org_slug ~ ".md" -%}
     <div title="{{ hint_text }}" class="badge ib">
       <a
@@ -102,7 +102,7 @@
         {{ style|get(key='text', default=code|upper) }}
     </a>
     </div>
-  {% endif %}
+  {% endif -%}
 {% endmacro %}
 
 {# Draws stretchy bars used in the career/appearances section for people and teams #}

--- a/templates/roster/person_orgs_matches.html
+++ b/templates/roster/person_orgs_matches.html
@@ -1,54 +1,53 @@
-{% set_global all_appearances = [] %}
-{% for app in appearances_entry %}
-  {% set match = all_matches[app] %}
-  {% set_global all_appearances = all_appearances | concat(with=match) %}
-{% endfor %}
+{% set_global all_appearances = [] -%}
+{% for app in appearances_entry -%}
+  {% set match = all_matches[app] -%}
+  {% set_global all_appearances = all_appearances | concat(with=match) -%}
+{% endfor -%}
 
-{# We can just concat them onto the list of matches - both are similar in structure #}
-{% for app in crew_appearances_entry %}
-  {% set_global all_appearances = all_appearances | concat(with=app) %}
-{% endfor %}
+{# We can just concat them onto the list of matches - both are similar in structure -#}
+{% for app in crew_appearances_entry -%}
+  {% set_global all_appearances = all_appearances | concat(with=app) -%}
+{% endfor -%}
 
-{# Calculate orgs from appearances #}
-{% set_global orgs = [] %}
-{% for match in all_appearances %}
-  {% for org in match.o %}
-    {% if orgs is not containing(org) %}{% set_global orgs=orgs | concat(with=org) %}{% endif %}
-  {% endfor %}
-{% endfor %}
+{# Calculate orgs from appearances -#}
+{% set_global orgs = [] -%}
+{% for match in all_appearances -%}
+  {% for org in match.o -%}
+    {% if orgs is not containing(org) %}{% set_global orgs=orgs | concat(with=org) %}{% endif -%}
+  {% endfor -%}
+{% endfor -%}
 
-{# And from crew_appearances_entry #}
-{% for row in crew_appearances_entry %}
-  {% set crew_orgs = row.o %}
-  {% for org in crew_orgs %}
-    {% if orgs is not containing(org) %}
-      {% set_global orgs = orgs|concat(with=org) %}
-    {% endif %}
-  {% endfor %}
-{% endfor %}
+{# And from crew_appearances_entry -#}
+{% for row in crew_appearances_entry -%}
+  {% set crew_orgs = row.o -%}
+  {% for org in crew_orgs -%}
+    {% if orgs is not containing(org) -%}
+      {% set_global orgs = orgs|concat(with=org) -%}
+    {% endif -%}
+  {% endfor -%}
+{% endfor -%}
 
-{% set_global used_events = [] %}
-{% set_global i = 1 %}
+{% set_global used_events = [] -%}
+{% set_global i = 1 -%}
 {# Now iterate through orgs, and find matches for that org #}
-{% for o in orgs %}
+{% for o in orgs -%}
   <span class="ot">
-    {# skip org if listing a name that was not used in it #}
-    {% set_global valid_org = false %}
-    {% for mm in all_appearances %}
-      {% if mm.o is containing(o) %}{% set_global valid_org = true %}{% break %}{% endif %}
-    {% endfor %}
-    {% if config.extra.special_orgs is containing(o) %}{% set_global valid_org = false %}{% endif %}
-    {% if not valid_org %}{% continue %}{% endif %}
+    {# skip org if listing a name that was not used in it -#}
+    {% set_global valid_org = false -%}
+    {% for mm in all_appearances -%}
+      {% if mm.o is containing(o) %}{% set_global valid_org = true %}{% break %}{% endif -%}
+    {% endfor -%}
+    {% if config.extra.special_orgs is containing(o) %}{% set_global valid_org = false %}{% endif -%}
     {% if not valid_org %}</span>{% continue %}{% endif -%}
     {{ macros::promolink_color_span(code=o, styles=org_styles) }}
-    {% if display_match_links and all_appearances|length < 5 %}
-      {% for match in all_appearances|sort(attribute='d') %}
-        {% if not match.o is containing(o) %} {% continue %} {% endif %}
-        {% if used_events is containing(match.p) %} {% continue %} {% endif %}
+    {% if display_match_links and all_appearances|length < 5 -%}
+      {% for match in all_appearances|sort(attribute='d') -%}
+        {% if not match.o is containing(o) %} {% continue -%} {% endif -%}
+        {% if used_events is containing(match.p) %} {% continue -%} {% endif -%}
         <a href="{{ get_url(path="@/" ~ match.p) }}"><small>[{{ i }}]</small></a>
-        {% set_global used_events = used_events|concat(with=match.p) %}
-        {% set_global i = i + 1 %}
-      {% endfor %}
-    {% endif %}
+        {% set_global used_events = used_events|concat(with=match.p) -%}
+        {% set_global i = i + 1 -%}
+      {% endfor -%}
+    {% endif -%}
     </span>
-{% endfor %}
+{% endfor -%}

--- a/templates/roster/person_orgs_matches.html
+++ b/templates/roster/person_orgs_matches.html
@@ -39,6 +39,7 @@
     {% endfor %}
     {% if config.extra.special_orgs is containing(o) %}{% set_global valid_org = false %}{% endif %}
     {% if not valid_org %}{% continue %}{% endif %}
+    {% if not valid_org %}</span>{% continue %}{% endif -%}
     {{ macros::promolink_color_span(code=o, styles=org_styles) }}
     {% if display_match_links and all_appearances|length < 5 %}
       {% for match in all_appearances|sort(attribute='d') %}


### PR DESCRIPTION
Previously, if a talent appeared for one of the specialorgs (like Splat), the rendering of their entry in the talentlist could be broken. This was due to incorrectly nesting tags, caused by not closing them properly for specialorgs (which aren't even displaying there, as desired).