### PR TITLE
Cudzysłowy zamiast apostrofów w ring name'ach

### DIFF
--- a/content/e/mzw/2025-06-28-mzw-green-madness.md
+++ b/content/e/mzw/2025-06-28-mzw-green-madness.md
@@ -25,7 +25,7 @@ The show was announced along with the poster depicting [Aron Wake](@/w/aron-wake
 * The third tournament match, revealed on 30.05.2025, was [Shadow](@/w/shadow.md) vs [Oskar Alexander](@/w/oskar-alexander.md), in Oskar's MZW debut.
 * On 3.06.2025 MZW announced a non-tournament match between [Goblin](@/w/goblin.md) and [Erik Šlotíř](@/w/erik-slotir.md). It marks Šlotíř's MZW debut.
 * On 5.06.2025 the stipulation for the main event was revealed: a Fatal 4-Way Ladder Match, a first for MZW.
-* The fourth tournament match, revealed on 10.06.2025, was [Gustav Gryffin](@/w/gustav-gryffin.md) vs [Febus 'The Wolf'](@/w/apollo-anderson.md).
+* The fourth tournament match, revealed on 10.06.2025, was [Gustav Gryffin](@/w/gustav-gryffin.md) vs [Febus "The Wolf"](@/w/apollo-anderson.md).
 * Another non-tournament match, revealed on 13.06.2025, was [PAKA](@/tt/paka.md)'s quasi-reunion, with [Disco Pablo](@/w/disco-pablo.md) enlisting [Boro's](@/w/boro.md) help to take on [Legia Łysych](@/tt/legia-lysych.md).
 * The final match, revealed on 13.06.2025, was another non-tournament bout: [Sambor](@/w/sambor.md) vs [Tony Sheen](@/w/riverman.md).
 
