### PR TITLE
DS_Store w gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ ppw_wiki/pages/content/
 ppw_wiki/pages/public/
 /static/minisearch_index.json
 node_modules/
+.DS_Store


### PR DESCRIPTION


EDIT: Powyżej to miało być logo Appla, ale zdaje się że poza Mac OSem się nie wyświetla jak powinno. :P