### PR TITLE
Badges cleanup

### DIFF
--- a/templates/badges/edojo.html
+++ b/templates/badges/edojo.html
@@ -1,9 +1,9 @@
-<div title="{{ hint_text }}" class="badge {% if ib %}ib{% endif %}{% if cnt is defined %}stretchy{% endif %}"
+<div title="{{ hint_text }}" class="badge bw {% if ib %}ib{% endif %}{% if cnt is defined %}stretchy{% endif %}"
      {% if cnt is defined %} style="flex-grow: {{ cnt/total }}; background: {{ bg }};" {% endif %}>
   <a href='{{ get_url(path="@/o/dojo.md") }}' class="org-badge nu"
      style="background: url({{ get_url(path='dojo.svg') }}) no-repeat 0 0 / cover, #fff; background-position: center;"
      title="{{ hint_text }}">
-     <span style="font-size: 1.12rem">DOJO</span>
+     <span>DOJO</span>
   </a>
   <small style="color: {{ text_fg }}">{{ displayed_count|default(value="") }}</small>
 </div>

--- a/templates/badges/frpw.html
+++ b/templates/badges/frpw.html
@@ -1,11 +1,11 @@
-<div title="{{ hint_text }}" class="badge {% if ib %}ib{% endif %}{% if cnt is defined %}stretchy{% endif %}"
+<div title="{{ hint_text }}" class="badge bw {% if ib %}ib{% endif %}{% if cnt is defined %}stretchy{% endif %}"
      {% if cnt is defined %} style="flex-grow: {{ cnt/total }}; background: {{ bg }};" {% endif %}>
   <a href='{{ get_url(path="@/o/frpw.md") }}' class="org-badge nu"
      style="background: url({{ get_url(path='frpw-badge.svg') }}) no-repeat 0 0 / cover, #4747c2; background-position: center;"
      title="{{ hint_text }}">
-     <span style="font-size: 1.1rem">FRPW</span>
+     <span>FRPW</span>
   </a>
