### PR TITLE
Clean up result templates and whitespace

### DIFF
--- a/templates/career/only_winner_row.html
+++ b/templates/career/only_winner_row.html
@@ -1,0 +1,12 @@
+Winner:
+{% if 0 in positions -%}
+  <strong>{{ winner | replace(from=";", to=" w/") | markdown(inline=true) | safe }}</strong>
+{% else -%}
+  {{ winner | replace(from=";", to=" w/") | markdown(inline=true) | safe }}
+{% endif -%}
+
+{% if final.r -%}
+  via {{ final.r | markdown(inline=true) | safe }}
+{% elif final.nc and final.nc != "upcoming" -%}
+  - {{ final.nc | markdown(inline=true) | safe }}
+{% endif -%}

--- a/templates/career/result_row.html
+++ b/templates/career/result_row.html
@@ -1,70 +1,67 @@
-{% set final = row | last %}
-{% set winner = row | first %}
-{% if final is object %}
-  {% set others = row | slice(start=1, end=-1) %}
-  {% set title = final.c | default(value="") %}
-  {% set stip = final.s | default(value="") %}
-  {% set segment = final | get(key="g", default=false) %}
-{% else %}
-  {% set others = row | slice(start=1) %}
-  {% set segment = false %}
-  {% set final = [] | group_by(key=0) %}
-{% endif %}
-{% set bodies = others | length %}
-{% if title %}
-  {% set default_stip = "Match" %}
-{% else %}
-  {% set default_stip = "Singles Match" %}
-{% endif %}
-{% if segment %}
-  {% set default_stip = "" %}
-{% endif %}
-{% if final.nc %}
-    {% set sep = "vs" %}
-{% else %}
-    {% set sep = "defeated" %}
-{% endif %}
-{% if not stip %}{% set stip = default_stip %}{% endif %}
-{% set positions = positions | default(value=[]) %}
+{% set final = row | last -%}
+{% set winner = row | first -%}
+{% if final is object -%}
+  {% set talent = row | slice(end=-1) -%}
+  {% set others = row | slice(start=1, end=-1) -%}
+  {% set title = final.c | default(value="") -%}
+  {% set stip = final.s | default(value="") -%}
+  {% set segment = final | get(key="g", default=false) -%}
+{% else -%}
+  {% set talent = row -%}
+  {% set others = row | slice(start=1) -%}
+  {% set segment = false -%}
+  {% set final = [] | group_by(key=0) -%}
+{% endif -%}
+{% set bodies = others | length -%}
+{% if title -%}
+  {% set default_stip = "Match" -%}
+{% else -%}
+  {% set default_stip = "Singles Match" -%}
+{% endif -%}
+{% if segment -%}
+  {% set default_stip = "" -%}
+{% endif -%}
+{% if final.nc -%}
+    {% set sep = "vs" -%}
+{% else -%}
+    {% set sep = "defeated" -%}
+{% endif -%}
+{% if final.nc and final.nc == "upcoming" -%}
+  {% set upcoming = true -%}
+{% endif -%}
+{% if not stip %}{% set stip = default_stip %}{% endif -%}
+{% set positions = positions | default(value=[]) -%}
 
-{% if segment %}
-  <strong>Segment:</strong> {{ winner | markdown(inline=true) | safe }}{% if others %}, {{ others | join(sep=", ") | markdown(inline=true) | safe }}{% endif %}
-{% else %}
-  {% if final.nc and final.nc == "upcoming" %}
-    <strong>Upcoming:</strong>
-  {% elif bodies == 0 and not final.nc %}
-    Winner:
-  {% endif %}
-  {% if 0 in positions %}
+{% if segment -%}
+  {% include "career/segment_row.html" -%}
+{% elif bodies == 0 and not final.nc -%}
+  {% include "career/only_winner_row.html" -%}
+{% else -%}
+  {% if upcoming %}<strong>Upcoming:</strong>{% endif %}
+  {% set highlight = 0 in positions %}
+  {% if highlight -%}
     <strong>{{ winner | replace(from=";", to=" w/") | markdown(inline=true) | safe }}</strong>