@@ -33,7 +33,7 @@ The show was announced along with the poster depicting [Aron Wake](@/w/aron-wake
 
 {% card() %}
 - - '[Gustav Gryffin](@/w/gustav-gryffin.md)'
-  - "[Febus 'The Wolf'](@/w/apollo-anderson.md)"
+  - '[Febus "The Wolf"](@/w/apollo-anderson.md)'
   - s: Tournament qualifying match
 - - '[Shadow](@/w/shadow.md)'
   - '[Oskar Alexander](@/w/oskar-alexander.md)'

--- a/content/e/mzw/2025-09-27-mzw-zjedz-mu-leb.md
+++ b/content/e/mzw/2025-09-27-mzw-zjedz-mu-leb.md
@@ -20,19 +20,19 @@ MZW Zjedz Mu Łeb (_Eat His Head_) was a show by [Maniac Zone Wrestling](@/o/mzw
 * On 18.08.2025 two matches were announced, splitting [Legia Łysych](@/tt/legia-lysych.md): [Marco Hammers](@/w/marco-hammers.md) vs [Shadow](@/w/shadow.md) and [Marcelito](@/w/marcelito.md) vs [Olgierd](@/w/olgierd.md).
 * On 22.08.2025 MZW published a [promo][promo-dziedzic] by [Syriusz Dziedzic](@/w/dziedzic.md), in which he challenged [Mister Z](@/w/mister-z.md) for a match at the upcoming show. In the video, Dziedzic stated that he's been hungry for success ever since he [escaped the cage](@/a/ptw-exits.md).
 * On 27.08.2025 Mister Z issued a [reply][promo-z] refusing the challenge, on the grounds of him being on high enough level that he should only come to MZW to fight in title matches.
-* On 7.09.2025 MZW announced a Triple Threat Match between [Febus 'The Wolf'](@/w/apollo-anderson.md), [Gustav Gryffin](@/w/gustav-gryffin.md) and [Max Speed](@/w/max-speed.md). This is Max's debut in MZW.
+* On 7.09.2025 MZW announced a Triple Threat Match between [Febus "The Wolf"](@/w/apollo-anderson.md), [Gustav Gryffin](@/w/gustav-gryffin.md) and [Max Speed](@/w/max-speed.md). This is Max's debut in MZW.
 * On 17.09.2025 MZW released a [video][promo-matt] in which [Matt Buckna](@/w/matt-buckna.md) called [Mister Z](@/w/mister-z.md) a nobody for winning the Ladder Match at the [last show](@/e/mzw/2025-06-28-mzw-green-madness.md) by playing dirty. He then addressed [Syriusz Dziedzic](@/w/dziedzic.md), whom he applauded for his perseverance and self-improvement, and in his appreciation of these traits he offered Dziedzic a match for his [MZW Championship](@/c/mzw-championship.md). The match was officially confirmed two days later.
 * On 24.09.2025 MZW published a [video][riverman-challenge] by [Tony Sheen](@/w/riverman.md), in which he issued an open challenge. The next day it was officially confirmed.
 
 ## Card
 
 {% card() %}
-- - "[Tony Sheen 'The Riverman'](@/w/riverman.md)"
+- - '[Tony Sheen "The Riverman"](@/w/riverman.md)'
   - 'Felix Schweizer'
   - s: Open Challenge
 - - '[Shadow](@/w/shadow.md)'
   - '[Marco Hammers](@/w/marco-hammers.md) w/ [Olgierd](@/w/olgierd.md)'
-- - "[Febus 'The Wolf'](@/w/apollo-anderson.md)"
+- - '[Febus "The Wolf"](@/w/apollo-anderson.md)'
   - '[Gustav Gryffin](@/w/gustav-gryffin.md)'
   - '[Max Speed](@/w/max-speed.md)'
   - s: Triple Threat Match

--- a/content/e/mzw/2026-03-28-mzw-no-time-to-die-2.md
+++ b/content/e/mzw/2026-03-28-mzw-no-time-to-die-2.md
@@ -39,7 +39,7 @@ No Time to Die 2 was a show by [Maniac Zone Wrestling](@/o/mzw.md), and a follow
   - s: Tag Team match
 - - "[Febus 'The Wolf'](@/w/apollo-anderson.md)"
   - '[Syriusz Dziedzic](@/w/dziedzic.md)'
-- - "['Fox' Jakub](@/w/jakub.md)(c)"
+- - '["Fox" Jakub](@/w/jakub.md)(c)'
   - '[Max Speed](@/w/max-speed.md)'
   - c: '[Legacy of Wrestling European Championship](@/c/low-european-championship.md)'
 - - '[Oskar Alexander](@/w/oskar-alexander.md)'

--- a/content/e/mzw/2026-03-28-mzw-no-time-to-die-2.md
+++ b/content/e/mzw/2026-03-28-mzw-no-time-to-die-2.md
@@ -24,7 +24,7 @@ No Time to Die 2 was a show by [Maniac Zone Wrestling](@/o/mzw.md), and a follow
 * On 16.03.2026 [Oskar Alexander](@/w/oskar-alexander.md) issued an open challenge "to show all the fans his pride and greatness".
 * In a [video][matta-nie-bedzie] posted on 23.03.2026 Matt Buckna explained that he won't be able to attend the show after all due to a recent shoulder injury. [Tony Sheen](@/w/riverman.md), in his [response][tony-poplynal] posted the next day, berated Buckna for not putting in the effort and addressed the federation's management to give him the match against Gustav Gryffin for the MZW Championship instead.
 * On 25.03.2026 MZW [announced][matt-bez-pasa] that since Matt Buckna won't defend his title at the show, the MZW Championship is hereby vacated and Gustav will face another opponent in a match to determine the new Champion.
-* The next day MZW announced [Febus 'The Wolf'](@/w/apollo-anderson.md) vs [Syriusz Dziedzic](@/w/dziedzic.md).
+* The next day MZW announced [Febus "The Wolf"](@/w/apollo-anderson.md) vs [Syriusz Dziedzic](@/w/dziedzic.md).
 
 ## Card
 
@@ -37,7 +37,7 @@ No Time to Die 2 was a show by [Maniac Zone Wrestling](@/o/mzw.md), and a follow
 - - '[Legia Łysych](@/tt/legia-lysych.md): [Marco Hammers](@/w/marco-hammers.md) & [Olgierd](@/w/olgierd.md)'
   - '[Shadow](@/w/shadow.md) & [Marcelito](@/w/marcelito.md)'
   - s: Tag Team match
-- - "[Febus 'The Wolf'](@/w/apollo-anderson.md)"
+- - '[Febus "The Wolf"](@/w/apollo-anderson.md)'
   - '[Syriusz Dziedzic](@/w/dziedzic.md)'
 - - '["Fox" Jakub](@/w/jakub.md)(c)'
   - '[Max Speed](@/w/max-speed.md)'
@@ -67,7 +67,7 @@ No Time to Die 2 was a show by [Maniac Zone Wrestling](@/o/mzw.md), and a follow
 * As Adrian was beginning to announce the first match, [Tony Sheen](@/w/riverman.md) (accompanied by [Arek Paterek](@/w/arek-paterek.md)) came out and demanded a spot in the main event. Paterek then prevented Adrian from reading his card with the actual participants, and inserted Tony into the match.
 * [Mister Z](@/w/mister-z.md) came out with the contract briefcase he won at [MZW Green Madness](@/e/mzw/2025-06-28-mzw-green-madness.md).
 * After [Olgierd](@/w/olgierd.md) & [Marco Hammers](@/w/marco-hammers.md) entered the ring, the lights suddenly went out. When they came back on, [Shadow](@/w/shadow.md) and [Marcelito](@/w/marcelito.md) were waiting perched on the turnbuckles.
-* [Syriusz Dziedzic](@/w/dziedzic.md) cut a promo in which he talked about him discovering wrestling, what it meant to him, how he decided to become a wrestler and the Champion. He ended by saying "Dajcie mi tego jebanego wilka, dajcie mi całą watahę!" (_Give me that fucking wolf, give me the entire wolfpack!_), referencing [Febus 'The Wolf'](@/w/apollo-anderson.md) and his old tag team [Wataha](@/tt/wataha.md).
+* [Syriusz Dziedzic](@/w/dziedzic.md) cut a promo in which he talked about him discovering wrestling, what it meant to him, how he decided to become a wrestler and the Champion. He ended by saying "Dajcie mi tego jebanego wilka, dajcie mi całą watahę!" (_Give me that fucking wolf, give me the entire wolfpack!_), referencing [Febus "The Wolf"](@/w/apollo-anderson.md) and his old tag team [Wataha](@/tt/wataha.md).
 * The promo was mocked by the audience, who saw it as meandering and boring. One of the fans countered "Dajcie mi wilka!" (_Give me the wolf!_) with "Nie dam ci BLIKa!" (_I'm not giving you any BLIK!_), playing on certain similarity between "wilk" (_wolf_) and ["BLIK"][blik]. BLIK is a popular Polish mobile payment system allowing for direct money transfers between two users via a one-time code.
 * Adrian Zgórski introduced [Jakub](@/w/jakub.md) as _Jakub "Fox"_, promting the [Legacy Champion](@/c/low-european-championship.md) to stare him down and whisper something into his ear for quite a while. Adrian then re-did the introduction, this time referring to him as _The man nicknamed "Fox" - Jakub!… … … "Fox"!_. Angered, Jakub went after Adrian, who quickly removed himself from the ring.
 * [Oskar Alexander](@/w/oskar-alexander.md) cut a heel promo, calling for an opponent to answer his open challenge (quietly hoping for [Jędruś Bułecka](@/w/jedrus-bulecka.md)). Behind his back, [Bartosz Plata](@/w/plata.md), who until this moment had been present at ringside, as a member of the security team, removed his uniform to reveal wrestling gear underneath, and stepped into the ring to face Oskar.

--- a/content/e/ppw/2026-07-04-ppw-nu-wrestling.md
+++ b/content/e/ppw/2026-07-04-ppw-nu-wrestling.md
@@ -48,7 +48,7 @@ Nü Wrestling was a show by [PpW Ewenement's](@/o/ppw.md) held in [2KOŁA Motorc
   - '[Jacob Crane](@/w/jacob-crane.md)'
   - g: Crane challenges Queen for his title.
 - - '[Rodzina](@/tt/rodzina.md): [Vic Golden](@/w/vic-golden.md) & [Oskar Alexander](@/w/oskar-alexander.md)'
-  - "['Ladykiller' Boro](@/w/boro.md) & [Mutant](@/w/mutant.md)"
+  - '["Ladykiller" Boro](@/w/boro.md) & [Mutant](@/w/mutant.md)'
   - c: '[PpW Tag Team Championship](@/c/ppw-tag-team-championship.md)'
     s: Tag Team Match
 - credits:


### PR DESCRIPTION
  Na liście ludzi osobno wisi `"Ladykiller" Boro` i `'Ladykiller' Boro`, co z lekka bez sensu jest.