### PR TITLE
Fix broken team parsing from #2861

### DIFF
--- a/src/card.py
+++ b/src/card.py
@@ -234,7 +234,7 @@ class Match:
 
     @classmethod
     def parse_partners(cls, partners: list[str]) -> Iterable[Union[Participant, Team]]:
-        return [t for p in partners if (t := cls.parse_maybe_team(p))]
+        return [t for p in partners if (t := cls.parse_maybe_team(p.strip()))]
 
     plain_name_re = r"[-.'&\w\s]+"
     team_link_re = rf'''


### PR DESCRIPTION
A plus sign represents multiple teams on one side; used when we want to denote that only some names belong to a team. Team composition ends at the plus sign, and more teams or single people can follow.

There was a bug in the code that tried to parse these groupings after splitting on the plus sign, and a quite hidden one: team regex didn't account for the space after plus sign. This caused the code to parse the first team fine (since it didn't start with a space before team name), but fail on any other one.

The fix is simple - just strip spaces from both ends before parsing each section.

This was not caught until #2861, where Laurance Roman gained a profile and all his prior appearances were updated, including in a match that two teams on one side, using exactly the plus notation. The new link (specifically parentheses and square brackets) now mistakenly matched longer text, making the whole team name plus first member (Engel) to be read as the name, and the rest (after the first open parentheses) as the path. This was obviously wrong, and broke build-aliases first (producing wrong path and wrong name), and then all-time-roster script.