-  {% else %}
+  {% else -%}
     {{ winner | replace(from=";", to=" w/") | markdown(inline=true) | safe }}
-  {% endif %}
-  {% if bodies > 0 %}
-    {{ sep }}
-    {% for opponent in others %}
-      {% if loop.index in positions %}
-        <strong>{{ opponent | replace(from=";", to=" w/") | markdown(inline=true) | safe }}</strong>
-      {% else %}
-        {{ opponent | replace(from=";", to=" w/") | markdown(inline=true) | safe }}
-      {% endif %}
-      {% if not loop.last %}
-        and
-      {% endif %}
-    {% endfor %}
-  {% endif %}
-  {% if final.r %}
+  {% endif -%}
+  {{ sep }}
+  {% for opponent in others -%}
+    {% set highlight = loop.index in positions %}
+    {% if highlight -%}
+      <strong>{{ opponent | replace(from=";", to=" w/") | markdown(inline=true) | safe }}</strong>
+    {% else -%}
+      {{ opponent | replace(from=";", to=" w/") | markdown(inline=true) | safe }}
+    {% endif -%}
+    {% if not loop.last %} and {% endif -%}
+  {% endfor -%}
+  {% if final.r -%}
       via {{ final.r | markdown(inline=true) | safe }}
-  {% elif final.nc and final.nc != "upcoming" %}
+  {% elif final.nc and not upcoming -%}
       - {{ final.nc | markdown(inline=true) | safe }}
-  {% endif %}
-  <strong>
-{% endif %}
-<br/>
-{% if segment and segment is string %}
-  {{ segment | markdown(inline=true) | safe }}
+  {% endif -%}
+{% endif -%}
+<strong>
   <br/>
-{% endif %}
-{{ title | default(value="") | markdown(inline=true) | safe }}
-{{ stip | default(value=default_stip) | markdown(inline=true) | safe }}
+  {{ title | default(value="") | markdown(inline=true) | safe }}
+  {{ stip | default(value=default_stip) | markdown(inline=true) | safe }}
 </strong>

--- a/templates/career/section.html
+++ b/templates/career/section.html
@@ -1,25 +1,25 @@
-{% set org_styles = config.extra.org_styles %}
-{% set careers = load_data(path="data/career_v2.json") %}
-{% set empty_obj = [] | group_by(attribute='0') %}
-{% set career_key = "@/" ~ page.relative_path %}
-{% set mycareer = careers | get(key=career_key, default=empty_obj) %}
-{% set enable_matchlist_links = true %}
+{% set org_styles = config.extra.org_styles -%}
+{% set careers = load_data(path="data/career_v2.json") -%}
+{% set empty_obj = [] | group_by(attribute='0') -%}
+{% set career_key = "@/" ~ page.relative_path -%}
+{% set mycareer = careers | get(key=career_key, default=empty_obj) -%}
+{% set enable_matchlist_links = true -%}
 
-{% if mycareer %}
+{% if mycareer -%}
   {% set_global years = [] -%}
   {% for year, _ignore in mycareer -%}
     {% set_global years = years | concat(with=year) -%}
   {% endfor -%}
 
   <h3>Appearances per promotion and year</h3>
-  {% include "career/years.html" %}
-{% endif %}
+  {% include "career/years.html" -%}
+{% endif -%}
 
 
-{% set fold_matchlist_config = config.extra | get(key="fold_matchlist", default="auto") %}
-{% set fold_matchlist_at = config.extra | get(key="fold_matchlist_at") %}
-{% set fold_matchlist = page.extra | get(key="fold_matchlist", default=fold_matchlist_config) %}
-{% include "career/matchlist.html" %}
+{% set fold_matchlist_config = config.extra | get(key="fold_matchlist", default="auto") -%}
+{% set fold_matchlist_at = config.extra | get(key="fold_matchlist_at") -%}
+{% set fold_matchlist = page.extra | get(key="fold_matchlist", default=fold_matchlist_config) -%}
+{% include "career/matchlist.html" -%}
 
 {% set fold_crew_appearances_config = config.extra | get(key="fold_crew_appearances", default="auto") %}
 {% set fold_crew_appearances_at = config.extra | get(key="fold_crew_appearances_at") %}

