### PR TITLE
Fix talent list missing rookies

### DIFF
--- a/templates/alphabetical_talent_list.html
+++ b/templates/alphabetical_talent_list.html
@@ -29,7 +29,7 @@
   {% set al = alpha_variants|get(key=letter, default=[letter]) %}
   {% for av in al %}
     {% for name_pair in head_names %}
-      {% set talent_name = name_pair[1]|replace(from='"', to='')|trim_start_matches(pat='The ') %}
+      {% set talent_name = name_pair[1]|replace(from='"', to='')|trim_start_matches(pat='The ') |upper %}
       {% if talent_name is starting_with(av) %}
         {% set_global talents = talents|concat(with=[name_pair]) %}
       {% endif %}


### PR DESCRIPTION
the rookies that we now denote with `adept/adeptka + name`. the error was trivial, and went unnoticed till now: the first letter of their name is lowercase `a` (because unlike the prefixes, `adept/adeptka` is not removed for this purpose). but the alphabet was uppercase, so the name didn't match any of the starting letters.

this does put them all under `a`, we can figure out the rest later. 