-  <small style="color: {{ text_fg }}">{{ displayed_count|default(value="") }}</small>
+  {% if displayed_count %}<small style="color: {{ text_fg }}">{{ displayed_count|default(value="") }}</small>{% endif %}
 </div>
 {# ead5a5 light beige #}
 {# 333399 lapis lazuli #}

--- a/templates/badges/piwg.html
+++ b/templates/badges/piwg.html
@@ -1,9 +1,9 @@
-<div title="{{ hint_text }}" class="badge {% if ib %}ib{% endif %}{% if cnt is defined %}stretchy{% endif %}"
+<div title="{{ hint_text }}" class="badge bw {% if ib %}ib{% endif %}{% if cnt is defined %}stretchy{% endif %}"
      {% if cnt is defined %} style="flex-grow: {{ cnt/total }}; background: {{ bg }};" {% endif %}>
   <a href='{{ get_url(path="@/o/piwg.md") }}' class="org-badge nu"
      style="background: url({{ get_url(path='piwg.svg') }}) no-repeat 0 0 / cover, #000; background-position: center;"
      title="{{ hint_text }}">
-     <span style="font-size: 0.9rem">PIWG</span>
+     <span>PIWG</span>
   </a>
   <small style="color: {{ text_fg }}">{{ displayed_count|default(value="") }}</small>
 </div>

--- a/templates/badges/pyrkon.html
+++ b/templates/badges/pyrkon.html
@@ -1,9 +1,9 @@
-<div title="{{ hint_text }}" class="badge {% if ib %}ib{% endif %}{% if cnt is defined %}stretchy{% endif %}"
+<div title="{{ hint_text }}" class="badge bw {% if ib %}ib{% endif %}{% if cnt is defined %}stretchy{% endif %}"
      {% if cnt is defined %} style="flex-grow: {{ cnt/total }}; background: {{ bg }};" {% endif %}>
   <a href='{{ get_url(path="@/o/pyrkon.md") }}' class="org-badge nu"
      style="background: url({{ get_url(path='pyrkon.svg') }}) no-repeat 0 0 / cover, #fff; background-position: center;"
      title="{{ hint_text }}">
-     <span style="font-size: 0.7rem">PYRKON</span>
+     <span style="font-size: 0.97rem">PYRKON</span>
   </a>
   <small style="color: {{ text_fg }}">{{ displayed_count|default(value="") }}</small>
 </div>

--- a/templates/badges/ryu.html
+++ b/templates/badges/ryu.html
@@ -1,9 +1,9 @@
-<div title="{{ hint_text }}" class="badge {% if ib %}ib{% endif %}{% if cnt is defined %}stretchy{% endif %}"
+<div title="{{ hint_text }}" class="badge bw {% if ib %}ib{% endif %}{% if cnt is defined %}stretchy{% endif %}"
      {% if cnt is defined %} style="flex-grow: {{ cnt/total }}; background: {{ bg }};" {% endif %}>
   <a href='{{ get_url(path="@/o/ryucon.md") }}' class="org-badge nu"
-     style="background: url({{ get_url(path='ryu-badge.svg') }}) 0 0 / 100%, #e2e2e2; background-position: center;"
+     style="background: url({{ get_url(path='ryu-badge.svg') }}) no-repeat 0 0 / 100%, #e2e2e2; background-position: center;"
      title="{{ hint_text }}">
-     <span style="font-size: 0.75rem">RYUCON</span>
+     <span style="font-size: 0.97rem">RYUCON</span>
   </a>
   <small style="color: {{ text_fg }}">{{ displayed_count|default(value="") }}</small>
 </div>

--- a/templates/badges/splat.html
+++ b/templates/badges/splat.html
@@ -1,9 +1,9 @@
-<div title="{{ hint_text }}" class="badge {% if ib %}ib{% endif %}{% if cnt is defined %}stretchy{% endif %}"
+<div title="{{ hint_text }}" class="badge bw {% if ib %}ib{% endif %}{% if cnt is defined %}stretchy{% endif %}"
      {% if cnt is defined %} style="flex-grow: {{ cnt/total }}; background: {{ bg }};" {% endif %}>
   <a href='{{ get_url(path="@/o/splat.md") }}' class="org-badge nu"
      style="background: url({{ get_url(path='splat-badge.svg') }}) no-repeat 0 0 / cover, #fff; background-position: center;"
      title="{{ hint_text }}">
-     <span style="font-size: 0.7rem">SPLAT!</span>
+     <span style="font-size: 0.97rem">SPLAT!</span>
   </a>
   <small style="color: {{ text_fg }}">{{ displayed_count|default(value="") }}</small>
 </div>

--- a/templates/events/org_badges.html
+++ b/templates/events/org_badges.html
@@ -8,7 +8,7 @@
 {% if orgs %}
   <span>
   {% for org in orgs %}
-    {{ macros::promolink_color_span(code=org, styles=config.extra.org_styles) }}
+    {{ macros::promolink_color(code=org, styles=config.extra.org_styles) }}
   {% endfor %}
   </span>
 {% endif %}

--- a/templates/macros/career.html
+++ b/templates/macros/career.html
@@ -1,5 +1,3 @@
-
-
 {% macro promolink_color(code, hint_text='', styles) %}
   {% set ib = true -%}
   {% set style = styles|get(key=code, default=[]|group_by(key=0)) -%}
@@ -7,38 +5,38 @@
   {% if code is starting_with("~") -%}
     {% set slug = code | replace(from="~", to="") -%}
   {% endif -%}
-  {% if code == "ddw" %}
-    {% include "badges/ddw.html" %}
-  {% elif code == "dfw" %}
-    {% include "badges/dfw.html" %}
-  {% elif code == "dojo" %}
-    {% include "badges/dojo.html" %}
-  {% elif code == "frpw" %}
-    {% include "badges/frpw.html" %}
-  {% elif code == "kpw" %}
-    {% include "badges/kpw.html" %}
-  {% elif code == "low" %}
-    {% include "badges/low.html" %}
-  {% elif code == "mcw" %}
-    {% include "badges/mcw.html" %}
-  {% elif code == "mzw" %}
-    {% include "badges/mzw.html" %}
-  {% elif code == "piwg" %}
-    {% include "badges/piwg.html" %}
-  {% elif code == "ppw" %}
-    {% include "badges/ppw.html" %}
-  {% elif code == "ptw" %}
-    {% include "badges/ptw.html" %}
-  {% elif code == "pxw" %}
-    {% include "badges/pxw.html" %}
-  {% elif code == "tbw" %}
-    {% include "badges/tbw.html" %}
-  {% elif code == "twf" %}
-    {% include "badges/twf.html" %}
-  {% elif code == "wsw" %}
-    {% include "badges/wsw.html" %}
-  {% elif code == "wwe" %}
-    {% include "badges/wwe.html" %}
+  {% if code == "ddw" -%}
+    {% include "badges/ddw.html" -%}
+  {% elif code == "dfw" -%}
+    {% include "badges/dfw.html" -%}
+  {% elif code == "dojo" -%}
+    {% include "badges/edojo.html" -%}
+  {% elif code == "frpw" -%}
+    {% include "badges/frpw.html" -%}
+  {% elif code == "kpw" -%}
+    {% include "badges/kpw.html" -%}
+  {% elif code == "low" -%}
+    {% include "badges/low.html" -%}
+  {% elif code == "mcw" -%}
+    {% include "badges/mcw.html" -%}
+  {% elif code == "mzw" -%}
+    {% include "badges/mzw.html" -%}
+  {% elif code == "piwg" -%}
+    {% include "badges/piwg.html" -%}
+  {% elif code == "ppw" -%}
+    {% include "badges/ppw.html" -%}
+  {% elif code == "ptw" -%}
+    {% include "badges/ptw.html" -%}
+  {% elif code == "pxw" -%}
+    {% include "badges/pxw.html" -%}
+  {% elif code == "tbw" -%}
+    {% include "badges/tbw.html" -%}
+  {% elif code == "twf" -%}
+    {% include "badges/twf.html" -%}
+  {% elif code == "wsw" -%}
+    {% include "badges/wsw.html" -%}
+  {% elif code == "wwe" -%}
+    {% include "badges/wwe.html" -%}
   {% elif code == "splat" -%}
     {% include "badges/splat.html" -%}
   {% elif code == "ryucon" -%}
@@ -66,74 +64,74 @@
 {# Params: career=dict(year => [[org, count], [org, count]]), year=int, styles=extra.styles #}
 {# Omits special orgs in two ways: excludes them from total and does not draw them. Not even the branch dispatch to badge templates should include special orgs. #}
 {% macro orgs_stretchy(career, year, styles) %}
-  {% set thisyear = career | get(key=year|as_str, default=[]|group_by(key=0)) %}
-  {% set_global total = 0 %}
-  {% for org, counts in thisyear %}
-    {% if config.extra.special_orgs is containing(org) %}{% continue %}{% endif %}
-    {% if counts is iterable %}
-      {% set m = counts|first %}{% set s = counts|nth(n=1) %}{% set c = counts|last %}
-      {% set_global total = total + m + s + c %}
-    {% elif counts is number %}{# Old usage but still relevant for teams #}
-      {% set_global total = total + counts %}
-    {% endif %}
-  {% endfor %}
-  {% for org, counts in thisyear %}
-    {% if counts is iterable %}
-      {% set m = counts|first %}{% set s = counts|nth(n=1) %}{% set c = counts|last %}
-      {% set cnt = m + s + c %}
-      {% if s == 0 and c == 0 %}
-        {% set displayed_count = m %}
+  {% set thisyear = career | get(key=year|as_str, default=[]|group_by(key=0)) -%}
+  {% set_global total = 0 -%}
+  {% for org, counts in thisyear -%}
+    {% if config.extra.special_orgs is containing(org) %}{% continue %}{% endif -%}
+    {% if counts is iterable -%}
+      {% set m = counts|first %}{% set s = counts|nth(n=1) %}{% set c = counts|last -%}
+      {% set_global total = total + m + s + c -%}
+    {% elif counts is number -%}{# Old usage but still relevant for teams #}
+      {% set_global total = total + counts -%}
+    {% endif -%}
+  {% endfor -%}
+  {% for org, counts in thisyear -%}
+    {% if counts is iterable -%}
+      {% set m = counts|first %}{% set s = counts|nth(n=1) %}{% set c = counts|last -%}
+      {% set cnt = m + s + c -%}
+      {% if s == 0 and c == 0 -%}
+        {% set displayed_count = m -%}
       {#% elif m == 0 and s == 0 %#}
          {#% set displayed_count = "::" ~ c %#}
-      {% elif c == 0 %}
-        {% set displayed_count = m ~ "-" ~ s %}
+      {% elif c == 0 -%}
+        {% set displayed_count = m ~ "-" ~ s -%}
       {% else %}
-        {% set displayed_count = m ~ "-" ~ s ~ "-" ~ c %}
-    {% endif %}
-    {% elif counts is number %}
-      {% set cnt = counts %}
-      {% set displayed_count = cnt %}
-    {% endif %}
-    {% if config.extra.special_orgs is containing(org) %}{% continue %}{% endif %}
-    {% set style = styles|get(key=org, default=[]|group_by(key=0)) %}
-    {% set hint_text = '' %}
-    {% set bg = style|get(key='bg', default='#000') %}
-    {% set fg = style|get(key='fg', default='#fff') %}
-    {% set text_fg = style|get(key='text_fg', default='#fff') %}
-    {% if org == "ddw" %}
-      {% include "badges/ddw.html" %}
-    {% elif org == "dfw" %}
-      {% include "badges/dfw.html" %}
-    {% elif org == "dojo" %}
-      {% include "badges/dojo.html" %}
-    {% elif org == "frpw" %}
-      {% include "badges/frpw.html" %}
-    {% elif org == "kpw" %}
-      {% include "badges/kpw.html" %}
-    {% elif org == "low" %}
-      {% include "badges/low.html" %}
-    {% elif org == "mcw" %}
-      {% include "badges/mcw.html" %}
-    {% elif org == "mzw" %}
-      {% include "badges/mzw.html" %}
-    {% elif org == "piwg" %}
-      {% include "badges/piwg.html" %}
-    {% elif org == "ppw" %}
-      {% include "badges/ppw.html" %}
-    {% elif org == "ptw" %}
-      {% include "badges/ptw.html" %}
-    {% elif org == "pxw" %}
-      {% include "badges/pxw.html" %}
-    {% elif org == "tbw" %}
-      {% include "badges/tbw.html" %}
-    {% elif org == "twf" %}
-      {% include "badges/twf.html" %}
-    {% elif org == "wsw" %}
-      {% include "badges/wsw.html" %}
-    {% elif org == "wwe" %}
-      {% include "badges/wwe.html" %}
+        {% set displayed_count = m ~ "-" ~ s ~ "-" ~ c -%}
+    {% endif -%}
+    {% elif counts is number -%}
+      {% set cnt = counts -%}
+      {% set displayed_count = cnt -%}
+    {% endif -%}
+    {% if config.extra.special_orgs is containing(org) %}{% continue %}{% endif -%}
+    {% set style = styles|get(key=org, default=[]|group_by(key=0)) -%}
+    {% set hint_text = '' -%}
+    {% set bg = style|get(key='bg', default='#000') -%}
+    {% set fg = style|get(key='fg', default='#fff') -%}
+    {% set text_fg = style|get(key='text_fg', default='#fff') -%}
+    {% if org == "ddw" -%}
+      {% include "badges/ddw.html" -%}
+    {% elif org == "dfw" -%}
+      {% include "badges/dfw.html" -%}
+    {% elif org == "dojo" -%}
+      {% include "badges/edojo.html" -%}
+    {% elif org == "frpw" -%}
+      {% include "badges/frpw.html" -%}
+    {% elif org == "kpw" -%}
+      {% include "badges/kpw.html" -%}
+    {% elif org == "low" -%}
+      {% include "badges/low.html" -%}
+    {% elif org == "mcw" -%}
+      {% include "badges/mcw.html" -%}
+    {% elif org == "mzw" -%}
+      {% include "badges/mzw.html" -%}
+    {% elif org == "piwg" -%}
+      {% include "badges/piwg.html" -%}
+    {% elif org == "ppw" -%}
+      {% include "badges/ppw.html" -%}
+    {% elif org == "ptw" -%}
+      {% include "badges/ptw.html" -%}
+    {% elif org == "pxw" -%}
+      {% include "badges/pxw.html" -%}
+    {% elif org == "tbw" -%}
+      {% include "badges/tbw.html" -%}
+    {% elif org == "twf" -%}
+      {% include "badges/twf.html" -%}
+    {% elif org == "wsw" -%}
+      {% include "badges/wsw.html" -%}
+    {% elif org == "wwe" -%}
+      {% include "badges/wwe.html" -%}
     {# NOTE: no badges for non-wrestling orgs like splat, ryucon or pyrkon #}
-    {% else %}
+    {% else -%}
       <div class="badge stretchy"
            style="flex-grow: {{ cnt / total }};
                   background: {{ bg }};
@@ -142,6 +140,6 @@
         {{ style|get(key='text', default=org|upper) }}
         <small>{{ displayed_count|default(value="") }}</small>
       </div>
-    {% endif %}
-  {% endfor %}
+    {% endif -%}
+  {% endfor -%}
 {% endmacro %}

--- a/templates/macros/career.html
+++ b/templates/macros/career.html
@@ -1,91 +1,46 @@
-{% macro promolink_color(code, hint_text='', styles) %}
-  {% set ib = false %}
-  {% set style = styles|get(key=code, default=[]|group_by(key=0)) %}
-  {% set text_fg = style|get(key='text_fg', default='#fff') %}
-  {% if code == "mcw" %}
-    {% include "badges/mcw.html" %}
-  {% elif code == "ddw" %}
-    {% include "badges/ddw.html" %}
-  {% elif code == "kpw" %}
-    {% include "badges/kpw.html" %}
-  {% elif code == "ppw" %}
-    {% include "badges/ppw.html" %}
-  {% elif code == "mzw" %}
-    {% include "badges/mzw.html" %}
-  {% elif code == "ptw" %}
-    {% include "badges/ptw.html" %}
-  {% elif code == "tbw" %}
-    {% include "badges/tbw.html" %}
-  {% elif code == "dfw" %}
-    {% include "badges/dfw.html" %}
-  {% elif code == "wwe" %}
-    {% include "badges/wwe.html" %}
-  {% elif code == "low" %}
-    {% include "badges/low.html" %}
-  {% elif code == "pxw" %}
-    {% include "badges/pxw.html" %}
-  {% elif code == "piwg" %}
-    {% include "badges/piwg.html" %}
-  {% elif code == "twf" %}
-    {% include "badges/twf.html" %}
-  {% elif code == "splat" %}
-    {% include "badges/splat.html" %}
-  {% elif code == "frpw" %}
-    {% include "badges/frpw.html" %}
-  {% elif code == "ryucon" %}
-    {% include "badges/ryu.html" %}
-  {% elif code == "pyrkon" %}
-    {% include "badges/pyrkon.html" %}
-  {% else %}
-    {% set org_path = "@/o/" ~ code ~ ".md" -%}
-    <div title="{{ hint_text }}" class="badge">
-      <a href="{{ get_url(path=org_path) }}" class="nu org-badge"
-        style="background: {{ style|get(key='bg', default='#000') }};
-               color: {{ style|get(key='fg', default='#fff') }};
-        ">
-        {{ style|get(key='text', default=code|upper) }}
-    </a>
-    </div>
-  {% endif %}
-{% endmacro %}
 
-{% macro promolink_color_span(code, hint_text='', styles) %}
+
+{% macro promolink_color(code, hint_text='', styles) %}
   {% set ib = true -%}
   {% set style = styles|get(key=code, default=[]|group_by(key=0)) -%}
   {% set text_fg = style|get(key='text_fg', default='#fff') -%}
   {% if code is starting_with("~") -%}
     {% set slug = code | replace(from="~", to="") -%}
   {% endif -%}
-  {% if code == "mcw" -%}
-    {% include "badges/mcw.html" -%}
-  {% elif code == "ddw" -%}
-    {% include "badges/ddw.html" -%}
-  {% elif code == "kpw" -%}
-    {% include "badges/kpw.html" -%}
-  {% elif code == "ppw" -%}
-    {% include "badges/ppw.html" -%}
-  {% elif code == "mzw" -%}
-    {% include "badges/mzw.html" -%}
-  {% elif code == "ptw" -%}
-    {% include "badges/ptw.html" -%}
-  {% elif code == "tbw" -%}
-    {% include "badges/tbw.html" -%}
-  {% elif code == "dfw" -%}
-    {% include "badges/dfw.html" -%}
-  {% elif code == "wwe" -%}
-    {% include "badges/wwe.html" -%}
-  {% elif code == "low" -%}
-    {% include "badges/low.html" -%}
-  {% elif code == "pxw" -%}
-    {% include "badges/pxw.html" -%}
-  {% elif code == "piwg" -%}
-    {% include "badges/piwg.html" -%}
-  {% elif code == "twf" -%}
-    {% include "badges/twf.html" -%}
-  {% elif code == "splat" -%}
-    {% include "badges/splat.html" -%}
+  {% if code == "ddw" %}
+    {% include "badges/ddw.html" %}
+  {% elif code == "dfw" %}
+    {% include "badges/dfw.html" %}
+  {% elif code == "dojo" %}
+    {% include "badges/dojo.html" %}
   {% elif code == "frpw" %}
     {% include "badges/frpw.html" %}
+  {% elif code == "kpw" %}
+    {% include "badges/kpw.html" %}
+  {% elif code == "low" %}
+    {% include "badges/low.html" %}
+  {% elif code == "mcw" %}
+    {% include "badges/mcw.html" %}
+  {% elif code == "mzw" %}
+    {% include "badges/mzw.html" %}
+  {% elif code == "piwg" %}
+    {% include "badges/piwg.html" %}
+  {% elif code == "ppw" %}
+    {% include "badges/ppw.html" %}
+  {% elif code == "ptw" %}
+    {% include "badges/ptw.html" %}
+  {% elif code == "pxw" %}
+    {% include "badges/pxw.html" %}
+  {% elif code == "tbw" %}
+    {% include "badges/tbw.html" %}
+  {% elif code == "twf" %}
+    {% include "badges/twf.html" %}
+  {% elif code == "wsw" %}
+    {% include "badges/wsw.html" %}
+  {% elif code == "wwe" %}
+    {% include "badges/wwe.html" %}
+  {% elif code == "splat" -%}
+    {% include "badges/splat.html" -%}
   {% elif code == "ryucon" -%}
     {% include "badges/ryu.html" -%}
   {% elif code == "pyrkon" -%}
@@ -145,34 +100,39 @@
     {% set bg = style|get(key='bg', default='#000') %}
     {% set fg = style|get(key='fg', default='#fff') %}
     {% set text_fg = style|get(key='text_fg', default='#fff') %}
-    {% if org == "mcw" %}
-      {% include "badges/mcw.html" %}
-    {% elif org == "ddw" %}
+    {% if org == "ddw" %}
       {% include "badges/ddw.html" %}
-    {% elif org == "kpw" %}
-      {% include "badges/kpw.html" %}
-    {% elif org == "ppw" %}
-      {% include "badges/ppw.html" %}
-    {% elif org == "mzw" %}
-      {% include "badges/mzw.html" %}
-    {% elif org == "ptw" %}
-      {% include "badges/ptw.html" %}
-    {% elif org == "tbw" %}
-      {% include "badges/tbw.html" %}
     {% elif org == "dfw" %}
       {% include "badges/dfw.html" %}
-    {% elif org == "wwe" %}
-      {% include "badges/wwe.html" %}
-    {% elif org == "low" %}
-      {% include "badges/low.html" %}
-    {% elif org == "pxw" %}
-      {% include "badges/pxw.html" %}
-    {% elif org == "piwg" %}
-      {% include "badges/piwg.html" %}
-    {% elif org == "twf" %}
-      {% include "badges/twf.html" %}
+    {% elif org == "dojo" %}
+      {% include "badges/dojo.html" %}
     {% elif org == "frpw" %}
       {% include "badges/frpw.html" %}
+    {% elif org == "kpw" %}
+      {% include "badges/kpw.html" %}
+    {% elif org == "low" %}
+      {% include "badges/low.html" %}
+    {% elif org == "mcw" %}
+      {% include "badges/mcw.html" %}
+    {% elif org == "mzw" %}
+      {% include "badges/mzw.html" %}
+    {% elif org == "piwg" %}
+      {% include "badges/piwg.html" %}
+    {% elif org == "ppw" %}
+      {% include "badges/ppw.html" %}
+    {% elif org == "ptw" %}
+      {% include "badges/ptw.html" %}
+    {% elif org == "pxw" %}
+      {% include "badges/pxw.html" %}
+    {% elif org == "tbw" %}
+      {% include "badges/tbw.html" %}
+    {% elif org == "twf" %}
+      {% include "badges/twf.html" %}
+    {% elif org == "wsw" %}
+      {% include "badges/wsw.html" %}
+    {% elif org == "wwe" %}
+      {% include "badges/wwe.html" %}
+    {# NOTE: no badges for non-wrestling orgs like splat, ryucon or pyrkon #}
     {% else %}
       <div class="badge stretchy"
            style="flex-grow: {{ cnt / total }};

--- a/templates/roster/person_orgs_matches.html
+++ b/templates/roster/person_orgs_matches.html
@@ -39,7 +39,7 @@
     {% endfor -%}
     {% if config.extra.special_orgs is containing(o) %}{% set_global valid_org = false %}{% endif -%}
     {% if not valid_org %}</span>{% continue %}{% endif -%}
-    {{ macros::promolink_color_span(code=o, styles=org_styles) }}
+    {{ macros::promolink_color(code=o, styles=org_styles) }}
     {% if display_match_links and all_appearances|length < 5 -%}
       {% for match in all_appearances|sort(attribute='d') -%}
         {% if not match.o is containing(o) %} {% continue -%} {% endif -%}

--- a/templates/shortcodes/org_badge.html
+++ b/templates/shortcodes/org_badge.html
@@ -1,9 +1,9 @@
 {%- import "macros/career.html" as macros %}
 
 {% if org %}
-{{ macros::promolink_color_span(code=org, styles=config.extra.org_styles) }}
+{{ macros::promolink_color(code=org, styles=config.extra.org_styles) }}
 {% elif orgs %}
   {% for org in orgs %}
-    {{ macros::promolink_color_span(code=org, styles=config.extra.org_styles) }}
+    {{ macros::promolink_color(code=org, styles=config.extra.org_styles) }}
   {% endfor %}
 {% endif %}

--- a/templates/team/h1_with_orgs.html
+++ b/templates/team/h1_with_orgs.html
@@ -4,7 +4,7 @@
     {% set orgs = page.extra.orgs | default(value=[]) %}
     {# XXX: Not sure if useful in this form #}
     {% for org in orgs %}
-      {{ macros::promolink_color_span(code=org, styles=config.extra.org_styles) }}
+      {{ macros::promolink_color(code=org, styles=config.extra.org_styles) }}
     {% endfor %}
   </span>
 </h1>

--- a/templates/team_index.html
+++ b/templates/team_index.html
@@ -17,7 +17,7 @@
           {% set orgs = page.extra.orgs | default(value=[]) %}
           <span class="ot">
             {% for org in orgs %}
-              {{ macros::promolink_color_span(code=org, styles=config.extra.org_styles) }}
+              {{ macros::promolink_color(code=org, styles=config.extra.org_styles) }}
             {% endfor %}
           </span>
         </span>

--- a/themes/web/sass/_icons-badges.sass
+++ b/themes/web/sass/_icons-badges.sass
@@ -50,3 +50,6 @@
     color: transparent
     white-space: nowrap
 
+  &.bw .org-badge
+    padding: 0 0.1em
+


### PR DESCRIPTION
1. Dedupe badge dispatch: it turns out we didn't use one of the badges macros, and can eliminate ⅓ of the file and repetitive dispatch branches.
2. Badges with more than 3 letter of (invisible) text had sizing issues, patched over with tuning the font size, however they were still showing different sizes in cm-list vs career matchlist. The simplest fix here is to add a `.bw` (badge-wide) class to some of them, and adjust the horizontal padding in that class. This affects Dojo, FRPW, Pyrkon, Ryucon, Splat and PIWG. These badges should now render at same width as all the others.