--- a/templates/career/segment_row.html
+++ b/templates/career/segment_row.html
@@ -1,0 +1,6 @@
+<strong>Segment:</strong>
+{{ talent | join(sep=", ") | markdown(inline=true) | safe }}
+<br/>
+{% if segment and segment is string -%}
+  {{ segment | markdown(inline=true) | safe }}
+{% endif -%}

--- a/templates/talent_page.html
+++ b/templates/talent_page.html
@@ -18,6 +18,6 @@
 
 {% if has_career -%}
   <h2 id="career">Career</h2>
-  {% include "career/section.html" %}
-{% endif %}
+  {% include "career/section.html" -%}
+{% endif -%}
 {% endblock content %}

--- a/themes/web/templates/card/notes.html
+++ b/themes/web/templates/card/notes.html
@@ -1,0 +1,12 @@
+{% if notes is string -%}
+  <span class="nt">NOTE: {{ notes | markdown(inline=true) | safe }}</span>
+{% elif notes %}
+  <span class="nt">
+    NOTES:<br/>
+    <ul>
+    {% for note in notes %}
+        <li>{{ note | markdown(inline=true) | safe }}</li>
+    {% endfor %}
+    </ul>
+  </span>
+{% endif -%}

--- a/themes/web/templates/card/only_winner_row.html
+++ b/themes/web/templates/card/only_winner_row.html
@@ -1,0 +1,16 @@
+<li class="match">
+  <span class="n">{{ rownum }}</span>
+  <span class="p">
+    Winner: {{ winner | replace(from=";", to="w/ ") | markdown(inline=true) | safe }}
+    {% if result %}
+      via {{ final.r | markdown(inline=true) | safe }}
+    {% elif nc %}
+      - {{ final.nc | markdown(inline=true) | safe }}
+    {% endif %}
+  </span>
+  <span class="c">
+    {{ title | markdown(inline=true) | safe }}
+    {{ stip | markdown(inline=true) | safe }}
+  </span>
+  {% include "card/notes.html" %}
+</li>

--- a/themes/web/templates/card/result_row.html
+++ b/themes/web/templates/card/result_row.html
@@ -1,6 +1,7 @@
 {% set final = row | last %}
 {% set winner = row | first %}
 {% if final is object %}
+  {% set talent = row | slice(end=-1) %}
   {% set others = row | slice(start=1, end=-1) %}
   {% set title = final | get(key="c", default="") %}
   {% set stip = final | get(key="s", default="") %}
@@ -23,44 +24,27 @@
 {% else %}
     {% set sep = "<strong>d.</strong>" %}
 {% endif %}
+{% if segment %}
+  {% include "card/segment_row.html" -%}
+{% elif bodies == 0 %}
+  {% include "card/only_winner_row.html" -%}
+{% else %}
 <li class="match">
     <span class="n">{{rownum}}</span>
     <span class="p">
-        {% if segment %}
-          <strong>Segment:</strong> {{ winner | markdown(inline=true) | safe }}{% if others -%}, {{ others | join(sep=", ") | markdown(inline=true) | safe }}{% endif %}
-        {% else %}
-          {% if bodies == 0 %}
-            Winner:
-          {% endif %}
           {{ winner | replace(from=";", to=" w/") | markdown(inline=true) | safe }}
-          {% if bodies > 0 %}
-              {{ sep | safe }}
-              {{ others | join(sep=" and ") | replace(from=";", to=" w/") | markdown(inline=true) | safe }}
-          {% endif %}
+          {{ sep | safe }}
+          {{ others | join(sep=" and ") | replace(from=";", to=" w/") | markdown(inline=true) | safe }}
           {% if result %}
               via {{ final.r | markdown(inline=true) | safe }}
           {% elif nc %}
               - {{ final.nc | markdown(inline=true) | safe }}
           {% endif %}
-        {% endif %}
     </span>
     <span class="c">
         {{ title | markdown(inline=true) | safe }}
-        {% if segment and segment is string %}
-          {{ segment | markdown(inline=true) | safe }}
-        {% endif %}
         {{ stip | markdown(inline=true) | safe }}
     </span>
