### PR TITLE
Richer career numbers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ METADATA=data/all_matches.json \
          data/crew_appearances.json \
          data/career.json \
 				 data/career_v2.json \
+         data/career_v3.json \
          data/team_careers.json \
          data/all_photos.json \
          data/photo_taggings.json \
@@ -40,7 +41,7 @@ clean:
 data/all_matches.json data/appearances.json data/crew_appearances.json data/appearances_v2.json &: content/e/**/*.md
 	bin/build-matches
 
-data/career.json data/career_v2.json data/team_careers.json &: content/e/**/*.md
+data/career.json data/career_v2.json data/career_v3.json data/team_careers.json &: content/e/**/*.md
 	bin/build-metadata
 
 data/aliases.json: content/w/*.md

--- a/src/bin/metadata.py
+++ b/src/bin/metadata.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from collections import Counter
 from articles import load_names_with_aliases
 import json
-from typing import cast, NewType, Callable
+from typing import cast, NewType, Callable, TypeVar
 from utils import RichEncoder, accepted_name
 from card import CardParseError, names_in_match, teams_in_match
 from page import EventPage
@@ -159,7 +159,9 @@ def merge_years(left: CareerYears, right: CareerYears) -> CareerYears:
         year.update(right[key])
     return result
 
-def merge_aliases(career: dict[str, T], merge: Callable[[T, T], T]):
+T = TypeVar('T')
+MergeOp = Callable[[T, T], T]
+def merge_aliases(career: dict[str, T], merge: MergeOp):
     """
     Mutate the career dict passed, by removing entries which are only ever
     listed as a career_aliases entry in some page. Merge them to their primary name.

--- a/src/bin/metadata.py
+++ b/src/bin/metadata.py
@@ -4,13 +4,26 @@ from pathlib import Path
 from collections import Counter
 from articles import load_names_with_aliases
 import json
-from typing import cast
+from typing import cast, NewType, Callable
 from utils import RichEncoder, accepted_name
 from card import CardParseError, names_in_match, teams_in_match
 from page import EventPage
 from sys import stderr, exit
+from dataclasses import dataclass
+
+@dataclass
+class MSC:
+    matches: int = 0
+    segments: int = 0
+    crew: int = 0
+
+    @property
+    def serialize_as_tuple(self):
+        pass
 
 OrgYears = dict[str, int]
+Year = NewType('Year', str)
+RichOrgYears = dict[Year, dict[str, MSC]]
 CareerYears = dict[int, OrgYears]
 
 def update_cbf(careers, team_careers, page: EventPage):
@@ -96,6 +109,47 @@ def update_career(career: dict[str, CareerYears], team_careers: dict[str, Career
         year = cast(Counter, entry.setdefault(event_date.year, Counter()))
         year.update(orgs)
 
+def update_split_career(career: dict[str, RichOrgYears], page: EventPage):
+    event_date = page.event_date
+    event_year = Year(str(event_date.year))
+    orgs = page.orgs
+    card = page.card
+
+    if not card.matches:
+        return
+
+    if not event_date:
+        return
+
+    for matchrow in card.matches:
+        opts = matchrow.options
+        for person in names_in_match(matchrow):
+            plain = person.name
+            if not accepted_name(plain): continue # Filter out '???'
+            key = person.link or person.name
+
+            entry: RichOrgYears = career.setdefault(key, {})
+            year = entry.setdefault(event_year, dict())
+            for org in orgs:
+                year.setdefault(org, MSC())
+                if 'g' in opts:
+                    year[org].segments += 1
+                else:
+                    year[org].matches += 1
+
+    if not card.crew: return
+
+    for person in card.crew.members:
+        plain = person.name
+        if not accepted_name(plain):
+            continue
+
+        key = person.link or person.name
+        entry: RichOrgYears = career.setdefault(key, {})
+        year = entry.setdefault(event_year, dict())
+        for org in orgs:
+            year.setdefault(org, MSC())
+            year[org].crew += 1
 
 
 def merge_years(left: CareerYears, right: CareerYears) -> CareerYears:
@@ -105,7 +159,7 @@ def merge_years(left: CareerYears, right: CareerYears) -> CareerYears:
         year.update(right[key])
     return result
 
-def merge_aliases(career: dict[str, CareerYears]):
+def merge_aliases(career: dict[str, T], merge: Callable[[T, T], T]):
     """
     Mutate the career dict passed, by removing entries which are only ever
     listed as a career_aliases entry in some page. Merge them to their primary name.
@@ -115,11 +169,12 @@ def merge_aliases(career: dict[str, CareerYears]):
         for alias in aliases:
             if alias not in career: continue
             c = career.pop(alias)
-            career[main_name] = merge_years(career.get(main_name, {}), c)
+            career[main_name] = merge(career.get(main_name, {}), c)
 
 def main():
     careers = {}
     careers_by_file = {}
+    careers_split = {}
     team_careers = {}
     team_cbf = {}
     cwd = Path.cwd()
@@ -138,6 +193,7 @@ def main():
                 continue
             update_career(careers, team_careers, page)
             update_cbf(careers_by_file, team_cbf, page)
+            update_split_career(careers_split, page)
         except CardParseError:
             num_errors += 1
 
@@ -145,7 +201,7 @@ def main():
         stderr.write("Errors found, aborting\n")
         exit(1)
 
-    merge_aliases(careers)
+    merge_aliases(careers, merge_years)
 
     data_dir = cwd / 'data'
     data_dir.mkdir(exist_ok=True)
@@ -157,6 +213,10 @@ def main():
     with (data_dir / 'career_v2.json').open('w') as f:
         print("Saving career v2 to %s" % f.name)
         json.dump(careers_by_file, f, cls=RichEncoder)
+
+    with (data_dir / 'career_v3.json').open('w') as f:
+        print(f"Saving career v3 to {f.name}")
+        json.dump(careers_split, f, cls=RichEncoder)
 
     with (data_dir / 'team_careers.json').open('w') as f:
         print("Saving team career v2 to %s" % f.name)

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,5 +1,6 @@
 from json import JSONEncoder
 from collections import Counter
+from dataclasses import asdict, is_dataclass, astuple
 import tomllib
 import re
 from typing import TextIO
@@ -59,6 +60,10 @@ class RichEncoder(JSONEncoder):
                 return list(o)
             case Counter():
                 return dict(o)
+            case obj if is_dataclass(obj) and hasattr(obj, 'serialize_as_tuple'):
+                return astuple(obj)
+            case obj if is_dataclass(obj):
+                return asdict(obj)
             case _:
                 return super().default(o)
 

--- a/templates/badges/ddw.html
+++ b/templates/badges/ddw.html
@@ -5,5 +5,5 @@
      title="{{ hint_text }}">
      <span>DDW</span>
   </a>
-  <small style="color: {{ text_fg }}">{{ cnt|default(value="") }}</small>
+  <small style="color: {{ text_fg }}">{{ displayed_count|default(value="") }}</small>
 </div>

--- a/templates/badges/dfw.html
+++ b/templates/badges/dfw.html
@@ -5,5 +5,5 @@
      title="{{ hint_text }}">
      <span>DFW</span>
   </a>
-  <small style="color: {{ text_fg }}">{{ cnt|default(value="") }}</small>
+  <small style="color: {{ text_fg }}">{{ displayed_count|default(value="") }}</small>
 </div>

--- a/templates/badges/edojo.html
+++ b/templates/badges/edojo.html
@@ -5,5 +5,5 @@
      title="{{ hint_text }}">
      <span style="font-size: 1.12rem">DOJO</span>
   </a>
-  <small style="color: {{ text_fg }}">{{ cnt|default(value="") }}</small>
+  <small style="color: {{ text_fg }}">{{ displayed_count|default(value="") }}</small>
 </div>

--- a/templates/badges/kpw.html
+++ b/templates/badges/kpw.html
@@ -5,5 +5,5 @@
      title="{{ hint_text }}">
      <span>KPW</span>
   </a>
-  <small style="color: {{ text_fg }}">{{ cnt|default(value="") }}</small>
+  <small style="color: {{ text_fg }}">{{ displayed_count|default(value="") }}</small>
 </div>

--- a/templates/badges/low.html
+++ b/templates/badges/low.html
@@ -5,5 +5,5 @@
      title="{{ hint_text }}">
      <span>LOW</span>
   </a>
-  <small style="color: {{ text_fg }}">{{ cnt|default(value="") }}</small>
+  <small style="color: {{ text_fg }}">{{ displayed_count|default(value="") }}</small>
 </div>

--- a/templates/badges/mcw.html
+++ b/templates/badges/mcw.html
@@ -4,5 +4,5 @@
      style="background: url({{ get_url(path='mcw-badge.svg') }}) 0 0 / 100%, #fff; background-position: center;">
      <span>MCW</span>
   </a>
-  <small style="color: {{ text_fg }}">{{ cnt|default(value="") }}</small>
+  <small style="color: {{ text_fg }}">{{ displayed_count|default(value="") }}</small>
 </div>

--- a/templates/badges/mzw.html
+++ b/templates/badges/mzw.html
@@ -4,5 +4,5 @@
      style="background: url({{ get_url(path='mzw-badge.svg') }}) no-repeat 0 0/cover, #208315; background-position: center;">
     <span>MZW</span>
   </a>
-  <small style="color: {{ text_fg }}">{{ cnt|default(value="") }}</small>
+  <small style="color: {{ text_fg }}">{{ displayed_count|default(value="") }}</small>
 </div>

--- a/templates/badges/piwg.html
+++ b/templates/badges/piwg.html
@@ -5,5 +5,5 @@
      title="{{ hint_text }}">
      <span style="font-size: 0.9rem">PIWG</span>
   </a>
-  <small style="color: {{ text_fg }}">{{ cnt|default(value="") }}</small>
+  <small style="color: {{ text_fg }}">{{ displayed_count|default(value="") }}</small>
 </div>

--- a/templates/badges/ppw.html
+++ b/templates/badges/ppw.html
@@ -5,5 +5,5 @@
      title="{{ hint_text }}">
      <span>PpW</span>
   </a>
-  <small style="color: {{ text_fg }}">{{ cnt|default(value="") }}</small>
+  <small style="color: {{ text_fg }}">{{ displayed_count|default(value="") }}</small>
 </div>

--- a/templates/badges/ptw.html
+++ b/templates/badges/ptw.html
@@ -5,5 +5,5 @@
      title="{{ hint_text }}">
      <span>PTW</span>
   </a>
-  <small style="color: {{ text_fg }}">{{ cnt|default(value="") }}</small>
+  <small style="color: {{ text_fg }}">{{ displayed_count|default(value="") }}</small>
 </div>

--- a/templates/badges/pxw.html
+++ b/templates/badges/pxw.html
@@ -4,5 +4,5 @@
      style="background: url({{ get_url(path='pxw-logo-x.svg') }}) no-repeat 0 0/cover, #000; background-position: center;">
     <span>PXW</span>
   </a>
-  <small style="color: {{ text_fg }}">{{ cnt|default(value="") }}</small>
+  <small style="color: {{ text_fg }}">{{ displayed_count|default(value="") }}</small>
 </div>

--- a/templates/badges/pyrkon.html
+++ b/templates/badges/pyrkon.html
@@ -5,5 +5,5 @@
      title="{{ hint_text }}">
      <span style="font-size: 0.7rem">PYRKON</span>
   </a>
-  <small style="color: {{ text_fg }}">{{ cnt|default(value="") }}</small>
+  <small style="color: {{ text_fg }}">{{ displayed_count|default(value="") }}</small>
 </div>

--- a/templates/badges/ryu.html
+++ b/templates/badges/ryu.html
@@ -5,5 +5,5 @@
      title="{{ hint_text }}">
      <span style="font-size: 0.75rem">RYUCON</span>
   </a>
-  <small style="color: {{ text_fg }}">{{ cnt|default(value="") }}</small>
+  <small style="color: {{ text_fg }}">{{ displayed_count|default(value="") }}</small>
 </div>

--- a/templates/badges/splat.html
+++ b/templates/badges/splat.html
@@ -5,5 +5,5 @@
      title="{{ hint_text }}">
      <span style="font-size: 0.7rem">SPLAT!</span>
   </a>
-  <small style="color: {{ text_fg }}">{{ cnt|default(value="") }}</small>
+  <small style="color: {{ text_fg }}">{{ displayed_count|default(value="") }}</small>
 </div>

--- a/templates/badges/tbw.html
+++ b/templates/badges/tbw.html
@@ -5,5 +5,5 @@
      title="{{ hint_text }}">
      <span>TBW</span>
   </a>
-  <small style="color: {{ text_fg }}">{{ cnt|default(value="") }}</small>
+  <small style="color: {{ text_fg }}">{{ displayed_count|default(value="") }}</small>
 </div>

--- a/templates/badges/twf.html
+++ b/templates/badges/twf.html
@@ -5,5 +5,5 @@
      title="{{ hint_text }}">
      <span>TWF</span>
   </a>
-  <small style="color: {{ text_fg }}">{{ cnt|default(value="") }}</small>
+  <small style="color: {{ text_fg }}">{{ displayed_count|default(value="") }}</small>
 </div>

--- a/templates/badges/wwe.html
+++ b/templates/badges/wwe.html
@@ -5,5 +5,5 @@
      title="{{ hint_text }}">
      <span>WWE</span>
   </a>
-  <small style="color: {{ text_fg }}">{{ cnt|default(value="") }}</small>
+  <small style="color: {{ text_fg }}">{{ displayed_count|default(value="") }}</small>
 </div>

--- a/templates/career/section.html
+++ b/templates/career/section.html
@@ -12,6 +12,7 @@
   {% endfor -%}
 
   <h3>Appearances per promotion and year</h3>
+  Numbers indicate in order: count of matches, segments and crew appearances. Trailing zeros are omitted.
   {% include "career/years.html" -%}
 {% endif -%}
 
@@ -19,6 +20,7 @@
 {% set fold_matchlist_config = config.extra | get(key="fold_matchlist", default="auto") -%}
 {% set fold_matchlist_at = config.extra | get(key="fold_matchlist_at") -%}
 {% set fold_matchlist = page.extra | get(key="fold_matchlist", default=fold_matchlist_config) -%}
+{# With mycareer in context, we can do similar calculations as for orgs_stretchy and show M-S in this section on year headers #}
 {% include "career/matchlist.html" -%}
 
 {% set fold_crew_appearances_config = config.extra | get(key="fold_crew_appearances", default="auto") %}

--- a/templates/career/section.html
+++ b/templates/career/section.html
@@ -1,5 +1,5 @@
 {% set org_styles = config.extra.org_styles -%}
-{% set careers = load_data(path="data/career_v2.json") -%}
+{% set careers = load_data(path="data/career_v3.json") -%}
 {% set empty_obj = [] | group_by(attribute='0') -%}
 {% set career_key = "@/" ~ page.relative_path -%}
 {% set mycareer = careers | get(key=career_key, default=empty_obj) -%}

--- a/templates/macros/career.html
+++ b/templates/macros/career.html
@@ -113,11 +113,32 @@
 {% macro orgs_stretchy(career, year, styles) %}
   {% set thisyear = career | get(key=year|as_str, default=[]|group_by(key=0)) %}
   {% set_global total = 0 %}
-  {% for org, cnt in thisyear %}
+  {% for org, counts in thisyear %}
     {% if config.extra.special_orgs is containing(org) %}{% continue %}{% endif %}
-    {% set_global total = total + cnt %}
+    {% if counts is iterable %}
+      {% set m = counts|first %}{% set s = counts|nth(n=1) %}{% set c = counts|last %}
+      {% set_global total = total + m + s + c %}
+    {% elif counts is number %}{# Old usage but still relevant for teams #}
+      {% set_global total = total + counts %}
+    {% endif %}
   {% endfor %}
-  {% for org, cnt in thisyear %}
+  {% for org, counts in thisyear %}
+    {% if counts is iterable %}
+      {% set m = counts|first %}{% set s = counts|nth(n=1) %}{% set c = counts|last %}
+      {% set cnt = m + s + c %}
+      {% if s == 0 and c == 0 %}
+        {% set displayed_count = m %}
+      {#% elif m == 0 and s == 0 %#}
+         {#% set displayed_count = "::" ~ c %#}
+      {% elif c == 0 %}
+        {% set displayed_count = m ~ "-" ~ s %}
+      {% else %}
+        {% set displayed_count = m ~ "-" ~ s ~ "-" ~ c %}
+    {% endif %}
+    {% elif counts is number %}
+      {% set cnt = counts %}
+      {% set displayed_count = cnt %}
+    {% endif %}
     {% if config.extra.special_orgs is containing(org) %}{% continue %}{% endif %}
     {% set style = styles|get(key=org, default=[]|group_by(key=0)) %}
     {% set hint_text = '' %}
@@ -155,9 +176,9 @@
            style="flex-grow: {{ cnt / total }};
                   background: {{ bg }};
                   color: {{ fg }};"
-            title="{{ cnt }} matches">
+            title="{{ displayed_count|default(value='') }} matches">
         {{ style|get(key='text', default=org|upper) }}
-        <small>{{ cnt }}</small>
+        <small>{{ displayed_count|default(value="") }}</small>
       </div>
     {% endif %}
   {% endfor %}

--- a/themes/web/sass/_icons-badges.sass
+++ b/themes/web/sass/_icons-badges.sass
@@ -40,8 +40,13 @@
     margin: 0 0.25em
     text-align: center
 
+    small
+      font-size: 0.9rem
+      vertical-align: center
+
   .org-badge
     padding: 0 0.4em
     font-family: monospace
     color: transparent
     white-space: nowrap
+


### PR DESCRIPTION
An implementation of #2520. Instead of a single total number, shows up to 3 numbers (on the career colorbars), separated with dashes. Trailing zeros are omitted.

- `6-3-1` matches,segments,crew
- `6-3` when zero crew appearances
- `6` when only matches, no segments or crew
- `0-0-6` only crew/referee

