### PR TITLE
Autorzy

### DIFF
--- a/content/authors.md
+++ b/content/authors.md
@@ -18,4 +18,5 @@ Krzysztof "M3n747" Gołębiewski
 With valuable contributions by:
 * Dawid Kucharski, MyWrestling.com.pl
 * [Jędruś Bułecka](@/w/jedrus-bulecka.md)
+* [Krystian Malinowski](@/w/krystian-malinowski.md)
 * 🇫🇮 Ville Paananen


### PR DESCRIPTION
Dopisuję Malinowskiego do sekcji Contributions, jako że dostaliśmy od niego nieco zdjęć z dawnych gal DDW oraz dużo informacji na temat tamtych czasów oraz osób.