-    {% if notes is string %}
-      <span class="nt">NOTE: {{ notes | markdown(inline=true) | safe }}</span>
-    {% elif notes %}
-      <span class="nt">
-        NOTES:<br/>
-        <ul>
-          {% for note in notes %}
-            <li>{{ note | markdown(inline=true) | safe }}</li>
-          {% endfor %}
-        </ul>
-      </span>
-    {% endif %}
+    {% include "card/notes.html" %}
 </li>
+{% endif %}

--- a/themes/web/templates/card/segment_row.html
+++ b/themes/web/templates/card/segment_row.html
@@ -1,0 +1,13 @@
+<li class="match">
+  <span class="n">{{ rownum }}</span>
+  <span class="p">
+    <strong>Segment:</strong>
+    {{ talent | join(sep=", ") | markdown(inline=true) | safe }}
+  </span>
+  <span class="c">
+    {% if segment is string -%}
+      {{ segment | markdown(inline=true) | safe }}
+    {% endif -%}
+  </span>
+  {% include "card/notes.html" %}
+</li>

--- a/themes/web/templates/career/match_table.html
+++ b/themes/web/templates/career/match_table.html
@@ -4,12 +4,12 @@
         <span class="o">Org</span>
         <span class="r">Details</span>
     </li>
-    {% set lastyr = "-" %}
-    {% for match in matches_by_date | reverse %}
-        {% set yr = match.d | date(format="%Y") %}
-        {% if lastyr != yr %}
-            {% if enable_year_headers %}
-                {% set_global lastyr = yr %}
+    {% set lastyr = "-" -%}
+    {% for match in matches_by_date | reverse -%}
+        {% set yr = match.d | date(format="%Y") -%}
+        {% if lastyr != yr -%}
+            {% if enable_year_headers -%}
+                {% set_global lastyr = yr -%}
                 {# Terminate current list and start a new one #}
                 </ul>
                 <ul class="career">
@@ -18,32 +18,28 @@
                             <summary role="heading">{{ yr }}</summary>
                         </details>
                     </li>
-                {% else %}
-                {% set yrtarget = "career-" ~ yr %}
-            {% endif %}
-        {% else %}
-            {% set yrtarget = false %}
-        {% endif %}
+                {% else -%}
+                {% set yrtarget = "career-" ~ yr -%}
+            {% endif -%}
+        {% else -%}
+            {% set yrtarget = false -%}
+        {% endif -%}
         <li class="entry {{ match.tt | default(value="") }}"
-        {% if yrtarget %}id="{{ yrtarget }}"{% endif %}>
+        {%- if yrtarget %}id="{{ yrtarget }}"{% endif -%}>
             <time class="d" style="white-space: nowrap" datetime="{{ match.d }}">{{ match.d }}</time>
             <span class="o">
-                {% for org in match.o %}
-                {{ macros::promolink_color(code=org, styles=org_styles) }}
-                {% endfor %}
+                {% for org in match.o -%}{{ macros::promolink_color(code=org, styles=org_styles) }}{% endfor -%}
             </span>
-            {% set row = match.m %}
+            {% set row = match.m -%}
             {# It may happen that the same match.i happens more than once #}
             {# This means more than one appearance in that match (think rumbles, entering under different names) #}
             {# These matches were filtered out by unique above, so we have only one. #}
-            {% set positions = my_match_pos[match.i] | map(attribute='1') %}
+            {% set positions = my_match_pos[match.i] | map(attribute='1') -%}
             <span class="r">
-                {% include "career/result_row.html" %}
-                {% set event_path = "@/" ~ match.p %}
+                {% include "career/result_row.html" -%}
+                {% set event_path = "@/" ~ match.p -%}
                 <small>at <a href="{{ get_url(path=event_path) }}">{{ match.n }}</a></small>
-                {% if match.tt %}
-                ({{ match.tt }})
-                {% endif %}
+                {% if match.tt %} ({{ match.tt }}) {% endif -%} {# predicted etc #}
             </span>
         </li>
     {% endfor %}

--- a/themes/web/templates/career/matchlist.html
+++ b/themes/web/templates/career/matchlist.html
@@ -1,44 +1,44 @@
 {%- import "macros/career.html" as macros %}
-{% set org_styles = config.extra.org_styles %}
-{% set alias_map = load_data(path="data/aliases.json") %}
-{% set all_my_names = [] %}
-{% if team_career_keys %}
-  {% set all_my_names = [team_career_keys] %}
-{% else %}
-  {% set all_my_names = [page.relative_path, page.title] %}
-{% endif %}
-{% for alias, path in alias_map %}
-  {% if path == page.relative_path %}{% set_global all_my_names = all_my_names | concat(with=alias) %}{% endif %}
-{% endfor %}
-{% set all_matches = load_data(path="data/all_matches.json") %}
-{% set appearances = load_data(path="data/appearances_v2.json") %}
-{% set my_appearances = [] %}
-{% for name in all_my_names %}
-  {% set napps = appearances | get(key=name, default=[]) %}
-  {% set_global my_appearances = my_appearances | concat(with=napps) %}
-{% endfor %}
+{% set org_styles = config.extra.org_styles -%}
+{% set alias_map = load_data(path="data/aliases.json") -%}
+{% set all_my_names = [] -%}
+{% if team_career_keys -%}
+  {% set all_my_names = [team_career_keys] -%}
+{% else -%}
+  {% set all_my_names = [page.relative_path, page.title] -%}
+{% endif -%}
+{% for alias, path in alias_map -%}
+  {% if path == page.relative_path %}{% set_global all_my_names = all_my_names | concat(with=alias) %}{% endif -%}
+{% endfor -%}
+{% set all_matches = load_data(path="data/all_matches.json") -%}
+{% set appearances = load_data(path="data/appearances_v2.json") -%}
+{% set my_appearances = [] -%}
+{% for name in all_my_names -%}
+  {% set napps = appearances | get(key=name, default=[]) -%}
+  {% set_global my_appearances = my_appearances | concat(with=napps) -%}
+{% endfor -%}
 {% set_global my_matches = [] -%}
-{% for entry in my_appearances %}
-  {% set index = entry[0] %}
-  {% set_global my_matches = my_matches | concat(with=all_matches[index]) %}
-{% endfor %}
-{% set careers = [] %}
-{% set all_matches = [] %}
-{% set appearances = [] %}
-{% set matches_by_date = my_matches | sort(attribute='d') | unique(attribute='i') %}
-{% set my_match_pos = my_appearances | group_by(attribute='0') %}
+{% for entry in my_appearances -%}
+  {% set index = entry[0] -%}
+  {% set_global my_matches = my_matches | concat(with=all_matches[index]) -%}
+{% endfor -%}
+{% set careers = [] -%}
+{% set all_matches = [] -%}
+{% set appearances = [] -%}
+{% set matches_by_date = my_matches | sort(attribute='d') | unique(attribute='i') -%}
+{% set my_match_pos = my_appearances | group_by(attribute='0') -%}
 
-{% if my_matches %}
+{% if my_matches -%}
   {% set mml = matches_by_date | length %}
 
-  {% if fold_matchlist == "always" or (fold_matchlist == "auto" and mml > fold_matchlist_at) %}
-    {% set enable_year_headers = true %}
+  {% if fold_matchlist == "always" or (fold_matchlist == "auto" and mml > fold_matchlist_at) -%}
+    {% set enable_year_headers = true -%}
     <details>
       <summary class="header h3-like">Matches and segments</summary>
-      {% include "career/match_table.html" %}
+      {% include "career/match_table.html" -%}
     </details>
-  {% else %}
+  {% else -%}
     <h3>Matches and segments</h3>
-    {% include "career/match_table.html" %}
-  {% endif %}
-{% endif %}
+    {% include "career/match_table.html" -%}
+  {% endif -%}
+{% endif -%}


### PR DESCRIPTION
This is internal-only: all the pages should render exactly the same as previously, but now the templates should be easier to understand. Also cuts down on the amount of whitespace in the HTML output, making it tighter (but again, no visual change expected).

Affected pages:
- a talent's career section
- an event's results (card toggled to show results)
